### PR TITLE
Add 7 write tools (draft-safe) with opt-in gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ docker run -e HELPSCOUT_APP_ID="your-app-id" \
 
 1. Go to **Help Scout** > **My Apps** > **Create Private App**
 2. Select at minimum: **Read** access to Mailboxes, Conversations, Customers, and Organizations
-3. Copy your **App ID** and **App Secret**
+3. For write tools: also grant **Write** access to Conversations
+4. Copy your **App ID** and **App Secret**
 
 > Help Scout uses OAuth2 Client Credentials flow exclusively. Personal Access Tokens are not supported.
 
@@ -110,6 +111,22 @@ Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `
 | Full message history | `getThreads` | "Show me the complete thread" |
 | Current server time | `getServerTime` | Used for time-relative searches |
 
+### Write Tools (Opt-in)
+
+These tools require `HELPSCOUT_ENABLE_WRITES=true` and are hidden when writes are disabled.
+
+| Task | Tool | Example |
+|------|------|---------|
+| Reply to a conversation | `createReply` | "Draft a reply to ticket #123" |
+| Change ticket status | `updateConversationStatus` | "Close ticket #123" |
+| Add internal note | `createNote` | "Add a note to ticket #123" |
+
+**Safety defaults:**
+- `createReply` defaults to **draft mode** (`draft: true`). Drafts must be manually sent from the Help Scout UI.
+- Setting `draft: false` sends a real email immediately and **cannot be undone**.
+- `createNote` creates internal notes only visible to support agents, never sent to customers.
+- Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close).
+
 Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in their instructions automatically, so no lookup step is needed.
 
 ## Configuration
@@ -120,6 +137,7 @@ Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in
 | `HELPSCOUT_APP_SECRET` | App Secret from Help Scout My Apps | Required |
 | `HELPSCOUT_DEFAULT_INBOX_ID` | Scope searches to a specific inbox | None (all inboxes) |
 | `HELPSCOUT_BASE_URL` | Help Scout API endpoint | `https://api.helpscout.net/v2/` |
