### PR TITLE
feat: add attachment metadata and downloadAttachment tool

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -14,6 +14,7 @@
     "searchConversations",
     "getConversationSummary",
     "getThreads",
+    "downloadAttachment",
     "getServerTime",
     "listAllInboxes",
     "advancedConversationSearch",

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,6 +1,9 @@
 import { 
+  AttachmentSchema,
+  DownloadAttachmentInputSchema,
   MultiStatusConversationSearchInputSchema,
   SearchConversationsInputSchema,
+  ThreadSchema,
 } from '../schema/types.js';
 
 describe('Schema Validation', () => {
@@ -128,6 +131,117 @@ describe('Schema Validation', () => {
       expect(() => {
         SearchConversationsInputSchema.parse({
           status: 'invalid'
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('AttachmentSchema', () => {
+    it('should validate a valid attachment', () => {
+      const attachment = {
+        id: 123,
+        filename: 'screenshot.png',
+        mimeType: 'image/png',
+        width: 800,
+        height: 600,
+        size: 45000,
+      };
+
+      const parsed = AttachmentSchema.parse(attachment);
+
+      expect(parsed.id).toBe(123);
+      expect(parsed.filename).toBe('screenshot.png');
+      expect(parsed.mimeType).toBe('image/png');
+      expect(parsed.width).toBe(800);
+      expect(parsed.height).toBe(600);
+      expect(parsed.size).toBe(45000);
+    });
+
+    it('should validate attachment without optional dimensions', () => {
+      const attachment = {
+        id: 456,
+        filename: 'report.pdf',
+        mimeType: 'application/pdf',
+      };
+
+      const parsed = AttachmentSchema.parse(attachment);
+
+      expect(parsed.id).toBe(456);
+      expect(parsed.filename).toBe('report.pdf');
+      expect(parsed.mimeType).toBe('application/pdf');
+      expect(parsed.width).toBeUndefined();
+      expect(parsed.height).toBeUndefined();
+      expect(parsed.size).toBeUndefined();
+    });
+  });
+
+  describe('ThreadSchema with _embedded.attachments', () => {
+    const baseThread = {
+      id: 1,
+      type: 'customer' as const,
+      status: 'active' as const,
+      state: 'published' as const,
+      action: null,
+      body: 'Hello',
+      source: { type: 'email', via: 'customer' },
+      customer: { id: 1, firstName: 'John', lastName: 'Doe', email: 'john@example.com' },
+      createdBy: { id: 1, firstName: 'John', lastName: 'Doe', email: 'john@example.com' },
+      assignedTo: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    it('should validate thread with attachments', () => {
+      const thread = {
+        ...baseThread,
+        _embedded: {
+          attachments: [
+            { id: 10, filename: 'file.txt', mimeType: 'text/plain', size: 1024 },
+            { id: 11, filename: 'image.png', mimeType: 'image/png', width: 100, height: 200 },
+          ],
+        },
+      };
+
+      const parsed = ThreadSchema.parse(thread);
+
+      expect(parsed._embedded).toBeDefined();
+      expect(parsed._embedded!.attachments).toHaveLength(2);
+      expect(parsed._embedded!.attachments[0].filename).toBe('file.txt');
+      expect(parsed._embedded!.attachments[1].width).toBe(100);
+    });
+
+    it('should validate thread without _embedded', () => {
+      const parsed = ThreadSchema.parse(baseThread);
+
+      expect(parsed._embedded).toBeUndefined();
+    });
+  });
+
+  describe('DownloadAttachmentInputSchema', () => {
+    it('should validate valid input', () => {
+      const input = {
+        conversationId: '12345',
+        attachmentId: '67890',
+      };
+
+      const parsed = DownloadAttachmentInputSchema.parse(input);
+
+      expect(parsed.conversationId).toBe('12345');
+      expect(parsed.attachmentId).toBe('67890');
+    });
+
+    it('should reject missing conversationId', () => {
+      expect(() => {
+        DownloadAttachmentInputSchema.parse({
+          attachmentId: '67890',
+        });
+      }).toThrow();
+    });
+
+    it('should reject missing attachmentId', () => {
+      expect(() => {
+        DownloadAttachmentInputSchema.parse({
+          conversationId: '12345',
         });
       }).toThrow();
     });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
 import { ToolHandler } from '../tools/index.js';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -37,12 +40,13 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(17);
+      expect(tools).toHaveLength(18);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
         'getConversationSummary',
         'getThreads',
+        'downloadAttachment',
         'getServerTime',
         'listAllInboxes',
         'advancedConversationSearch',
@@ -1875,6 +1879,138 @@ describe('ToolHandler', () => {
         expect(response.pagination.totalAvailable).toBe(300);
         expect(response.pagination.note).toContain('filtered count (2)');
         expect(response.pagination.note).toContain('pre-filter API total (300)');
+      });
+    });
+
+    describe('getThreads with attachments', () => {
+      it('should include attachment metadata in thread responses', async () => {
+        const mockThreadsResponse = {
+          _embedded: {
+            threads: [{
+              id: 100,
+              type: 'customer',
+              status: 'active',
+              state: 'published',
+              action: null,
+              body: 'See attached screenshot',
+              source: { type: 'email', via: 'customer' },
+              customer: { id: 1, firstName: 'Test', lastName: 'User', email: 'test@example.com' },
+              createdBy: null,
+              assignedTo: null,
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+              _embedded: {
+                attachments: [{
+                  id: 5000,
+                  filename: 'screenshot.png',
+                  mimeType: 'image/png',
+                  width: 1920,
+                  height: 1080,
+                  size: 45000,
+                }],
+              },
+            }],
+          },
+          page: { size: 50, totalElements: 1, totalPages: 1, number: 1 },
+        };
+
+        nock(baseURL)
+          .get('/conversations/123/threads')
+          .query(true)
+          .reply(200, mockThreadsResponse);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'getThreads',
+            arguments: { conversationId: '123' },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const textContent = result.content[0] as { type: 'text'; text: string };
+        const response = JSON.parse(textContent.text);
+
+        expect(response.threads[0]._embedded.attachments).toHaveLength(1);
+        expect(response.threads[0]._embedded.attachments[0]).toEqual({
+          id: 5000,
+          filename: 'screenshot.png',
+          mimeType: 'image/png',
+          width: 1920,
+          height: 1080,
+          size: 45000,
+        });
+      });
+    });
+
+    describe('downloadAttachment', () => {
+      let downloadDir: string;
+
+      beforeEach(async () => {
+        downloadDir = path.join(os.tmpdir(), 'helpscout-test-attachments-' + Date.now());
+        process.env.ATTACHMENT_DOWNLOAD_DIR = downloadDir;
+      });
+
+      afterEach(async () => {
+        delete process.env.ATTACHMENT_DOWNLOAD_DIR;
+        try {
+          await fs.rm(downloadDir, { recursive: true, force: true });
+        } catch {
+          // ignore cleanup errors
+        }
+      });
+
+      it('should download attachment and save to disk', async () => {
+        const base64Content = Buffer.from('Hello, World!').toString('base64');
+
+        nock(baseURL)
+          .get('/conversations/100/attachments/5000/data')
+          .reply(200, { data: base64Content });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'downloadAttachment',
+            arguments: {
+              conversationId: '100',
+              attachmentId: '5000',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const textContent = result.content[0] as { type: 'text'; text: string };
+        const response = JSON.parse(textContent.text);
+
+        expect(response.success).toBe(true);
+        expect(response.filePath).toContain('5000');
+        expect(response.attachmentId).toBe('5000');
+        expect(response.conversationId).toBe('100');
+        expect(response.sizeBytes).toBe(13); // "Hello, World!" is 13 bytes
+
+        // Verify file exists on disk with correct content
+        const fileContent = await fs.readFile(response.filePath, 'utf-8');
+        expect(fileContent).toBe('Hello, World!');
+      });
+
+      it('should return error for non-existent attachment', async () => {
+        nock(baseURL)
+          .get('/conversations/100/attachments/9999/data')
+          .reply(404, { message: 'Not Found' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'downloadAttachment',
+            arguments: {
+              conversationId: '100',
+              attachmentId: '9999',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
       });
     });
 

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -286,8 +286,8 @@ export const ListAllInboxesInputSchema = z.object({
 });
 
 export const DownloadAttachmentInputSchema = z.object({
-  conversationId: z.string(),
-  attachmentId: z.string(),
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
+  attachmentId: z.string().regex(/^\d+$/, 'Attachment ID must be numeric'),
 });
 
 // Response Types

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -87,7 +87,7 @@ export const ThreadSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   _embedded: z.object({
-    attachments: z.array(AttachmentSchema),
+    attachments: z.array(AttachmentSchema).optional().default([]),
   }).optional(),
 });
 

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -43,6 +43,15 @@ export const ConversationSchema = z.object({
   threads: z.number(),
 });
 
+export const AttachmentSchema = z.object({
+  id: z.number(),
+  filename: z.string(),
+  mimeType: z.string(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  size: z.number().optional(),
+});
+
 export const ThreadSchema = z.object({
   id: z.number(),
   type: z.enum(['customer', 'note', 'lineitem', 'phone', 'message']),
@@ -77,6 +86,9 @@ export const ThreadSchema = z.object({
   }).nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  _embedded: z.object({
+    attachments: z.array(AttachmentSchema),
+  }).optional(),
 });
 
 // MCP Tool Input Schemas
@@ -273,6 +285,11 @@ export const ListAllInboxesInputSchema = z.object({
   limit: z.number().min(1).max(100).default(100),
 });
 
+export const DownloadAttachmentInputSchema = z.object({
+  conversationId: z.string(),
+  attachmentId: z.string(),
+});
+
 // Response Types
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
@@ -293,6 +310,7 @@ export type Thread = z.infer<typeof ThreadSchema>;
 export type Customer = z.infer<typeof CustomerSchema>;
 export type CustomerAddress = z.infer<typeof CustomerAddressSchema>;
 export type Organization = z.infer<typeof OrganizationSchema>;
+export type Attachment = z.infer<typeof AttachmentSchema>;
 export type SearchInboxesInput = z.infer<typeof SearchInboxesInputSchema>;
 export type SearchConversationsInput = z.infer<typeof SearchConversationsInputSchema>;
 export type GetThreadsInput = z.infer<typeof GetThreadsInputSchema>;
@@ -308,5 +326,6 @@ export type GetOrganizationMembersInput = z.infer<typeof GetOrganizationMembersI
 export type GetOrganizationConversationsInput = z.infer<typeof GetOrganizationConversationsInputSchema>;
 export type GetCustomerContactsInput = z.infer<typeof GetCustomerContactsInputSchema>;
 export type ListAllInboxesInput = z.infer<typeof ListAllInboxesInputSchema>;
+export type DownloadAttachmentInput = z.infer<typeof DownloadAttachmentInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,7 @@ import { config } from '../utils/config.js';
 import { PII_REDACTED_BODY } from '../utils/constants.js';
 import { z } from 'zod';
 import { promises as fs } from 'fs';
+import { randomUUID } from 'crypto';
 import os from 'os';
 import path from 'path';
 import {
@@ -1103,22 +1104,24 @@ export class ToolHandler {
     const response = await helpScoutClient.get<{ data: string }>(
       `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`,
       undefined,
-      { ttl: -1 }  // Don't cache attachment data (ttl: 0 is falsy, falls through to default in cache.set)
+      { skipCache: true }
     );
 
     // Decode base64 to binary
     const buffer = Buffer.from(response.data, 'base64');
 
-    // Determine download directory
-    const downloadDir = process.env.ATTACHMENT_DOWNLOAD_DIR
-      || config.attachments.downloadDir
-      || path.join(os.tmpdir(), 'helpscout-attachments');
+    // Determine and resolve download directory to an absolute path
+    const downloadDir = path.resolve(
+      process.env.ATTACHMENT_DOWNLOAD_DIR
+        || config.attachments.downloadDir
+        || path.join(os.tmpdir(), 'helpscout-attachments')
+    );
 
     // Ensure directory exists
     await fs.mkdir(downloadDir, { recursive: true });
 
-    // Write file to disk
-    const filename = `${input.attachmentId}-${Date.now()}`;
+    // Write file to disk with unique name to avoid collisions
+    const filename = `${input.attachmentId}-${randomUUID()}`;
     const filePath = path.join(downloadDir, filename);
     await fs.writeFile(filePath, buffer);
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,9 @@ import { logger } from '../utils/logger.js';
 import { config } from '../utils/config.js';
 import { PII_REDACTED_BODY } from '../utils/constants.js';
 import { z } from 'zod';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
 import {
   Inbox,
   Conversation,
@@ -30,6 +33,7 @@ import {
   ListOrganizationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetOrganizationConversationsInputSchema,
+  DownloadAttachmentInputSchema,
 } from '../schema/types.js';
 
 /**
@@ -253,6 +257,24 @@ export class ToolHandler {
             },
           },
           required: ['conversationId'],
+        },
+      },
+      {
+        name: 'downloadAttachment',
+        description: 'Download an attachment from a conversation thread to disk. Returns the local file path. Use getThreads first to discover attachment IDs.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            conversationId: {
+              type: 'string',
+              description: 'The conversation ID containing the attachment',
+            },
+            attachmentId: {
+              type: 'string',
+              description: 'The attachment ID from getThreads response (_embedded.attachments[].id)',
+            },
+          },
+          required: ['conversationId', 'attachmentId'],
         },
       },
       {
@@ -599,6 +621,9 @@ export class ToolHandler {
           break;
         case 'getThreads':
           result = await this.getThreads(request.params.arguments || {});
+          break;
+        case 'downloadAttachment':
+          result = await this.downloadAttachment(request.params.arguments || {});
           break;
         case 'getServerTime':
           result = await this.getServerTime();
@@ -1065,6 +1090,49 @@ export class ToolHandler {
             threads: processedThreads,
             pagination: response.page,
             nextCursor: response._links?.next?.href,
+          }, null, 2),
+        },
+      ],
+    };
+  }
+
+  private async downloadAttachment(args: unknown): Promise<CallToolResult> {
+    const input = DownloadAttachmentInputSchema.parse(args);
+
+    // Fetch base64-encoded attachment data from Help Scout API
+    const response = await helpScoutClient.get<{ data: string }>(
+      `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`,
+      undefined,
+      { ttl: 0 }  // Don't cache attachment data
+    );
+
+    // Decode base64 to binary
+    const buffer = Buffer.from(response.data, 'base64');
+
+    // Determine download directory
+    const downloadDir = process.env.ATTACHMENT_DOWNLOAD_DIR
+      || config.attachments.downloadDir
+      || path.join(os.tmpdir(), 'helpscout-attachments');
+
+    // Ensure directory exists
+    await fs.mkdir(downloadDir, { recursive: true });
+
+    // Write file to disk
+    const filename = `${input.attachmentId}-${Date.now()}`;
+    const filePath = path.join(downloadDir, filename);
+    await fs.writeFile(filePath, buffer);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            filePath,
+            conversationId: input.conversationId,
+            attachmentId: input.attachmentId,
+            sizeBytes: buffer.length,
+            downloadDir,
           }, null, 2),
         },
       ],

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1103,7 +1103,7 @@ export class ToolHandler {
     const response = await helpScoutClient.get<{ data: string }>(
       `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`,
       undefined,
-      { ttl: 0 }  // Don't cache attachment data
+      { ttl: -1 }  // Don't cache attachment data (ttl: 0 is falsy, falls through to default in cache.set)
     );
 
     // Decode base64 to binary

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -30,6 +30,9 @@ export interface Config {
     keepAlive: boolean;
     keepAliveMsecs: number;
   };
+  attachments: {
+    downloadDir: string | null;
+  };
 }
 
 export const config: Config = {
@@ -59,6 +62,9 @@ export const config: Config = {
     timeout: parseInt(process.env.HTTP_SOCKET_TIMEOUT || '30000', 10),
     keepAlive: process.env.HTTP_KEEP_ALIVE !== 'false', // Default to true
     keepAliveMsecs: parseInt(process.env.HTTP_KEEP_ALIVE_MSECS || '1000', 10),
+  },
+  attachments: {
+    downloadDir: process.env.ATTACHMENT_DOWNLOAD_DIR || null,
   },
 };
 

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -413,24 +413,29 @@ export class HelpScoutClient {
     };
   }
 
-  async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
-    const cacheKey = `GET:${endpoint}`;
-    const cachedResult = cache.get<T>(cacheKey, params);
-    
-    if (cachedResult) {
-      return cachedResult;
+  async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number; skipCache?: boolean }): Promise<T> {
+    if (!cacheOptions?.skipCache) {
+      const cacheKey = `GET:${endpoint}`;
+      const cachedResult = cache.get<T>(cacheKey, params);
+      
+      if (cachedResult) {
+        return cachedResult;
+      }
     }
 
     const response = await this.executeWithRetry<T>(() => 
       this.client.get<T>(endpoint, { params })
     );
     
-    if (cacheOptions?.ttl || cacheOptions?.ttl === 0) {
-      cache.set(cacheKey, params, response.data, { ttl: cacheOptions.ttl });
-    } else {
-      // Default cache TTL based on endpoint
-      const defaultTtl = this.getDefaultCacheTtl(endpoint);
-      cache.set(cacheKey, params, response.data, { ttl: defaultTtl });
+    if (!cacheOptions?.skipCache) {
+      const cacheKey = `GET:${endpoint}`;
+      if (cacheOptions?.ttl || cacheOptions?.ttl === 0) {
+        cache.set(cacheKey, params, response.data, { ttl: cacheOptions.ttl });
+      } else {
+        // Default cache TTL based on endpoint
+        const defaultTtl = this.getDefaultCacheTtl(endpoint);
+        cache.set(cacheKey, params, response.data, { ttl: defaultTtl });
+      }
     }
     
     return response.data;


### PR DESCRIPTION
## Summary

- Surface attachment metadata (`_embedded.attachments`) in `getThreads` responses -- this data is already in the Help Scout API response but was being dropped by the schema
- Add a new `downloadAttachment` tool that fetches attachment file content and saves it to disk, returning the file path instead of loading content into the AI context window
- Add `ATTACHMENT_DOWNLOAD_DIR` env var for configuring where attachments are saved (defaults to `os.tmpdir()/helpscout-attachments/`)

Relates to #17

## Usage

1. Call `getThreads` -- each thread now includes attachment info (id, filename, mimeType, size)
2. Call `downloadAttachment` with `conversationId` and `attachmentId` -- file is saved to disk and the path is returned

## Changes

- `src/schema/types.ts` -- Added `AttachmentSchema`, `DownloadAttachmentInputSchema`, extended `ThreadSchema` with optional `_embedded`
- `src/utils/config.ts` -- Added `attachments.downloadDir` config
- `src/tools/index.ts` -- Registered and implemented `downloadAttachment` tool
- `mcp.json` -- Added `downloadAttachment` to tool list
- Tests added for all new schemas and tool behaviors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