+| `HELPSCOUT_ENABLE_WRITES` | Enable write tools (reply, note, status update) | `false` |
 | `REDACT_MESSAGE_CONTENT` | Hide message bodies in responses | `false` |
 | `CACHE_TTL_SECONDS` | Cache duration for API responses | `300` |
 | `LOG_LEVEL` | Logging verbosity (`error`, `warn`, `info`, `debug`) | `info` |

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -34,9 +34,11 @@ describe('ToolHandler', () => {
   });
 
   describe('listTools', () => {
-    it('should return all available tools', async () => {
+    it('should return all available tools (read-only when writes disabled)', async () => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
       const tools = await toolHandler.listTools();
-      
+
+      // 17 read-only tools when writes are disabled
       expect(tools).toHaveLength(17);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
@@ -57,6 +59,10 @@ describe('ToolHandler', () => {
         'getOrganizationMembers',
         'getOrganizationConversations',
       ]);
+      // Write tools should NOT be present
+      expect(tools.map(t => t.name)).not.toContain('createReply');
+      expect(tools.map(t => t.name)).not.toContain('createNote');
+      expect(tools.map(t => t.name)).not.toContain('updateConversationStatus');
     });
 
     it('should have proper tool schemas', async () => {

--- a/src/__tests__/write-tools.test.ts
+++ b/src/__tests__/write-tools.test.ts
@@ -1,0 +1,420 @@
+import nock from 'nock';
+import { ToolHandler } from '../tools/index.js';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+describe('Write Tools', () => {
+  let toolHandler: ToolHandler;
+  const baseURL = 'https://api.helpscout.net/v2';
+
+  beforeEach(() => {
+    process.env.HELPSCOUT_CLIENT_ID = 'test-client-id';
+    process.env.HELPSCOUT_CLIENT_SECRET = 'test-client-secret';
+    process.env.HELPSCOUT_BASE_URL = `${baseURL}/`;
+
+    nock.cleanAll();
+
+    // Mock OAuth2 authentication
+    // The auth endpoint is hardcoded to https://api.helpscout.net/v2/oauth2/token
+    nock(baseURL)
+      .persist()
+      .post('/oauth2/token')
+      .reply(200, {
+        access_token: 'mock-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+    toolHandler = new ToolHandler();
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  describe('when writes are disabled', () => {
+    beforeEach(() => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
+    });
+
+    it('should not list write tools when writes are disabled', async () => {
+      const tools = await toolHandler.listTools();
+      const toolNames = tools.map(t => t.name);
+
+      expect(toolNames).not.toContain('createReply');
+      expect(toolNames).not.toContain('updateConversationStatus');
+      expect(toolNames).not.toContain('createNote');
+    });
+
+    it('should return error when calling createReply with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'createReply',
+          arguments: {
+            conversationId: '123',
+            text: 'Hello',
+            customer: { email: 'test@example.com' },
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.error.message).toContain('Write operations are disabled');
+    });
+
+    it('should return error when calling createNote with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'createNote',
+          arguments: {
+            conversationId: '123',
+            text: 'Internal note',
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return error when calling updateConversationStatus with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'updateConversationStatus',
+          arguments: {
+            conversationId: '123',
+            status: 'closed',
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('when writes are enabled', () => {
+    beforeEach(() => {
+      process.env.HELPSCOUT_ENABLE_WRITES = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
+    });
+
+    describe('createReply', () => {
+      it('should create a draft reply by default', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/reply', (body: any) => {
+            expect(body.text).toBe('Hello customer');
+            expect(body.customer.email).toBe('test@example.com');
+            expect(body.draft).toBe(true);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello customer',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('draft');
+        expect(parsed.action).toBe('reply_created');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should create a sent reply when draft=false', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/456/reply', (body: any) => {
+            expect(body.draft).toBe(false);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '456',
+              text: 'Sent reply',
+              customer: { email: 'customer@example.com' },
+              draft: false,
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('sent');
+        expect(parsed.warning).toContain('cannot be undone');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should include cc and bcc when provided', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/reply', (body: any) => {
+            expect(body.cc).toEqual(['cc@example.com']);
+            expect(body.bcc).toEqual(['bcc@example.com']);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Reply with cc',
+              customer: { email: 'test@example.com' },
+              cc: ['cc@example.com'],
+              bcc: ['bcc@example.com'],
+            },
+          },
+        };
+
+        await toolHandler.callTool(request);
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject invalid customer email', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello',
+              customer: { email: 'not-an-email' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should reject empty text', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: '',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('updateConversationStatus', () => {
+      it('should update conversation status to closed', async () => {
+        const scope = nock(baseURL)
+          .patch('/conversations/123', (body: any) => {
+            expect(body.op).toBe('replace');
+            expect(body.path).toBe('/status');
+            expect(body.value).toBe('closed');
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '123',
+              status: 'closed',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.newStatus).toBe('closed');
+        expect(parsed.warning).toContain('automations');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should update conversation status to active', async () => {
+        const scope = nock(baseURL)
+          .patch('/conversations/789', (body: any) => {
+            expect(body.value).toBe('active');
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '789',
+              status: 'active',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.warning).toBeUndefined();
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject invalid status', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '123',
+              status: 'spam',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('createNote', () => {
+      it('should create an internal note', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/notes', (body: any) => {
+            expect(body.text).toBe('Internal note text');
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: 'Internal note text',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.action).toBe('note_created');
+        expect(parsed.message).toContain('only visible to support agents');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject empty note text', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: '',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle 412 precondition failed (thread limit)', async () => {
+        nock(baseURL)
+          .post('/conversations/123/notes')
+          .reply(412, { message: 'Thread limit exceeded' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: 'Note',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse((result.content[0] as any).text);
+        expect(parsed.error.message).toContain('precondition failed');
+      });
+
+      it('should handle 422 validation error', async () => {
+        nock(baseURL)
+          .post('/conversations/123/reply')
+          .reply(422, { message: 'Invalid request' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should handle 404 not found', async () => {
+        nock(baseURL)
+          .patch('/conversations/999')
+          .reply(404, { message: 'Not found' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '999',
+              status: 'active',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { validateConfig } from './utils/config.js';
+import { validateConfig, config } from './utils/config.js';
 import { logger } from './utils/logger.js';
 import { helpScoutClient, type PaginatedResponse } from './utils/helpscout-client.js';
 import { resourceHandler } from './resources/index.js';
@@ -108,7 +108,21 @@ ${inboxes.length > 0 ? inboxList : '  No inboxes found - check API credentials'}
 ## Notes
 - Always use inbox IDs from the list above (not names)
 - All search tools default to active+pending+closed statuses
-- Use getServerTime for date-relative queries`;
+- Use getServerTime for date-relative queries
+${config.writes.enabled ? `
+## Write Tools (ENABLED)
+| Task | Tool |
+|------|------|
+| Reply to a conversation | createReply (defaults to draft mode) |
+| Change ticket status | updateConversationStatus |
+| Add internal note | createNote |
+
+### Safety
+- **createReply defaults to draft=true** — drafts must be sent manually from Help Scout UI
+- Setting draft=false sends a real email immediately and CANNOT be undone
+- Notes are internal only and never visible to customers
+- Status changes may trigger Help Scout automations` : ''}`;
+
 
       logger.info('Inbox discovery successful', { inboxCount: inboxes.length });
       return { instructions, inboxes };

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -273,6 +273,64 @@ export const ListAllInboxesInputSchema = z.object({
   limit: z.number().min(1).max(100).default(100),
 });
 
+// Write Operation Input Schemas
+export const CreateReplyInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  text: z.string().min(1, 'Reply text is required'),
+  customer: z.object({
+    email: z.string().email('Valid customer email is required'),
+  }),
+  draft: z.boolean().default(true),
+  cc: z.array(z.string().email('Each CC entry must be a valid email')).optional(),
+  bcc: z.array(z.string().email('Each BCC entry must be a valid email')).optional(),
+});
+
+export const UpdateConversationStatusInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  status: z.enum(['active', 'pending', 'closed']),
+});
+
+export const CreateNoteInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  text: z.string().min(1, 'Note text is required'),
+});
+
+export const CreateConversationInputSchema = z.object({
+  subject: z.string().min(1, 'Subject is required'),
+  customer: z.object({
+    email: z.string().email('Valid customer email is required'),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+  }),
+  mailboxId: z.string().min(1, 'Mailbox ID is required'),
+  text: z.string().min(1, 'Message text is required'),
+  draft: z.boolean().default(true),
+  tags: z.array(z.string()).optional(),
+  assignTo: z.string().optional().describe('User ID to assign the conversation to'),
+});
+
+export const AssignConversationInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  assigneeId: z.string().min(1, 'Assignee user ID is required'),
+});
+
+export const ListUsersInputSchema = z.object({
+  page: z.number().min(1).default(1),
+});
+
+export const ListMailboxesInputSchema = z.object({
+  page: z.number().min(1).default(1),
+});
+
+export const UserSchema = z.object({
+  id: z.number(),
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string(),
+  role: z.string().optional(),
+  type: z.string().optional(),
+});
+
 // Response Types
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
@@ -308,5 +366,13 @@ export type GetOrganizationMembersInput = z.infer<typeof GetOrganizationMembersI
 export type GetOrganizationConversationsInput = z.infer<typeof GetOrganizationConversationsInputSchema>;
 export type GetCustomerContactsInput = z.infer<typeof GetCustomerContactsInputSchema>;
 export type ListAllInboxesInput = z.infer<typeof ListAllInboxesInputSchema>;
+export type CreateReplyInput = z.infer<typeof CreateReplyInputSchema>;
+export type UpdateConversationStatusInput = z.infer<typeof UpdateConversationStatusInputSchema>;
+export type CreateNoteInput = z.infer<typeof CreateNoteInputSchema>;
+export type CreateConversationInput = z.infer<typeof CreateConversationInputSchema>;
+export type AssignConversationInput = z.infer<typeof AssignConversationInputSchema>;
+export type ListUsersInput = z.infer<typeof ListUsersInputSchema>;
+export type ListMailboxesInput = z.infer<typeof ListMailboxesInputSchema>;
+export type User = z.infer<typeof UserSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -30,6 +30,13 @@ import {
   ListOrganizationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetOrganizationConversationsInputSchema,
+  CreateReplyInputSchema,
+  UpdateConversationStatusInputSchema,
+  CreateNoteInputSchema,
+  CreateConversationInputSchema,
+  AssignConversationInputSchema,
+  ListUsersInputSchema,
+  ListMailboxesInputSchema,
 } from '../schema/types.js';
 
 /**
@@ -530,6 +537,145 @@ export class ToolHandler {
           required: ['organizationId'],
         },
       },
+      // Write tools (require HELPSCOUT_ENABLE_WRITES=true)
+      ...(config.writes.enabled ? [
+        {
+          name: 'createReply',
+          description: 'Send a reply on an existing conversation. IMPORTANT: Defaults to draft mode (draft=true) so a human can review before sending. Set draft=false to send immediately — this sends a real email to the customer and CANNOT be undone. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to reply to',
+              },
+              text: {
+                type: 'string',
+                description: 'The reply body text (HTML supported)',
+              },
+              customer: {
+                type: 'object',
+                description: 'Customer object with email address',
+                properties: {
+                  email: { type: 'string', description: 'Customer email address' },
+                },
+                required: ['email'],
+              },
+              draft: {
+                type: 'boolean',
+                description: 'Create as draft for human review (default: true). Set to false to send immediately — THIS SENDS A REAL EMAIL.',
+                default: true,
+              },
+              cc: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'CC email addresses',
+              },
+              bcc: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'BCC email addresses',
+              },
+            },
+            required: ['conversationId', 'text', 'customer'],
+          },
+        },
+        {
+          name: 'updateConversationStatus',
+          description: 'Update a conversation\'s status to active, pending, or closed. WARNING: Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to update',
+              },
+              status: {
+                type: 'string',
+                enum: ['active', 'pending', 'closed'],
+                description: 'New status for the conversation',
+              },
+            },
+            required: ['conversationId', 'status'],
+          },
+        },
+        {
+          name: 'createNote',
+          description: 'Add an internal note to a conversation. Notes are only visible to support agents and are NOT sent to the customer. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to add a note to',
+              },
+              text: {
+                type: 'string',
+                description: 'The note text (HTML supported)',
+              },
+            },
+            required: ['conversationId', 'text'],
+          },
+        },
+        {
+          name: 'createConversation',
+          description: 'Create a new conversation. Defaults to draft mode (draft=true). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              subject: { type: 'string', description: 'Conversation subject line' },
+              customer: {
+                type: 'object',
+                description: 'Customer details',
+                properties: {
+                  email: { type: 'string', description: 'Customer email address' },
+                  firstName: { type: 'string', description: 'Customer first name (optional)' },
+                  lastName: { type: 'string', description: 'Customer last name (optional)' },
+                },
+                required: ['email'],
+              },
+              mailboxId: { type: 'string', description: 'Mailbox ID to create conversation in' },
+              text: { type: 'string', description: 'Message body text (HTML supported)' },
+              draft: { type: 'boolean', description: 'Create as draft (default: true)', default: true },
+              tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply' },
+              assignTo: { type: 'string', description: 'User ID to assign to' },
+            },
+            required: ['subject', 'customer', 'mailboxId', 'text'],
+          },
+        },
+        {
+          name: 'assignConversation',
+          description: 'Assign a conversation to a team member. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: { type: 'string', description: 'The conversation ID' },
+              assigneeId: { type: 'string', description: 'User ID to assign to (use listUsers to find IDs)' },
+            },
+            required: ['conversationId', 'assigneeId'],
+          },
+        },
+        {
+          name: 'listUsers',
+          description: 'List Help Scout users (agents). Useful for finding user IDs for assignment.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            },
+          },
+        },
+        {
+          name: 'listMailboxes',
+          description: 'List available mailboxes. Useful for finding mailbox IDs for creating conversations.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            },
+          },
+        },
+      ] : []),
     ];
   }
 
@@ -638,6 +784,27 @@ export class ToolHandler {
           break;
         case 'getOrganizationConversations':
           result = await this.getOrganizationConversations(request.params.arguments || {});
+          break;
+        case 'createReply':
+          result = await this.createReply(request.params.arguments || {});
+          break;
+        case 'updateConversationStatus':
+          result = await this.updateConversationStatus(request.params.arguments || {});
+          break;
+        case 'createNote':
+          result = await this.createNote(request.params.arguments || {});
+          break;
+        case 'createConversation':
+          result = await this.createConversation(request.params.arguments || {});
+          break;
+        case 'assignConversation':
+          result = await this.assignConversation(request.params.arguments || {});
+          break;
+        case 'listUsers':
+          result = await this.listUsers(request.params.arguments || {});
+          break;
+        case 'listMailboxes':
+          result = await this.listMailboxes(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -2043,6 +2210,256 @@ export class ToolHandler {
           nextCursor: response._links?.next?.href,
           nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
           usage: 'Use conversation.id with getThreads to read full message history, or getConversationSummary for a quick overview.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // --- Write Operations ---
+
+  private checkWritesEnabled(): void {
+    if (process.env.HELPSCOUT_ENABLE_WRITES !== 'true') {
+      throw new Error(
+        'Write operations are disabled. Set HELPSCOUT_ENABLE_WRITES=true to enable reply, note, and status update tools.'
+      );
+    }
+  }
+
+  private async createReply(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateReplyInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating reply', {
+      conversationId,
+      draft: input.draft,
+      hasCC: !!(input.cc && input.cc.length > 0),
+      hasBCC: !!(input.bcc && input.bcc.length > 0),
+    });
+
+    const requestBody: Record<string, unknown> = {
+      customer: { email: input.customer.email },
+      text: input.text,
+      draft: input.draft,
+    };
+
+    if (input.cc && input.cc.length > 0) {
+      requestBody.cc = input.cc;
+    }
+    if (input.bcc && input.bcc.length > 0) {
+      requestBody.bcc = input.bcc;
+    }
+
+    await helpScoutClient.post(`/conversations/${conversationId}/reply`, requestBody);
+
+    const mode = input.draft ? 'draft' : 'sent';
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'reply_created',
+          mode,
+          message: input.draft
+            ? `Draft reply created on conversation ${conversationId}. A human must review and send it from the Help Scout UI.`
+            : `Reply sent on conversation ${conversationId}. The email has been delivered to the customer.`,
+          warning: input.draft ? undefined : 'This reply has been sent to the customer and cannot be undone.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async updateConversationStatus(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = UpdateConversationStatusInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Updating conversation status', {
+      conversationId,
+      newStatus: input.status,
+    });
+
+    await helpScoutClient.patch(`/conversations/${conversationId}`, {
+      op: 'replace',
+      path: '/status',
+      value: input.status,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'status_updated',
+          newStatus: input.status,
+          message: `Conversation ${conversationId} status updated to "${input.status}".`,
+          warning: input.status === 'closed' ? 'Closing a conversation may trigger automations such as satisfaction surveys.' : undefined,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async createNote(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateNoteInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating note', {
+      conversationId,
+    });
+
+    await helpScoutClient.post(`/conversations/${conversationId}/notes`, {
+      text: input.text,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'note_created',
+          message: `Internal note added to conversation ${conversationId}. This note is only visible to support agents.`,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async createConversation(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateConversationInputSchema.parse(args);
+
+    logger.info('Creating conversation', {
+      mailboxId: input.mailboxId,
+      draft: input.draft,
+      hasTags: !!(input.tags && input.tags.length > 0),
+      hasAssignTo: !!input.assignTo,
+    });
+
+    const thread = {
+      type: 'customer',
+      customer: { email: input.customer.email },
+      text: input.text,
+    };
+
+    const requestBody: Record<string, unknown> = {
+      subject: input.subject,
+      customer: input.customer,
+      mailboxId: Number(input.mailboxId),
+      type: 'email',
+      status: input.draft ? 'pending' : 'active',
+      threads: [thread],
+    };
+
+    if (input.tags && input.tags.length > 0) {
+      requestBody.tags = input.tags;
+    }
+    if (input.assignTo) {
+      requestBody.assignTo = Number(input.assignTo);
+    }
+
+    await helpScoutClient.post('/conversations', requestBody);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          action: 'conversation_created',
+          draft: input.draft,
+          message: input.draft
+            ? 'Draft conversation created. A human must review and send it from the Help Scout UI.'
+            : 'Conversation created and active.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async assignConversation(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = AssignConversationInputSchema.parse(args);
+
+    logger.info('Assigning conversation', {
+      conversationId: input.conversationId,
+      assigneeId: input.assigneeId,
+    });
+
+    await helpScoutClient.patch(`/conversations/${input.conversationId}`, {
+      op: 'replace',
+      path: '/assignTo',
+      value: Number(input.assigneeId),
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId: input.conversationId,
+          action: 'conversation_assigned',
+          assigneeId: input.assigneeId,
+          message: `Conversation ${input.conversationId} assigned to user ${input.assigneeId}.`,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listUsers(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = ListUsersInputSchema.parse(args);
+
+    const response = await helpScoutClient.get<PaginatedResponse<Record<string, unknown>>>('/users', {
+      page: input.page,
+    });
+
+    const users = response._embedded?.users || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          users: users.map((u: Record<string, unknown>) => ({
+            id: u.id,
+            firstName: u.firstName,
+            lastName: u.lastName,
+            email: u.email,
+            role: u.role,
+            type: u.type,
+          })),
+          returnedCount: users.length,
+          pagination: response.page,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listMailboxes(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = ListMailboxesInputSchema.parse(args);
+
+    const response = await helpScoutClient.get<PaginatedResponse<Record<string, unknown>>>('/mailboxes', {
+      page: input.page,
+    });
+
+    const mailboxes = response._embedded?.mailboxes || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          mailboxes: mailboxes.map((m: Record<string, unknown>) => ({
+            id: m.id,
+            name: m.name,
+            email: m.email,
+          })),
+          returnedCount: mailboxes.length,
+          pagination: response.page,
         }, null, 2),
       }],
     };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,6 +23,9 @@ export interface Config {
   security: {
     allowPii: boolean;
   };
+  writes: {
+    enabled: boolean;
+  };
   connectionPool: {
     maxSockets: number;
     maxFreeSockets: number;
@@ -52,6 +55,9 @@ export const config: Config = {
     // Default: show content. Set REDACT_MESSAGE_CONTENT=true to hide message bodies
     // ALLOW_PII=true is backwards compat (always shows content)
     allowPii: process.env.REDACT_MESSAGE_CONTENT !== 'true' || process.env.ALLOW_PII === 'true',
+  },
+  writes: {
+    enabled: process.env.HELPSCOUT_ENABLE_WRITES === 'true',
   },
   connectionPool: {
     maxSockets: parseInt(process.env.HTTP_MAX_SOCKETS || '50', 10),
@@ -90,6 +96,11 @@ export function validateConfig(): void {
       'Optional configuration:\n' +
       '  - HELPSCOUT_DEFAULT_INBOX_ID: Default inbox for scoped searches (improves LLM context)'
     );
+  }
+
+  // Log write access status
+  if (config.writes.enabled) {
+    console.error('Help Scout write access ENABLED (HELPSCOUT_ENABLE_WRITES=true)');
   }
 
   // Enforce HTTPS for API base URL to prevent credential exposure

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -352,6 +352,18 @@ export class HelpScoutClient {
       };
     }
 
+    if (error.response?.status === 412) {
+      return {
+        code: 'INVALID_INPUT',
+        message: 'Help Scout precondition failed. The conversation may have reached the 100-thread limit, or a company policy prevents updates to old conversations.',
+        details: {
+          requestId,
+          statusCode: 412,
+          suggestion: 'Check the conversation thread count and company policies in Help Scout settings',
+        },
+      };
+    }
+
     if (error.response?.status === 422) {
       const responseData = error.response.data as Record<string, any> || {};
       return {
@@ -411,6 +423,52 @@ export class HelpScoutClient {
         suggestion: 'Check your network connection and Help Scout service status',
       },
     };
+  }
+
+  /**
+   * Check response status and throw a structured error for 4xx responses.
+   * Needed because validateStatus allows 4xx through without throwing.
+   */
+  private checkResponseStatus(response: AxiosResponse): void {
+    if (response.status >= 400 && response.status < 500) {
+      const error = new Error(`Request failed with status ${response.status}`) as any;
+      error.response = response;
+      error.config = response.config;
+      throw this.transformError(error as AxiosError);
+    }
+  }
+
+  async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.post<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
+  async patch<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.patch<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
+  /**
+   * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
+   */
+  private invalidateCacheAfterWrite(endpoint: string): void {
+    const match = endpoint.match(/\/conversations\/(\d+)/);
+    if (match) {
+      logger.debug('Invalidating cache after write operation', { endpoint });
+      cache.clear();
+    }
   }
 
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -467,7 +467,7 @@ export class HelpScoutClient {
    * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
    */
   private invalidateCacheAfterWrite(endpoint: string): void {
-    const match = endpoint.match(/\/conversations\/(\d+)/);
+    const match = endpoint.match(/\/conversations/);
     if (match) {
       logger.debug('Invalidating cache after write operation', { endpoint });
       cache.clear();

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -439,8 +439,11 @@ export class HelpScoutClient {
   }
 
   async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
-    const response = await this.executeWithRetry<T>(() =>
-      this.client.post<T>(endpoint, data)
+    // POST is not idempotent — never retry to prevent duplicate creates (emails, notes, conversations)
+    const noRetryConfig: RetryConfig = { retries: 0, retryDelay: 0, maxRetryDelay: 0 };
+    const response = await this.executeWithRetry<T>(
+      () => this.client.post<T>(endpoint, data),
+      noRetryConfig
     );
 
     this.checkResponseStatus(response);


### PR DESCRIPTION
## Summary

Adds 7 write tools to the MCP server, building on patterns from #19 by @jcwatson11 — thank you for the excellent foundation! 🙏

This PR is rebased on top of the latest `main` (v1.7.0+), incorporating all recent upstream changes that landed after #19 was opened — including customer/org tools, PII redaction, navigator plugin, and bugfixes.

### Key design choices:
- **Draft-by-default**: `createReply` and `createConversation` create drafts, not sent messages
- **Opt-in gating**: Write tools only load when `HELPSCOUT_ENABLE_WRITES=true` (off by default)
- **POST idempotency**: No retries on create operations to prevent duplicates
- **Cache invalidation**: LRU cache clears after write operations

### Write Tools
| Tool | Description |
|------|-------------|
| `createReply` | Draft reply on a conversation |
| `createNote` | Internal note (agent-only) |
| `updateConversationStatus` | Change status (active/pending/closed) |
| `createConversation` | New conversation (draft by default) |
| `assignConversation` | Assign to a team member |
| `listUsers` | List agents (for assignments) |
| `listMailboxes` | List mailboxes (for new conversations) |

### Safety
- Write tools hidden unless `HELPSCOUT_ENABLE_WRITES=true`
- `createReply` and `createConversation` default to draft mode
- POST requests skip retry logic to prevent duplicate creates
- 412/422 error handling for thread limits and validation
