### PR TITLE
Add customer, organization, and Docs API support with write operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ docker run -e HELPSCOUT_APP_ID="your-app-id" \
 
 1. Go to **Help Scout** > **My Apps** > **Create Private App**
 2. Select at minimum: **Read** access to Mailboxes and Conversations
-3. Copy your **App ID** and **App Secret**
+3. For write tools: also grant **Write** access to Conversations
+4. Copy your **App ID** and **App Secret**
 
 > Help Scout uses OAuth2 Client Credentials flow exclusively. Personal Access Tokens are not supported.
 
@@ -100,6 +101,22 @@ Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `
 | Full message history | `getThreads` | "Show me the complete thread" |
 | Current server time | `getServerTime` | Used for time-relative searches |
 
+### Write Tools (Opt-in)
+
+These tools require `HELPSCOUT_ENABLE_WRITES=true` and are hidden when writes are disabled.
+
+| Task | Tool | Example |
+|------|------|---------|
+| Reply to a conversation | `createReply` | "Draft a reply to ticket #123" |
+| Change ticket status | `updateConversationStatus` | "Close ticket #123" |
+| Add internal note | `createNote` | "Add a note to ticket #123" |
+
+**Safety defaults:**
+- `createReply` defaults to **draft mode** (`draft: true`). Drafts must be manually sent from the Help Scout UI.
+- Setting `draft: false` sends a real email immediately and **cannot be undone**.
+- `createNote` creates internal notes only visible to support agents, never sent to customers.
+- Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close).
+
 Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in their instructions automatically, so no lookup step is needed.
 
 ## Configuration
@@ -110,6 +127,7 @@ Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in
 | `HELPSCOUT_APP_SECRET` | App Secret from Help Scout My Apps | Required |
 | `HELPSCOUT_DEFAULT_INBOX_ID` | Scope searches to a specific inbox | None (all inboxes) |
 | `HELPSCOUT_BASE_URL` | Help Scout API endpoint | `https://api.helpscout.net/v2/` |
+| `HELPSCOUT_ENABLE_WRITES` | Enable write tools (reply, note, status update) | `false` |
 | `REDACT_MESSAGE_CONTENT` | Hide message bodies in responses | `false` |
 | `CACHE_TTL_SECONDS` | Cache duration for API responses | `300` |
 | `LOG_LEVEL` | Logging verbosity (`error`, `warn`, `info`, `debug`) | `info` |

--- a/README.md
+++ b/README.md
@@ -2,15 +2,20 @@
 
 [![npm version](https://badge.fury.io/js/help-scout-mcp-server.svg)](https://badge.fury.io/js/help-scout-mcp-server) [![Docker](https://img.shields.io/docker/v/drewburchfield/help-scout-mcp-server?logo=docker&label=docker)](https://hub.docker.com/r/drewburchfield/help-scout-mcp-server) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/drewburchfield/help-scout-mcp-server) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-An [MCP server](https://modelcontextprotocol.io) that gives AI assistants direct access to your Help Scout inboxes, conversations, and threads. Search tickets, pull context, spot patterns, and get answers without leaving your editor or chat window.
+An [MCP server](https://modelcontextprotocol.io) that gives AI assistants direct access to your Help Scout inboxes, conversations, customers, organizations, and threads. Search tickets, manage customers, create draft replies, and get answers without leaving your editor or chat window.
 
 Built by a Help Scout customer who wanted to give his support team superpowers. If you handle customer conversations in Help Scout and want AI to help you work faster, this is for you.
 
 ## What You Can Do
 
 - **Search conversations** by keyword, date range, status, tag, email domain, or ticket number
+- **Look up customers** by name, email, or organization
+- **Browse organizations** and their members and conversation history
 - **Pull full thread history** into context before drafting a reply
 - **Get conversation summaries** with the original customer message and latest staff response
+- **Create draft replies** for human review before sending
+- **Add internal notes** and manage conversation status
+- **Create and assign conversations** to team members
 - **Monitor inbox activity** across multiple inboxes with a single query
 - **Stay compliant** with optional PII redaction and scoped inbox access
 
@@ -87,9 +92,9 @@ docker run -e HELPSCOUT_APP_ID="your-app-id" \
 
 Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `HELPSCOUT_API_KEY` are also supported.
 
-## Tools
+## Tools (24 total)
 
-### Which tool should I use?
+### Conversation Tools
 
 | Task | Tool | Example |
 |------|------|---------|
@@ -100,6 +105,20 @@ Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `
 | Quick conversation overview | `getConversationSummary` | "Summarize this conversation" |
 | Full message history | `getThreads` | "Show me the complete thread" |
 | Current server time | `getServerTime` | Used for time-relative searches |
+| List inboxes | `searchInboxes` / `listAllInboxes` | "What inboxes are available?" |
+
+### Customer & Organization Tools
+
+| Task | Tool | Example |
+|------|------|---------|
+| Get customer profile | `getCustomer` | "Look up customer 12345" |
+| Search customers | `listCustomers` | "Find customers named Smith" |
+| Find by email | `searchCustomersByEmail` | "Find customer with email john@acme.com" |
+| Get contact details | `getCustomerContacts` | "Get all contact info for customer 12345" |
+| Get organization | `getOrganization` | "Show me organization 789" |
+| List organizations | `listOrganizations` | "List all organizations by activity" |
+| Organization members | `getOrganizationMembers` | "Who is in organization 789?" |
+| Organization conversations | `getOrganizationConversations` | "Show conversations for org 789" |
 
 ### Write Tools (Opt-in)
 
@@ -108,14 +127,20 @@ These tools require `HELPSCOUT_ENABLE_WRITES=true` and are hidden when writes ar
 | Task | Tool | Example |
 |------|------|---------|
 | Reply to a conversation | `createReply` | "Draft a reply to ticket #123" |
-| Change ticket status | `updateConversationStatus` | "Close ticket #123" |
 | Add internal note | `createNote` | "Add a note to ticket #123" |
+| Change ticket status | `updateConversationStatus` | "Close ticket #123" |
+| Create new conversation | `createConversation` | "Create a draft ticket for john@acme.com" |
+| Assign to team member | `assignConversation` | "Assign ticket #123 to user 456" |
+| List team members | `listUsers` | "Who can I assign tickets to?" |
+| List mailboxes | `listMailboxes` | "Which mailbox should I create the ticket in?" |
 
 **Safety defaults:**
-- `createReply` defaults to **draft mode** (`draft: true`). Drafts must be manually sent from the Help Scout UI.
+- `HELPSCOUT_ENABLE_WRITES` defaults to **`false`**. Write tools are completely hidden until explicitly enabled.
+- `createReply` and `createConversation` default to **draft mode** (`draft: true`). Drafts must be manually sent from the Help Scout UI.
 - Setting `draft: false` sends a real email immediately and **cannot be undone**.
 - `createNote` creates internal notes only visible to support agents, never sent to customers.
 - Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close).
+- POST operations (creates) do not retry to prevent duplicate records.
 
 Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in their instructions automatically, so no lookup step is needed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "help-scout-mcp-server",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "help-scout-mcp-server",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@modelcontextprotocol/sdk": "1.27.1",
         "axios": "^1.6.2",
         "dotenv": "^16.3.1",
         "lru-cache": "^10.1.0",
@@ -1086,19 +1086,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -1110,9 +1097,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
+      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1135,19 +1122,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1997,9 +1971,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -3753,19 +3727,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -4154,19 +4115,6 @@
         "minimatch": "^5.0.1"
       }
     },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4544,19 +4492,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -4670,9 +4605,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.4.tgz",
+      "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5046,19 +4981,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jest": {
@@ -5966,13 +5888,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6778,22 +6700,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -7257,19 +7163,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "help-scout-mcp-server",
-  "version": "1.6.2",
-  "description": "The first MCP server for Help Scout - search conversations, threads, and inboxes with AI agents",
+  "version": "1.7.0",
+  "mcpName": "io.github.drewburchfield/help-scout-mcp",
+  "description": "Search Help Scout conversations, customers, organizations, threads, and inboxes with AI assistants",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
@@ -35,7 +36,8 @@
     "prepack": "npm run build",
     "mcpb:build": "node scripts/build-mcpb.js",
     "mcpb:pack": "npm run mcpb:build && cd helpscout-mcp-extension && npx @anthropic-ai/mcpb pack",
-    "build:all": "npm run build && npm run mcpb:build"
+    "build:all": "npm run build && npm run mcpb:build",
+    "sync:plugin": "rm -rf plugins/helpscout-navigator && git clone --depth 1 https://github.com/drewburchfield/helpscout-navigator.git plugins/helpscout-navigator && rm -rf plugins/helpscout-navigator/.git"
   },
   "keywords": [
     "mcp",
@@ -47,6 +49,9 @@
     "helpscout",
     "help scout",
     "customer-support",
+    "claude-cowork",
+    "claude-code-plugin",
+    "claude-desktop",
     "typescript",
     "nodejs"
   ],
@@ -64,7 +69,7 @@
     "url": "https://github.com/drewburchfield/help-scout-mcp-server/issues"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@modelcontextprotocol/sdk": "1.27.1",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "lru-cache": "^10.1.0",
@@ -90,6 +95,9 @@
   },
   "overrides": {
     "cross-spawn": "^7.0.6",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "minimatch": "^9.0.7",
+    "hono": "4.12.4",
+    "@hono/node-server": "1.19.10"
   }
 }

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -34,21 +34,21 @@ describe('ToolHandler', () => {
   });
 
   describe('listTools', () => {
-    it('should return all available tools', async () => {
+    it('should return all available tools (read-only when writes disabled)', async () => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
       const tools = await toolHandler.listTools();
-      
-      expect(tools).toHaveLength(9);
-      expect(tools.map(t => t.name)).toEqual([
-        'searchInboxes',
-        'searchConversations',
-        'getConversationSummary',
-        'getThreads',
-        'getServerTime',
-        'listAllInboxes',
-        'advancedConversationSearch',
-        'comprehensiveConversationSearch',
-        'structuredConversationFilter'
-      ]);
+
+      // 9 read-only tools when writes are disabled
+      expect(tools.length).toBeGreaterThanOrEqual(9);
+      expect(tools.map(t => t.name)).toContain('searchInboxes');
+      expect(tools.map(t => t.name)).toContain('searchConversations');
+      expect(tools.map(t => t.name)).toContain('getConversationSummary');
+      expect(tools.map(t => t.name)).toContain('getThreads');
+      expect(tools.map(t => t.name)).toContain('getServerTime');
+      expect(tools.map(t => t.name)).toContain('listAllInboxes');
+      expect(tools.map(t => t.name)).toContain('advancedConversationSearch');
+      expect(tools.map(t => t.name)).toContain('comprehensiveConversationSearch');
+      expect(tools.map(t => t.name)).toContain('structuredConversationFilter');
     });
 
     it('should have proper tool schemas', async () => {

--- a/src/__tests__/write-tools.test.ts
+++ b/src/__tests__/write-tools.test.ts
@@ -1,0 +1,420 @@
+import nock from 'nock';
+import { ToolHandler } from '../tools/index.js';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+describe('Write Tools', () => {
+  let toolHandler: ToolHandler;
+  const baseURL = 'https://api.helpscout.net/v2';
+
+  beforeEach(() => {
+    process.env.HELPSCOUT_CLIENT_ID = 'test-client-id';
+    process.env.HELPSCOUT_CLIENT_SECRET = 'test-client-secret';
+    process.env.HELPSCOUT_BASE_URL = `${baseURL}/`;
+
+    nock.cleanAll();
+
+    // Mock OAuth2 authentication
+    // The auth endpoint is hardcoded to https://api.helpscout.net/v2/oauth2/token
+    nock(baseURL)
+      .persist()
+      .post('/oauth2/token')
+      .reply(200, {
+        access_token: 'mock-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+    toolHandler = new ToolHandler();
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  describe('when writes are disabled', () => {
+    beforeEach(() => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
+    });
+
+    it('should not list write tools when writes are disabled', async () => {
+      const tools = await toolHandler.listTools();
+      const toolNames = tools.map(t => t.name);
+
+      expect(toolNames).not.toContain('createReply');
+      expect(toolNames).not.toContain('updateConversationStatus');
+      expect(toolNames).not.toContain('createNote');
+    });
+
+    it('should return error when calling createReply with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'createReply',
+          arguments: {
+            conversationId: '123',
+            text: 'Hello',
+            customer: { email: 'test@example.com' },
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.error.message).toContain('Write operations are disabled');
+    });
+
+    it('should return error when calling createNote with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'createNote',
+          arguments: {
+            conversationId: '123',
+            text: 'Internal note',
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return error when calling updateConversationStatus with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'updateConversationStatus',
+          arguments: {
+            conversationId: '123',
+            status: 'closed',
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('when writes are enabled', () => {
+    beforeEach(() => {
+      process.env.HELPSCOUT_ENABLE_WRITES = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
+    });
+
+    describe('createReply', () => {
+      it('should create a draft reply by default', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/reply', (body: any) => {
+            expect(body.text).toBe('Hello customer');
+            expect(body.customer.email).toBe('test@example.com');
+            expect(body.draft).toBe(true);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello customer',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('draft');
+        expect(parsed.action).toBe('reply_created');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should create a sent reply when draft=false', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/456/reply', (body: any) => {
+            expect(body.draft).toBe(false);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '456',
+              text: 'Sent reply',
+              customer: { email: 'customer@example.com' },
+              draft: false,
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('sent');
+        expect(parsed.warning).toContain('cannot be undone');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should include cc and bcc when provided', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/reply', (body: any) => {
+            expect(body.cc).toEqual(['cc@example.com']);
+            expect(body.bcc).toEqual(['bcc@example.com']);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Reply with cc',
+              customer: { email: 'test@example.com' },
+              cc: ['cc@example.com'],
+              bcc: ['bcc@example.com'],
+            },
+          },
+        };
+
+        await toolHandler.callTool(request);
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject invalid customer email', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello',
+              customer: { email: 'not-an-email' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should reject empty text', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: '',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('updateConversationStatus', () => {
+      it('should update conversation status to closed', async () => {
+        const scope = nock(baseURL)
+          .patch('/conversations/123', (body: any) => {
+            expect(body.op).toBe('replace');
+            expect(body.path).toBe('/status');
+            expect(body.value).toBe('closed');
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '123',
+              status: 'closed',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.newStatus).toBe('closed');
+        expect(parsed.warning).toContain('automations');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should update conversation status to active', async () => {
+        const scope = nock(baseURL)
+          .patch('/conversations/789', (body: any) => {
+            expect(body.value).toBe('active');
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '789',
+              status: 'active',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.warning).toBeUndefined();
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject invalid status', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '123',
+              status: 'spam',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('createNote', () => {
+      it('should create an internal note', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/notes', (body: any) => {
+            expect(body.text).toBe('Internal note text');
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: 'Internal note text',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.action).toBe('note_created');
+        expect(parsed.message).toContain('only visible to support agents');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject empty note text', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: '',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle 412 precondition failed (thread limit)', async () => {
+        nock(baseURL)
+          .post('/conversations/123/notes')
+          .reply(412, { message: 'Thread limit exceeded' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: 'Note',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse((result.content[0] as any).text);
+        expect(parsed.error.message).toContain('precondition failed');
+      });
+
+      it('should handle 422 validation error', async () => {
+        nock(baseURL)
+          .post('/conversations/123/reply')
+          .reply(422, { message: 'Invalid request' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should handle 404 not found', async () => {
+        nock(baseURL)
+          .patch('/conversations/999')
+          .reply(404, { message: 'Not found' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '999',
+              status: 'active',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export class HelpScoutMCPServer {
     this.server = new Server(
       {
         name: 'helpscout-search',
-        version: '1.6.2',
+        version: '1.7.0',
       },
       {
         capabilities: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { validateConfig } from './utils/config.js';
+import { validateConfig, config } from './utils/config.js';
 import { logger } from './utils/logger.js';
 import { helpScoutClient, type PaginatedResponse } from './utils/helpscout-client.js';
 import { resourceHandler } from './resources/index.js';
@@ -99,7 +99,21 @@ ${inboxes.length > 0 ? inboxList : '  No inboxes found - check API credentials'}
 ## Notes
 - Always use inbox IDs from the list above (not names)
 - All search tools default to active+pending+closed statuses
-- Use getServerTime for date-relative queries`;
+- Use getServerTime for date-relative queries
+${config.writes.enabled ? `
+## Write Tools (ENABLED)
+| Task | Tool |
+|------|------|
+| Reply to a conversation | createReply (defaults to draft mode) |
+| Change ticket status | updateConversationStatus |
+| Add internal note | createNote |
+
+### Safety
+- **createReply defaults to draft=true** — drafts must be sent manually from Help Scout UI
+- Setting draft=false sends a real email immediately and CANNOT be undone
+- Notes are internal only and never visible to customers
+- Status changes may trigger Help Scout automations` : ''}`;
+
 
       logger.info('Inbox discovery successful', { inboxCount: inboxes.length });
       return { instructions, inboxes };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import { logger } from './utils/logger.js';
 import { helpScoutClient, type PaginatedResponse } from './utils/helpscout-client.js';
 import { resourceHandler } from './resources/index.js';
 import { toolHandler } from './tools/index.js';
+import { docsToolHandler } from './tools/docs.js';
+import { docsClient } from './utils/docs-client.js';
 import { promptHandler } from './prompts/index.js';
 import type { Inbox } from './schema/types.js';
 
@@ -112,7 +114,25 @@ ${config.writes.enabled ? `
 - **createReply defaults to draft=true** — drafts must be sent manually from Help Scout UI
 - Setting draft=false sends a real email immediately and CANNOT be undone
 - Notes are internal only and never visible to customers
-- Status changes may trigger Help Scout automations` : ''}`;
+- Status changes may trigger Help Scout automations` : ''}
+${config.docs ? `
+## Docs API (Knowledge Base)
+| Task | Tool |
+|------|------|
+| Browse KB structure | docs_listCollections → docs_listCategories |
+| Find articles | docs_searchArticles or docs_listArticles |
+| Read article content | docs_getArticle |
+| Check article history | docs_listArticleRevisions → docs_getArticleRevision |
+| List Docs sites | docs_listSites |
+${config.writes.enabled ? `
+### Docs Write Tools (ENABLED)
+| Task | Tool |
+|------|------|
+| Create/update articles | docs_createArticle / docs_updateArticle |
+| Manage collections | docs_createCollection / docs_updateCollection |
+| Manage categories | docs_createCategory / docs_updateCategory |
+| Manage redirects | docs_createRedirect / docs_updateRedirect |
+| Delete resources | docs_deleteArticle / docs_deleteCollection / docs_deleteCategory` : ''}` : ''}`;
 
 
       logger.info('Inbox discovery successful', { inboxCount: inboxes.length });
@@ -161,8 +181,10 @@ Note: Inbox auto-discovery failed (${safeError}). Use listAllInboxes tool to see
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       logger.debug('Listing tools');
       try {
+        const coreTools = await toolHandler.listTools();
+        const docsTools = docsToolHandler ? await docsToolHandler.listTools() : [];
         return {
-          tools: await toolHandler.listTools(),
+          tools: [...coreTools, ...docsTools],
         };
       } catch (error) {
         logger.error('Error listing tools', { error: error instanceof Error ? error.message : String(error) });
@@ -171,10 +193,14 @@ Note: Inbox auto-discovery failed (${safeError}). Use listAllInboxes tool to see
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      logger.debug('Calling tool', { 
-        name: request.params.name, 
-        arguments: request.params.arguments 
+      logger.debug('Calling tool', {
+        name: request.params.name,
+        arguments: request.params.arguments
       });
+      // Route docs_* tools to the Docs handler
+      if (request.params.name.startsWith('docs_') && docsToolHandler) {
+        return await docsToolHandler.callTool(request);
+      }
       return await toolHandler.callTool(request);
     });
 
@@ -247,9 +273,10 @@ Note: Inbox auto-discovery failed (${safeError}). Use listAllInboxes tool to see
       // Close the MCP server
       await this.server.close();
       
-      // Close HTTP connection pool
+      // Close HTTP connection pools
       await helpScoutClient.closePool();
-      
+      if (docsClient) await docsClient.closePool();
+
       logger.info('Help Scout MCP Server stopped');
     } catch (error) {
       logger.error('Error stopping server', { 

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -2,6 +2,8 @@ import { TextResourceContents, Resource } from '@modelcontextprotocol/sdk/types.
 import { helpScoutClient, PaginatedResponse } from '../utils/helpscout-client.js';
 import { Inbox, Conversation, Thread, ServerTime } from '../schema/types.js';
 import { logger } from '../utils/logger.js';
+import { config } from '../utils/config.js';
+import { PII_REDACTED_BODY } from '../utils/constants.js';
 
 export class ResourceHandler {
   async handleResource(uri: string): Promise<TextResourceContents> {
@@ -14,6 +16,20 @@ export class ResourceHandler {
 
     const path = url.hostname; // For custom protocols like helpscout://, the resource name is in hostname
     const searchParams = Object.fromEntries(url.searchParams.entries());
+
+    // NAS-471: Bounds checking for page/size params
+    if (searchParams.page) {
+      const page = parseInt(searchParams.page, 10);
+      if (isNaN(page) || page < 1 || page > 10000) {
+        throw new Error('page must be a number between 1 and 10000');
+      }
+    }
+    if (searchParams.size) {
+      const size = parseInt(searchParams.size, 10);
+      if (isNaN(size) || size < 1 || size > 50) {
+        throw new Error('size must be a number between 1 and 50');
+      }
+    }
 
     logger.info('Handling resource request', { uri, path, params: searchParams });
 
@@ -91,6 +107,9 @@ export class ResourceHandler {
     if (!conversationId) {
       throw new Error('conversationId parameter is required for threads resource');
     }
+    if (!/^\d+$/.test(conversationId)) {
+      throw new Error('conversationId must be a numeric value');
+    }
 
     try {
       const response = await helpScoutClient.get<PaginatedResponse<Thread>>(`/conversations/${conversationId}/threads`, {
@@ -100,12 +119,17 @@ export class ResourceHandler {
 
       const threads = response._embedded?.threads || [];
 
+      const redactedThreads = threads.map(thread => ({
+        ...thread,
+        body: config.security.allowPii ? thread.body : PII_REDACTED_BODY,
+      }));
+
       return {
         uri: `helpscout://threads?conversationId=${conversationId}`,
         mimeType: 'application/json',
         text: JSON.stringify({
           conversationId,
-          threads,
+          threads: redactedThreads,
           pagination: response.page,
           links: response._links,
         }, null, 2),

--- a/src/schema/docs-types.ts
+++ b/src/schema/docs-types.ts
@@ -1,0 +1,291 @@
+import { z } from 'zod';
+
+// ── Docs API Data Models ───────────────────────────────────────────
+
+export const DocsSiteSchema = z.object({
+  id: z.string(),
+  status: z.string().optional(),
+  subDomain: z.string().optional(),
+  cname: z.string().nullable().optional(),
+  hasPublicSite: z.boolean().optional(),
+  companyName: z.string().nullable().optional(),
+  title: z.string().nullable().optional(),
+  logoUrl: z.string().nullable().optional(),
+  logoWidth: z.number().nullable().optional(),
+  logoHeight: z.number().nullable().optional(),
+  favIconUrl: z.string().nullable().optional(),
+  touchIconUrl: z.string().nullable().optional(),
+  homeUrl: z.string().nullable().optional(),
+  homeLinkText: z.string().nullable().optional(),
+  contactUrl: z.string().nullable().optional(),
+  styleSheetUrl: z.string().nullable().optional(),
+  headerCode: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export const DocsCollectionSchema = z.object({
+  id: z.string(),
+  siteId: z.string().optional(),
+  number: z.number().optional(),
+  slug: z.string().optional(),
+  visibility: z.string().optional(),
+  order: z.number().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  publicUrl: z.string().nullable().optional(),
+  articleCount: z.number().optional(),
+  publishedArticleCount: z.number().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export const DocsCategorySchema = z.object({
+  id: z.string(),
+  collectionId: z.string().optional(),
+  number: z.number().optional(),
+  slug: z.string().optional(),
+  visibility: z.string().optional(),
+  order: z.number().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  articleCount: z.number().optional(),
+  publishedArticleCount: z.number().optional(),
+  publicUrl: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export const DocsArticleSchema = z.object({
+  id: z.string(),
+  collectionId: z.string().optional(),
+  number: z.number().optional(),
+  slug: z.string().optional(),
+  status: z.string().optional(),
+  name: z.string(),
+  text: z.string().nullable().optional(),
+  categories: z.array(z.string()).optional(),
+  related: z.array(z.string()).optional(),
+  keywords: z.array(z.string()).optional(),
+  publicUrl: z.string().nullable().optional(),
+  popularity: z.number().nullable().optional(),
+  viewCount: z.number().nullable().optional(),
+  hasDraft: z.boolean().optional(),
+  lastPublishedAt: z.string().nullable().optional(),
+  createdBy: z.number().nullable().optional(),
+  updatedBy: z.number().nullable().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export const DocsArticleRefSchema = z.object({
+  id: z.string(),
+  collectionId: z.string().optional(),
+  number: z.number().optional(),
+  slug: z.string().optional(),
+  status: z.string().optional(),
+  name: z.string(),
+  publicUrl: z.string().nullable().optional(),
+  popularity: z.number().nullable().optional(),
+  viewCount: z.number().nullable().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+export const DocsRevisionSchema = z.object({
+  id: z.string(),
+  articleId: z.string().optional(),
+  createdBy: z.union([
+    z.object({
+      id: z.number(),
+      firstName: z.string().optional(),
+      lastName: z.string().optional(),
+    }),
+    z.number(),
+  ]).nullable().optional(),
+  createdAt: z.string().optional(),
+});
+
+export const DocsRedirectSchema = z.object({
+  id: z.string(),
+  siteId: z.string().optional(),
+  urlMapping: z.string().optional(),
+  redirect: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+// ── Input Schemas for Tools ────────────────────────────────────────
+
+// Sites
+export const DocsListSitesInputSchema = z.object({
+  page: z.number().min(1).default(1),
+});
+
+export const DocsGetSiteInputSchema = z.object({
+  siteId: z.string().min(1, 'Site ID is required'),
+});
+
+// Collections
+export const DocsListCollectionsInputSchema = z.object({
+  siteId: z.string().optional().describe('Filter by site ID'),
+  page: z.number().min(1).default(1),
+  visibility: z.enum(['all', 'public', 'private']).optional(),
+  sort: z.enum(['order', 'name', 'createdAt', 'updatedAt']).optional(),
+  order: z.enum(['asc', 'desc']).optional(),
+});
+
+export const DocsGetCollectionInputSchema = z.object({
+  collectionId: z.string().min(1, 'Collection ID is required'),
+});
+
+export const DocsCreateCollectionInputSchema = z.object({
+  siteId: z.string().min(1, 'Site ID is required'),
+  name: z.string().min(1, 'Collection name is required'),
+  visibility: z.enum(['public', 'private']).default('public'),
+  description: z.string().optional(),
+  order: z.number().optional(),
+});
+
+export const DocsUpdateCollectionInputSchema = z.object({
+  collectionId: z.string().min(1, 'Collection ID is required'),
+  name: z.string().optional(),
+  visibility: z.enum(['public', 'private']).optional(),
+  description: z.string().optional(),
+  order: z.number().optional(),
+});
+
+export const DocsDeleteCollectionInputSchema = z.object({
+  collectionId: z.string().min(1, 'Collection ID is required'),
+});
+
+// Categories
+export const DocsListCategoriesInputSchema = z.object({
+  collectionId: z.string().min(1, 'Collection ID is required'),
+  page: z.number().min(1).default(1),
+  sort: z.enum(['order', 'name', 'createdAt', 'updatedAt']).optional(),
+  order: z.enum(['asc', 'desc']).optional(),
+});
+
+export const DocsGetCategoryInputSchema = z.object({
+  categoryId: z.string().min(1, 'Category ID is required'),
+});
+
+export const DocsCreateCategoryInputSchema = z.object({
+  collectionId: z.string().min(1, 'Collection ID is required'),
+  name: z.string().min(1, 'Category name is required'),
+  description: z.string().optional(),
+  order: z.number().optional(),
+  visibility: z.enum(['public', 'private']).optional(),
+});
+
+export const DocsUpdateCategoryInputSchema = z.object({
+  categoryId: z.string().min(1, 'Category ID is required'),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  order: z.number().optional(),
+  visibility: z.enum(['public', 'private']).optional(),
+});
+
+export const DocsDeleteCategoryInputSchema = z.object({
+  categoryId: z.string().min(1, 'Category ID is required'),
+});
+
+// Articles
+export const DocsListArticlesInputSchema = z.object({
+  collectionId: z.string().optional().describe('List articles in this collection'),
+  categoryId: z.string().optional().describe('List articles in this category'),
+  page: z.number().min(1).default(1),
+  sort: z.enum(['order', 'name', 'createdAt', 'updatedAt', 'popularity', 'viewCount']).optional(),
+  order: z.enum(['asc', 'desc']).optional(),
+  status: z.enum(['all', 'published', 'notpublished']).optional(),
+}).refine(
+  (data) => data.collectionId || data.categoryId,
+  { message: 'Either collectionId or categoryId is required' },
+);
+
+export const DocsGetArticleInputSchema = z.object({
+  articleId: z.string().min(1, 'Article ID is required'),
+  draft: z.boolean().optional().describe('If true, return the draft version'),
+});
+
+export const DocsSearchArticlesInputSchema = z.object({
+  query: z.string().min(1, 'Search query is required'),
+  collectionId: z.string().optional().describe('Limit search to a collection'),
+  page: z.number().min(1).default(1),
+  status: z.enum(['all', 'published', 'notpublished']).optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional(),
+});
+
+export const DocsGetRelatedArticlesInputSchema = z.object({
+  articleId: z.string().min(1, 'Article ID is required'),
+  page: z.number().min(1).default(1),
+});
+
+export const DocsListArticleRevisionsInputSchema = z.object({
+  articleId: z.string().min(1, 'Article ID is required'),
+  page: z.number().min(1).default(1),
+});
+
+export const DocsGetArticleRevisionInputSchema = z.object({
+  articleId: z.string().min(1, 'Article ID is required'),
+  revisionId: z.string().min(1, 'Revision ID is required'),
+});
+
+export const DocsCreateArticleInputSchema = z.object({
+  collectionId: z.string().min(1, 'Collection ID is required'),
+  name: z.string().min(1, 'Article title is required'),
+  text: z.string().min(1, 'Article text/HTML is required'),
+  slug: z.string().optional(),
+  status: z.enum(['published', 'notpublished']).default('published'),
+  categories: z.array(z.string()).optional().describe('Array of category IDs'),
+  related: z.array(z.string()).optional().describe('Array of related article IDs'),
+  keywords: z.array(z.string()).optional(),
+});
+
+export const DocsUpdateArticleInputSchema = z.object({
+  articleId: z.string().min(1, 'Article ID is required'),
+  name: z.string().optional(),
+  text: z.string().optional(),
+  slug: z.string().optional(),
+  status: z.enum(['published', 'notpublished']).optional(),
+  categories: z.array(z.string()).optional(),
+  related: z.array(z.string()).optional(),
+  keywords: z.array(z.string()).optional(),
+});
+
+export const DocsDeleteArticleInputSchema = z.object({
+  articleId: z.string().min(1, 'Article ID is required'),
+});
+
+// Redirects
+export const DocsListRedirectsInputSchema = z.object({
+  siteId: z.string().min(1, 'Site ID is required'),
+  page: z.number().min(1).default(1),
+});
+
+export const DocsCreateRedirectInputSchema = z.object({
+  siteId: z.string().min(1, 'Site ID is required'),
+  urlMapping: z.string().min(1, 'URL mapping (old path) is required'),
+  redirect: z.string().min(1, 'Redirect destination URL is required'),
+});
+
+export const DocsUpdateRedirectInputSchema = z.object({
+  redirectId: z.string().min(1, 'Redirect ID is required'),
+  urlMapping: z.string().optional(),
+  redirect: z.string().optional(),
+});
+
+export const DocsDeleteRedirectInputSchema = z.object({
+  redirectId: z.string().min(1, 'Redirect ID is required'),
+});
+
+// ── Type Exports ───────────────────────────────────────────────────
+
+export type DocsSite = z.infer<typeof DocsSiteSchema>;
+export type DocsCollection = z.infer<typeof DocsCollectionSchema>;
+export type DocsCategory = z.infer<typeof DocsCategorySchema>;
+export type DocsArticle = z.infer<typeof DocsArticleSchema>;
+export type DocsArticleRef = z.infer<typeof DocsArticleRefSchema>;
+export type DocsRevision = z.infer<typeof DocsRevisionSchema>;
+export type DocsRedirect = z.infer<typeof DocsRedirectSchema>;

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -95,19 +95,19 @@ export const SearchConversationsInputSchema = z.object({
   createdBefore: z.string().optional(),
   limit: z.number().min(1).max(100).default(50),
   cursor: z.string().optional(),
-  sort: z.enum(['createdAt', 'updatedAt', 'number']).default('createdAt'),
+  sort: z.enum(['createdAt', 'modifiedAt', 'number']).default('createdAt'),
   order: z.enum(['asc', 'desc']).default('desc'),
   fields: z.array(z.string()).optional(),
 });
 
 export const GetThreadsInputSchema = z.object({
-  conversationId: z.string(),
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
   limit: z.number().min(1).max(200).default(200),
   cursor: z.string().optional(),
 });
 
 export const GetConversationSummaryInputSchema = z.object({
-  conversationId: z.string(),
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
 });
 
 export const AdvancedConversationSearchInputSchema = z.object({
@@ -132,7 +132,6 @@ export const MultiStatusConversationSearchInputSchema = z.object({
   createdAfter: z.string().optional(),
   createdBefore: z.string().optional(),
   limitPerStatus: z.number().min(1).max(100).default(25),
-  includeVariations: z.boolean().default(true),
 });
 
 export const StructuredConversationFilterInputSchema = z.object({
@@ -155,9 +154,128 @@ export const StructuredConversationFilterInputSchema = z.object({
   { message: 'Must use at least one unique field: assignedTo, folderId, customerIds, conversationNumber, or unique sorting. For content search, use comprehensiveConversationSearch.' }
 );
 
+// Customer API Types
+
+// Shared schema for contact sub-resources (emails, phones, chats, social profiles)
+const ContactEntrySchema = z.object({ id: z.number(), value: z.string(), type: z.string() });
+
+export const CustomerSchema = z.object({
+  id: z.number(),
+  firstName: z.string().nullable().optional(),
+  lastName: z.string().nullable().optional(),
+  gender: z.string().optional(),
+  jobTitle: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  organizationId: z.number().nullable().optional(),
+  photoType: z.string().optional(),
+  photoUrl: z.string().nullable().optional(),
+  age: z.string().nullable().optional(),
+  background: z.string().nullable().optional(),
+  conversationCount: z.number().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  draft: z.boolean().optional(),
+  _embedded: z.object({
+    emails: z.array(ContactEntrySchema).optional(),
+    phones: z.array(ContactEntrySchema).optional(),
+    chats: z.array(ContactEntrySchema).optional(),
+    social_profiles: z.array(ContactEntrySchema).optional(),
+    websites: z.array(z.object({ id: z.number(), value: z.string() })).optional(),
+    properties: z.array(z.object({
+      type: z.string().optional(),
+      slug: z.string().optional(),
+      name: z.string().optional(),
+      value: z.unknown().optional(),
+      text: z.string().nullable().optional(),
+      source: z.string().nullable().optional(),
+    })).optional(),
+  }).optional(),
+});
+
+export const CustomerAddressSchema = z.object({
+  city: z.string().optional(),
+  state: z.string().optional(),
+  postalCode: z.string().optional(),
+  country: z.string().optional(),
+  lines: z.array(z.string()).optional(),
+});
+
+export const OrganizationSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  website: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  logoUrl: z.string().nullable().optional(),
+  note: z.string().nullable().optional(),
+  domains: z.array(z.string()).optional(),
+  phones: z.array(z.string()).optional(),
+  brandColor: z.string().nullable().optional(),
+  customerCount: z.number().optional(),
+  conversationCount: z.number().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+// Customer & Organization Input Schemas
+export const GetCustomerInputSchema = z.object({
+  customerId: z.string().regex(/^\d+$/, 'Customer ID must be numeric').describe('Customer ID'),
+});
+
+export const ListCustomersInputSchema = z.object({
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  query: z.string().optional().describe('Advanced query syntax, e.g. (email:"john@example.com")'),
+  mailbox: z.coerce.number().optional().describe('Filter by inbox ID'),
+  modifiedSince: z.string().optional().describe('ISO 8601 date'),
+  sortField: z.enum(['createdAt', 'firstName', 'lastName', 'modifiedAt']).default('createdAt'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+  page: z.number().min(1).default(1),
+});
+
+export const SearchCustomersByEmailInputSchema = z.object({
+  email: z.string().describe('Email address to search for'),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  query: z.string().optional(),
+  modifiedSince: z.string().optional(),
+  createdSince: z.string().optional(),
+  cursor: z.string().optional().describe('Cursor for v3 pagination (from nextCursor in previous response)'),
+});
+
+export const GetOrganizationInputSchema = z.object({
+  organizationId: z.string().regex(/^\d+$/, 'Organization ID must be numeric').describe('Organization ID'),
+  includeCounts: z.boolean().default(true),
+  includeProperties: z.boolean().default(false),
+});
+
+export const ListOrganizationsInputSchema = z.object({
+  sortField: z.enum(['name', 'customerCount', 'conversationCount', 'lastInteractionAt']).default('lastInteractionAt'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+  page: z.number().min(1).default(1),
+});
+
+export const GetOrganizationMembersInputSchema = z.object({
+  organizationId: z.string().regex(/^\d+$/, 'Organization ID must be numeric').describe('Organization ID'),
+  page: z.number().min(1).default(1),
+});
+
+export const GetOrganizationConversationsInputSchema = z.object({
+  organizationId: z.string().regex(/^\d+$/, 'Organization ID must be numeric').describe('Organization ID'),
+  page: z.number().min(1).default(1),
+});
+
+export const GetCustomerContactsInputSchema = z.object({
+  customerId: z.string().regex(/^\d+$/, 'Customer ID must be numeric').describe('Customer ID'),
+});
+
+export const ListAllInboxesInputSchema = z.object({
+  limit: z.number().min(1).max(100).default(100),
+});
+
 // Write Operation Input Schemas
 export const CreateReplyInputSchema = z.object({
-  conversationId: z.string().min(1, 'conversationId is required'),
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
   text: z.string().min(1, 'Reply text is required'),
   customer: z.object({
     email: z.string().email('Valid customer email is required'),
@@ -168,13 +286,52 @@ export const CreateReplyInputSchema = z.object({
 });
 
 export const UpdateConversationStatusInputSchema = z.object({
-  conversationId: z.string().min(1, 'conversationId is required'),
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
   status: z.enum(['active', 'pending', 'closed']),
 });
 
 export const CreateNoteInputSchema = z.object({
-  conversationId: z.string().min(1, 'conversationId is required'),
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
   text: z.string().min(1, 'Note text is required'),
+});
+
+export const CreateConversationInputSchema = z.object({
+  subject: z.string().min(1, 'Subject is required'),
+  customer: z.object({
+    email: z.string().email('Valid customer email is required'),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+  }),
+  mailboxId: z.number().int().min(1, 'Mailbox ID is required'),
+  text: z.string().min(1, 'Message text is required'),
+  draft: z.boolean().default(true),
+  tags: z.array(z.string()).optional(),
+  assignTo: z.number().int().optional().describe('User ID to assign the conversation to'),
+});
+
+export const AssignConversationInputSchema = z.object({
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
+  assigneeId: z.number().int().min(1, 'Assignee user ID is required'),
+});
+
+export const ListUsersInputSchema = z.object({
+  page: z.number().min(1).default(1),
+  limit: z.number().min(1).max(100).default(50),
+});
+
+export const ListMailboxesInputSchema = z.object({
+  limit: z.number().min(1).max(100).default(100),
+});
+
+export const UserSchema = z.object({
+  id: z.number(),
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string(),
+  role: z.string().optional(),
+  type: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
 });
 
 // Response Types
@@ -194,14 +351,31 @@ export const ErrorSchema = z.object({
 export type Inbox = z.infer<typeof InboxSchema>;
 export type Conversation = z.infer<typeof ConversationSchema>;
 export type Thread = z.infer<typeof ThreadSchema>;
+export type Customer = z.infer<typeof CustomerSchema>;
+export type CustomerAddress = z.infer<typeof CustomerAddressSchema>;
+export type Organization = z.infer<typeof OrganizationSchema>;
+export type User = z.infer<typeof UserSchema>;
 export type SearchInboxesInput = z.infer<typeof SearchInboxesInputSchema>;
 export type SearchConversationsInput = z.infer<typeof SearchConversationsInputSchema>;
 export type GetThreadsInput = z.infer<typeof GetThreadsInputSchema>;
 export type GetConversationSummaryInput = z.infer<typeof GetConversationSummaryInputSchema>;
 export type AdvancedConversationSearchInput = z.infer<typeof AdvancedConversationSearchInputSchema>;
 export type MultiStatusConversationSearchInput = z.infer<typeof MultiStatusConversationSearchInputSchema>;
+export type GetCustomerInput = z.infer<typeof GetCustomerInputSchema>;
+export type ListCustomersInput = z.infer<typeof ListCustomersInputSchema>;
+export type SearchCustomersByEmailInput = z.infer<typeof SearchCustomersByEmailInputSchema>;
+export type GetOrganizationInput = z.infer<typeof GetOrganizationInputSchema>;
+export type ListOrganizationsInput = z.infer<typeof ListOrganizationsInputSchema>;
+export type GetOrganizationMembersInput = z.infer<typeof GetOrganizationMembersInputSchema>;
+export type GetOrganizationConversationsInput = z.infer<typeof GetOrganizationConversationsInputSchema>;
+export type GetCustomerContactsInput = z.infer<typeof GetCustomerContactsInputSchema>;
+export type ListAllInboxesInput = z.infer<typeof ListAllInboxesInputSchema>;
 export type CreateReplyInput = z.infer<typeof CreateReplyInputSchema>;
 export type UpdateConversationStatusInput = z.infer<typeof UpdateConversationStatusInputSchema>;
 export type CreateNoteInput = z.infer<typeof CreateNoteInputSchema>;
+export type CreateConversationInput = z.infer<typeof CreateConversationInputSchema>;
+export type AssignConversationInput = z.infer<typeof AssignConversationInputSchema>;
+export type ListUsersInput = z.infer<typeof ListUsersInputSchema>;
+export type ListMailboxesInput = z.infer<typeof ListMailboxesInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -155,6 +155,28 @@ export const StructuredConversationFilterInputSchema = z.object({
   { message: 'Must use at least one unique field: assignedTo, folderId, customerIds, conversationNumber, or unique sorting. For content search, use comprehensiveConversationSearch.' }
 );
 
+// Write Operation Input Schemas
+export const CreateReplyInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  text: z.string().min(1, 'Reply text is required'),
+  customer: z.object({
+    email: z.string().email('Valid customer email is required'),
+  }),
+  draft: z.boolean().default(true),
+  cc: z.array(z.string().email('Each CC entry must be a valid email')).optional(),
+  bcc: z.array(z.string().email('Each BCC entry must be a valid email')).optional(),
+});
+
+export const UpdateConversationStatusInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  status: z.enum(['active', 'pending', 'closed']),
+});
+
+export const CreateNoteInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  text: z.string().min(1, 'Note text is required'),
+});
+
 // Response Types
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
@@ -178,5 +200,8 @@ export type GetThreadsInput = z.infer<typeof GetThreadsInputSchema>;
 export type GetConversationSummaryInput = z.infer<typeof GetConversationSummaryInputSchema>;
 export type AdvancedConversationSearchInput = z.infer<typeof AdvancedConversationSearchInputSchema>;
 export type MultiStatusConversationSearchInput = z.infer<typeof MultiStatusConversationSearchInputSchema>;
+export type CreateReplyInput = z.infer<typeof CreateReplyInputSchema>;
+export type UpdateConversationStatusInput = z.infer<typeof UpdateConversationStatusInputSchema>;
+export type CreateNoteInput = z.infer<typeof CreateNoteInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -670,7 +670,7 @@ export class DocsToolHandler {
     const params: Record<string, unknown> = {};
     if (input.draft) params.draft = true;
 
-    const article = await client.getOne<DocsArticle>(`/articles/${input.articleId}`, 'article');
+    const article = await client.getOne<DocsArticle>(`/articles/${input.articleId}`, 'article', params);
     return this.jsonResult({ article });
   }
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -493,7 +493,7 @@ export class DocsToolHandler {
   private async listSites(args: Record<string, unknown>): Promise<CallToolResult> {
     const input = DocsListSitesInputSchema.parse(args);
     const client = this.getClient();
-    const data = await client.get<DocsPaginatedResponse<DocsSite>>('/sites', {
+    const data = await client.getList<DocsSite>('/sites', 'sites', {
       page: input.page,
     });
     return this.jsonResult({
@@ -520,7 +520,7 @@ export class DocsToolHandler {
     if (input.sort) params.sort = input.sort;
     if (input.order) params.order = input.order;
 
-    const data = await client.get<DocsPaginatedResponse<DocsCollection>>('/collections', params);
+    const data = await client.getList<DocsCollection>('/collections', 'collections', params);
     return this.jsonResult({
       collections: data.items,
       pagination: { page: data.page, pages: data.pages, count: data.count },
@@ -583,8 +583,8 @@ export class DocsToolHandler {
     if (input.sort) params.sort = input.sort;
     if (input.order) params.order = input.order;
 
-    const data = await client.get<DocsPaginatedResponse<DocsCategory>>(
-      `/collections/${input.collectionId}/categories`, params,
+    const data = await client.getList<DocsCategory>(
+      `/collections/${input.collectionId}/categories`, 'categories', params,
     );
     return this.jsonResult({
       categories: data.items,
@@ -657,7 +657,7 @@ export class DocsToolHandler {
       endpoint = `/collections/${input.collectionId}/articles`;
     }
 
-    const data = await client.get<DocsPaginatedResponse<DocsArticleRef>>(endpoint, params);
+    const data = await client.getList<DocsArticleRef>(endpoint, 'articles', params);
     return this.jsonResult({
       articles: data.items,
       pagination: { page: data.page, pages: data.pages, count: data.count },
@@ -686,7 +686,7 @@ export class DocsToolHandler {
     if (input.status) params.status = input.status;
     if (input.visibility) params.visibility = input.visibility;
 
-    const data = await client.get<DocsPaginatedResponse<DocsArticleRef>>('/articles/search', params);
+    const data = await client.getList<DocsArticleRef>('/search/articles', 'articles', params);
     return this.jsonResult({
       articles: data.items,
       pagination: { page: data.page, pages: data.pages, count: data.count },
@@ -697,8 +697,8 @@ export class DocsToolHandler {
   private async getRelatedArticles(args: Record<string, unknown>): Promise<CallToolResult> {
     const input = DocsGetRelatedArticlesInputSchema.parse(args);
     const client = this.getClient();
-    const data = await client.get<DocsPaginatedResponse<DocsArticleRef>>(
-      `/articles/${input.articleId}/related`, { page: input.page },
+    const data = await client.getList<DocsArticleRef>(
+      `/articles/${input.articleId}/related`, 'articles', { page: input.page },
     );
     return this.jsonResult({
       articles: data.items,
@@ -709,8 +709,8 @@ export class DocsToolHandler {
   private async listArticleRevisions(args: Record<string, unknown>): Promise<CallToolResult> {
     const input = DocsListArticleRevisionsInputSchema.parse(args);
     const client = this.getClient();
-    const data = await client.get<DocsPaginatedResponse<DocsRevision>>(
-      `/articles/${input.articleId}/revisions`, { page: input.page },
+    const data = await client.getList<DocsRevision>(
+      `/articles/${input.articleId}/revisions`, 'revisions', { page: input.page },
     );
     return this.jsonResult({
       revisions: data.items,
@@ -778,7 +778,7 @@ export class DocsToolHandler {
   private async listRedirects(args: Record<string, unknown>): Promise<CallToolResult> {
     const input = DocsListRedirectsInputSchema.parse(args);
     const client = this.getClient();
-    const data = await client.get<DocsPaginatedResponse<DocsRedirect>>('/redirects', {
+    const data = await client.getList<DocsRedirect>('/redirects', 'redirects', {
       siteId: input.siteId,
       page: input.page,
     });

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,0 +1,827 @@
+import { Tool, CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { docsClient, DocsPaginatedResponse } from '../utils/docs-client.js';
+import { createMcpToolError, isApiError } from '../utils/mcp-errors.js';
+import { logger } from '../utils/logger.js';
+import { config } from '../utils/config.js';
+import { z } from 'zod';
+import {
+  DocsArticle,
+  DocsArticleRef,
+  DocsCollection,
+  DocsCategory,
+  DocsSite,
+  DocsRevision,
+  DocsRedirect,
+  DocsListSitesInputSchema,
+  DocsGetSiteInputSchema,
+  DocsListCollectionsInputSchema,
+  DocsGetCollectionInputSchema,
+  DocsCreateCollectionInputSchema,
+  DocsUpdateCollectionInputSchema,
+  DocsDeleteCollectionInputSchema,
+  DocsListCategoriesInputSchema,
+  DocsGetCategoryInputSchema,
+  DocsCreateCategoryInputSchema,
+  DocsUpdateCategoryInputSchema,
+  DocsDeleteCategoryInputSchema,
+  DocsListArticlesInputSchema,
+  DocsGetArticleInputSchema,
+  DocsSearchArticlesInputSchema,
+  DocsGetRelatedArticlesInputSchema,
+  DocsListArticleRevisionsInputSchema,
+  DocsGetArticleRevisionInputSchema,
+  DocsCreateArticleInputSchema,
+  DocsUpdateArticleInputSchema,
+  DocsDeleteArticleInputSchema,
+  DocsListRedirectsInputSchema,
+  DocsCreateRedirectInputSchema,
+  DocsUpdateRedirectInputSchema,
+  DocsDeleteRedirectInputSchema,
+} from '../schema/docs-types.js';
+
+export class DocsToolHandler {
+  private checkWritesEnabled(): void {
+    if (!config.writes.enabled) {
+      throw {
+        code: 'UNAUTHORIZED' as const,
+        message: 'Write operations are disabled. Set HELPSCOUT_ENABLE_WRITES=true to enable.',
+        details: {},
+      };
+    }
+  }
+
+  private getClient() {
+    if (!docsClient) {
+      throw new Error('Docs API client not initialized. Set HELPSCOUT_DOCS_API_KEY.');
+    }
+    return docsClient;
+  }
+
+  private jsonResult(data: unknown): CallToolResult {
+    return {
+      content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+    };
+  }
+
+  async listTools(): Promise<Tool[]> {
+    if (!config.docs) return [];
+
+    const tools: Tool[] = [
+      // ── Sites ──
+      {
+        name: 'docs_listSites',
+        description: 'List all Docs sites in your Help Scout account.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+        },
+      },
+      {
+        name: 'docs_getSite',
+        description: 'Get details of a specific Docs site.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            siteId: { type: 'string', description: 'Site ID' },
+          },
+          required: ['siteId'],
+        },
+      },
+      // ── Collections ──
+      {
+        name: 'docs_listCollections',
+        description: 'List knowledge base collections. Optionally filter by site ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            siteId: { type: 'string', description: 'Filter by site ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            visibility: { type: 'string', enum: ['all', 'public', 'private'], description: 'Visibility filter' },
+            sort: { type: 'string', enum: ['order', 'name', 'createdAt', 'updatedAt'], description: 'Sort field' },
+            order: { type: 'string', enum: ['asc', 'desc'], description: 'Sort order' },
+          },
+        },
+      },
+      {
+        name: 'docs_getCollection',
+        description: 'Get details of a specific knowledge base collection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            collectionId: { type: 'string', description: 'Collection ID' },
+          },
+          required: ['collectionId'],
+        },
+      },
+      // ── Categories ──
+      {
+        name: 'docs_listCategories',
+        description: 'List categories within a knowledge base collection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            collectionId: { type: 'string', description: 'Collection ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            sort: { type: 'string', enum: ['order', 'name', 'createdAt', 'updatedAt'], description: 'Sort field' },
+            order: { type: 'string', enum: ['asc', 'desc'], description: 'Sort order' },
+          },
+          required: ['collectionId'],
+        },
+      },
+      {
+        name: 'docs_getCategory',
+        description: 'Get details of a specific category.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            categoryId: { type: 'string', description: 'Category ID' },
+          },
+          required: ['categoryId'],
+        },
+      },
+      // ── Articles ──
+      {
+        name: 'docs_listArticles',
+        description: 'List articles in a collection or category. Provide either collectionId or categoryId.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            collectionId: { type: 'string', description: 'List articles in this collection' },
+            categoryId: { type: 'string', description: 'List articles in this category' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            sort: { type: 'string', enum: ['order', 'name', 'createdAt', 'updatedAt', 'popularity', 'viewCount'], description: 'Sort field' },
+            order: { type: 'string', enum: ['asc', 'desc'], description: 'Sort order' },
+            status: { type: 'string', enum: ['all', 'published', 'notpublished'], description: 'Filter by status' },
+          },
+        },
+      },
+      {
+        name: 'docs_getArticle',
+        description: 'Get a knowledge base article by ID, including its full HTML content.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            articleId: { type: 'string', description: 'Article ID' },
+            draft: { type: 'boolean', description: 'If true, return the draft version' },
+          },
+          required: ['articleId'],
+        },
+      },
+      {
+        name: 'docs_searchArticles',
+        description: 'Search knowledge base articles by keyword. Optionally scope to a collection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Search query' },
+            collectionId: { type: 'string', description: 'Limit search to a collection' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            status: { type: 'string', enum: ['all', 'published', 'notpublished'], description: 'Filter by status' },
+            visibility: { type: 'string', enum: ['all', 'public', 'private'], description: 'Filter by visibility' },
+          },
+          required: ['query'],
+        },
+      },
+      {
+        name: 'docs_getRelatedArticles',
+        description: 'Get articles related to a specific article.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            articleId: { type: 'string', description: 'Article ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+          required: ['articleId'],
+        },
+      },
+      {
+        name: 'docs_listArticleRevisions',
+        description: 'List revision history for an article.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            articleId: { type: 'string', description: 'Article ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+          required: ['articleId'],
+        },
+      },
+      {
+        name: 'docs_getArticleRevision',
+        description: 'Get a specific revision of an article.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            articleId: { type: 'string', description: 'Article ID' },
+            revisionId: { type: 'string', description: 'Revision ID' },
+          },
+          required: ['articleId', 'revisionId'],
+        },
+      },
+      // ── Redirects ──
+      {
+        name: 'docs_listRedirects',
+        description: 'List URL redirects for a Docs site.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            siteId: { type: 'string', description: 'Site ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+          required: ['siteId'],
+        },
+      },
+    ];
+
+    // ── Write tools (gated behind HELPSCOUT_ENABLE_WRITES) ──
+    if (config.writes.enabled) {
+      tools.push(
+        // Collections
+        {
+          name: 'docs_createCollection',
+          description: 'Create a new knowledge base collection.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              siteId: { type: 'string', description: 'Site ID' },
+              name: { type: 'string', description: 'Collection name' },
+              visibility: { type: 'string', enum: ['public', 'private'], default: 'public', description: 'Visibility' },
+              description: { type: 'string', description: 'Collection description' },
+              order: { type: 'number', description: 'Display order' },
+            },
+            required: ['siteId', 'name'],
+          },
+        },
+        {
+          name: 'docs_updateCollection',
+          description: 'Update an existing knowledge base collection.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              collectionId: { type: 'string', description: 'Collection ID' },
+              name: { type: 'string', description: 'New name' },
+              visibility: { type: 'string', enum: ['public', 'private'], description: 'Visibility' },
+              description: { type: 'string', description: 'New description' },
+              order: { type: 'number', description: 'Display order' },
+            },
+            required: ['collectionId'],
+          },
+        },
+        {
+          name: 'docs_deleteCollection',
+          description: 'Delete a knowledge base collection. WARNING: This deletes all articles and categories within it.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              collectionId: { type: 'string', description: 'Collection ID to delete' },
+            },
+            required: ['collectionId'],
+          },
+        },
+        // Categories
+        {
+          name: 'docs_createCategory',
+          description: 'Create a new category within a collection.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              collectionId: { type: 'string', description: 'Collection ID' },
+              name: { type: 'string', description: 'Category name' },
+              description: { type: 'string', description: 'Category description' },
+              order: { type: 'number', description: 'Display order' },
+              visibility: { type: 'string', enum: ['public', 'private'], description: 'Visibility' },
+            },
+            required: ['collectionId', 'name'],
+          },
+        },
+        {
+          name: 'docs_updateCategory',
+          description: 'Update an existing category.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              categoryId: { type: 'string', description: 'Category ID' },
+              name: { type: 'string', description: 'New name' },
+              description: { type: 'string', description: 'New description' },
+              order: { type: 'number', description: 'Display order' },
+              visibility: { type: 'string', enum: ['public', 'private'], description: 'Visibility' },
+            },
+            required: ['categoryId'],
+          },
+        },
+        {
+          name: 'docs_deleteCategory',
+          description: 'Delete a category. Articles in this category are not deleted but become uncategorized.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              categoryId: { type: 'string', description: 'Category ID to delete' },
+            },
+            required: ['categoryId'],
+          },
+        },
+        // Articles
+        {
+          name: 'docs_createArticle',
+          description: 'Create a new knowledge base article. Supports HTML content.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              collectionId: { type: 'string', description: 'Collection ID' },
+              name: { type: 'string', description: 'Article title' },
+              text: { type: 'string', description: 'Article body (HTML)' },
+              slug: { type: 'string', description: 'URL slug (auto-generated if omitted)' },
+              status: { type: 'string', enum: ['published', 'notpublished'], default: 'published', description: 'Publish status' },
+              categories: { type: 'array', items: { type: 'string' }, description: 'Category IDs' },
+              related: { type: 'array', items: { type: 'string' }, description: 'Related article IDs' },
+              keywords: { type: 'array', items: { type: 'string' }, description: 'SEO keywords' },
+            },
+            required: ['collectionId', 'name', 'text'],
+          },
+        },
+        {
+          name: 'docs_updateArticle',
+          description: 'Update an existing knowledge base article.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              articleId: { type: 'string', description: 'Article ID' },
+              name: { type: 'string', description: 'New title' },
+              text: { type: 'string', description: 'New body (HTML)' },
+              slug: { type: 'string', description: 'New URL slug' },
+              status: { type: 'string', enum: ['published', 'notpublished'], description: 'Publish status' },
+              categories: { type: 'array', items: { type: 'string' }, description: 'Category IDs' },
+              related: { type: 'array', items: { type: 'string' }, description: 'Related article IDs' },
+              keywords: { type: 'array', items: { type: 'string' }, description: 'SEO keywords' },
+            },
+            required: ['articleId'],
+          },
+        },
+        {
+          name: 'docs_deleteArticle',
+          description: 'Delete a knowledge base article. This is IRREVERSIBLE.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              articleId: { type: 'string', description: 'Article ID to delete' },
+            },
+            required: ['articleId'],
+          },
+        },
+        // Redirects
+        {
+          name: 'docs_createRedirect',
+          description: 'Create a URL redirect for a Docs site.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              siteId: { type: 'string', description: 'Site ID' },
+              urlMapping: { type: 'string', description: 'Old URL path to redirect from' },
+              redirect: { type: 'string', description: 'Destination URL to redirect to' },
+            },
+            required: ['siteId', 'urlMapping', 'redirect'],
+          },
+        },
+        {
+          name: 'docs_updateRedirect',
+          description: 'Update an existing URL redirect.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              redirectId: { type: 'string', description: 'Redirect ID' },
+              urlMapping: { type: 'string', description: 'New old URL path' },
+              redirect: { type: 'string', description: 'New destination URL' },
+            },
+            required: ['redirectId'],
+          },
+        },
+        {
+          name: 'docs_deleteRedirect',
+          description: 'Delete a URL redirect.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              redirectId: { type: 'string', description: 'Redirect ID to delete' },
+            },
+            required: ['redirectId'],
+          },
+        },
+      );
+    }
+
+    return tools;
+  }
+
+  async callTool(request: CallToolRequest): Promise<CallToolResult> {
+    const startTime = Date.now();
+    const requestId = Math.random().toString(36).substring(7);
+    const args = request.params.arguments || {};
+
+    try {
+      switch (request.params.name) {
+        // Sites
+        case 'docs_listSites':
+          return await this.listSites(args);
+        case 'docs_getSite':
+          return await this.getSite(args);
+        // Collections
+        case 'docs_listCollections':
+          return await this.listCollections(args);
+        case 'docs_getCollection':
+          return await this.getCollection(args);
+        case 'docs_createCollection':
+          return await this.createCollection(args);
+        case 'docs_updateCollection':
+          return await this.updateCollection(args);
+        case 'docs_deleteCollection':
+          return await this.deleteCollection(args);
+        // Categories
+        case 'docs_listCategories':
+          return await this.listCategories(args);
+        case 'docs_getCategory':
+          return await this.getCategory(args);
+        case 'docs_createCategory':
+          return await this.createCategory(args);
+        case 'docs_updateCategory':
+          return await this.updateCategory(args);
+        case 'docs_deleteCategory':
+          return await this.deleteCategory(args);
+        // Articles
+        case 'docs_listArticles':
+          return await this.listArticles(args);
+        case 'docs_getArticle':
+          return await this.getArticle(args);
+        case 'docs_searchArticles':
+          return await this.searchArticles(args);
+        case 'docs_getRelatedArticles':
+          return await this.getRelatedArticles(args);
+        case 'docs_listArticleRevisions':
+          return await this.listArticleRevisions(args);
+        case 'docs_getArticleRevision':
+          return await this.getArticleRevision(args);
+        case 'docs_createArticle':
+          return await this.createArticle(args);
+        case 'docs_updateArticle':
+          return await this.updateArticle(args);
+        case 'docs_deleteArticle':
+          return await this.deleteArticle(args);
+        // Redirects
+        case 'docs_listRedirects':
+          return await this.listRedirects(args);
+        case 'docs_createRedirect':
+          return await this.createRedirect(args);
+        case 'docs_updateRedirect':
+          return await this.updateRedirect(args);
+        case 'docs_deleteRedirect':
+          return await this.deleteRedirect(args);
+        default:
+          throw new Error(`Unknown docs tool: ${request.params.name}`);
+      }
+    } catch (error) {
+      return createMcpToolError(error, {
+        toolName: request.params.name,
+        requestId,
+        duration: Date.now() - startTime,
+      });
+    }
+  }
+
+  // ── Site Handlers ──
+
+  private async listSites(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsListSitesInputSchema.parse(args);
+    const client = this.getClient();
+    const data = await client.get<DocsPaginatedResponse<DocsSite>>('/sites', {
+      page: input.page,
+    });
+    return this.jsonResult({
+      sites: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async getSite(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsGetSiteInputSchema.parse(args);
+    const client = this.getClient();
+    const site = await client.getOne<DocsSite>(`/sites/${input.siteId}`, 'site');
+    return this.jsonResult({ site });
+  }
+
+  // ── Collection Handlers ──
+
+  private async listCollections(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsListCollectionsInputSchema.parse(args);
+    const client = this.getClient();
+    const params: Record<string, unknown> = { page: input.page };
+    if (input.siteId) params.siteId = input.siteId;
+    if (input.visibility) params.visibility = input.visibility;
+    if (input.sort) params.sort = input.sort;
+    if (input.order) params.order = input.order;
+
+    const data = await client.get<DocsPaginatedResponse<DocsCollection>>('/collections', params);
+    return this.jsonResult({
+      collections: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async getCollection(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsGetCollectionInputSchema.parse(args);
+    const client = this.getClient();
+    const collection = await client.getOne<DocsCollection>(`/collections/${input.collectionId}`, 'collection');
+    return this.jsonResult({ collection });
+  }
+
+  private async createCollection(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsCreateCollectionInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {
+      siteId: input.siteId,
+      name: input.name,
+      visibility: input.visibility,
+    };
+    if (input.description) body.description = input.description;
+    if (input.order !== undefined) body.order = input.order;
+
+    const result = await client.post<{ collection: DocsCollection }>('/collections', body);
+    return this.jsonResult({ collection: result.collection || result, message: 'Collection created successfully' });
+  }
+
+  private async updateCollection(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsUpdateCollectionInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {};
+    if (input.name) body.name = input.name;
+    if (input.visibility) body.visibility = input.visibility;
+    if (input.description !== undefined) body.description = input.description;
+    if (input.order !== undefined) body.order = input.order;
+
+    await client.put(`/collections/${input.collectionId}`, body);
+    return this.jsonResult({ message: 'Collection updated successfully' });
+  }
+
+  private async deleteCollection(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsDeleteCollectionInputSchema.parse(args);
+    const client = this.getClient();
+    await client.delete(`/collections/${input.collectionId}`);
+    return this.jsonResult({ message: 'Collection deleted successfully' });
+  }
+
+  // ── Category Handlers ──
+
+  private async listCategories(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsListCategoriesInputSchema.parse(args);
+    const client = this.getClient();
+    const params: Record<string, unknown> = { page: input.page };
+    if (input.sort) params.sort = input.sort;
+    if (input.order) params.order = input.order;
+
+    const data = await client.get<DocsPaginatedResponse<DocsCategory>>(
+      `/collections/${input.collectionId}/categories`, params,
+    );
+    return this.jsonResult({
+      categories: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async getCategory(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsGetCategoryInputSchema.parse(args);
+    const client = this.getClient();
+    const category = await client.getOne<DocsCategory>(`/categories/${input.categoryId}`, 'category');
+    return this.jsonResult({ category });
+  }
+
+  private async createCategory(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsCreateCategoryInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {
+      collectionId: input.collectionId,
+      name: input.name,
+    };
+    if (input.description) body.description = input.description;
+    if (input.order !== undefined) body.order = input.order;
+    if (input.visibility) body.visibility = input.visibility;
+
+    const result = await client.post<{ category: DocsCategory }>('/categories', body);
+    return this.jsonResult({ category: result.category || result, message: 'Category created successfully' });
+  }
+
+  private async updateCategory(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsUpdateCategoryInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {};
+    if (input.name) body.name = input.name;
+    if (input.description !== undefined) body.description = input.description;
+    if (input.order !== undefined) body.order = input.order;
+    if (input.visibility) body.visibility = input.visibility;
+
+    await client.put(`/categories/${input.categoryId}`, body);
+    return this.jsonResult({ message: 'Category updated successfully' });
+  }
+
+  private async deleteCategory(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsDeleteCategoryInputSchema.parse(args);
+    const client = this.getClient();
+    await client.delete(`/categories/${input.categoryId}`);
+    return this.jsonResult({ message: 'Category deleted successfully' });
+  }
+
+  // ── Article Handlers ──
+
+  private async listArticles(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsListArticlesInputSchema.parse(args);
+    const client = this.getClient();
+
+    const params: Record<string, unknown> = { page: input.page };
+    if (input.sort) params.sort = input.sort;
+    if (input.order) params.order = input.order;
+    if (input.status) params.status = input.status;
+
+    let endpoint: string;
+    if (input.categoryId) {
+      endpoint = `/categories/${input.categoryId}/articles`;
+    } else {
+      endpoint = `/collections/${input.collectionId}/articles`;
+    }
+
+    const data = await client.get<DocsPaginatedResponse<DocsArticleRef>>(endpoint, params);
+    return this.jsonResult({
+      articles: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async getArticle(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsGetArticleInputSchema.parse(args);
+    const client = this.getClient();
+    const params: Record<string, unknown> = {};
+    if (input.draft) params.draft = true;
+
+    const article = await client.getOne<DocsArticle>(`/articles/${input.articleId}`, 'article');
+    return this.jsonResult({ article });
+  }
+
+  private async searchArticles(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsSearchArticlesInputSchema.parse(args);
+    const client = this.getClient();
+
+    const params: Record<string, unknown> = {
+      query: input.query,
+      page: input.page,
+    };
+    if (input.collectionId) params.collectionId = input.collectionId;
+    if (input.status) params.status = input.status;
+    if (input.visibility) params.visibility = input.visibility;
+
+    const data = await client.get<DocsPaginatedResponse<DocsArticleRef>>('/articles/search', params);
+    return this.jsonResult({
+      articles: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+      query: input.query,
+    });
+  }
+
+  private async getRelatedArticles(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsGetRelatedArticlesInputSchema.parse(args);
+    const client = this.getClient();
+    const data = await client.get<DocsPaginatedResponse<DocsArticleRef>>(
+      `/articles/${input.articleId}/related`, { page: input.page },
+    );
+    return this.jsonResult({
+      articles: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async listArticleRevisions(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsListArticleRevisionsInputSchema.parse(args);
+    const client = this.getClient();
+    const data = await client.get<DocsPaginatedResponse<DocsRevision>>(
+      `/articles/${input.articleId}/revisions`, { page: input.page },
+    );
+    return this.jsonResult({
+      revisions: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async getArticleRevision(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsGetArticleRevisionInputSchema.parse(args);
+    const client = this.getClient();
+    const revision = await client.getOne<DocsRevision>(
+      `/articles/${input.articleId}/revisions/${input.revisionId}`, 'revision',
+    );
+    return this.jsonResult({ revision });
+  }
+
+  private async createArticle(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsCreateArticleInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {
+      collectionId: input.collectionId,
+      name: input.name,
+      text: input.text,
+      status: input.status,
+    };
+    if (input.slug) body.slug = input.slug;
+    if (input.categories) body.categories = input.categories;
+    if (input.related) body.related = input.related;
+    if (input.keywords) body.keywords = input.keywords;
+
+    const result = await client.post<{ article: DocsArticle }>('/articles', body);
+    return this.jsonResult({ article: result.article || result, message: 'Article created successfully' });
+  }
+
+  private async updateArticle(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsUpdateArticleInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {};
+    if (input.name) body.name = input.name;
+    if (input.text) body.text = input.text;
+    if (input.slug) body.slug = input.slug;
+    if (input.status) body.status = input.status;
+    if (input.categories) body.categories = input.categories;
+    if (input.related) body.related = input.related;
+    if (input.keywords) body.keywords = input.keywords;
+
+    await client.put(`/articles/${input.articleId}`, body);
+    return this.jsonResult({ message: 'Article updated successfully' });
+  }
+
+  private async deleteArticle(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsDeleteArticleInputSchema.parse(args);
+    const client = this.getClient();
+    await client.delete(`/articles/${input.articleId}`);
+    return this.jsonResult({ message: 'Article deleted successfully' });
+  }
+
+  // ── Redirect Handlers ──
+
+  private async listRedirects(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = DocsListRedirectsInputSchema.parse(args);
+    const client = this.getClient();
+    const data = await client.get<DocsPaginatedResponse<DocsRedirect>>('/redirects', {
+      siteId: input.siteId,
+      page: input.page,
+    });
+    return this.jsonResult({
+      redirects: data.items,
+      pagination: { page: data.page, pages: data.pages, count: data.count },
+    });
+  }
+
+  private async createRedirect(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsCreateRedirectInputSchema.parse(args);
+    const client = this.getClient();
+
+    const result = await client.post<{ redirect: DocsRedirect }>('/redirects', {
+      siteId: input.siteId,
+      urlMapping: input.urlMapping,
+      redirect: input.redirect,
+    });
+    return this.jsonResult({ redirect: result.redirect || result, message: 'Redirect created successfully' });
+  }
+
+  private async updateRedirect(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsUpdateRedirectInputSchema.parse(args);
+    const client = this.getClient();
+
+    const body: Record<string, unknown> = {};
+    if (input.urlMapping) body.urlMapping = input.urlMapping;
+    if (input.redirect) body.redirect = input.redirect;
+
+    await client.put(`/redirects/${input.redirectId}`, body);
+    return this.jsonResult({ message: 'Redirect updated successfully' });
+  }
+
+  private async deleteRedirect(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+    const input = DocsDeleteRedirectInputSchema.parse(args);
+    const client = this.getClient();
+    await client.delete(`/redirects/${input.redirectId}`);
+    return this.jsonResult({ message: 'Redirect deleted successfully' });
+  }
+}
+
+// Export singleton — only when Docs API is configured
+export const docsToolHandler = config.docs ? new DocsToolHandler() : null;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -55,6 +55,9 @@ import {
   AdvancedConversationSearchInputSchema,
   MultiStatusConversationSearchInputSchema,
   StructuredConversationFilterInputSchema,
+  CreateReplyInputSchema,
+  UpdateConversationStatusInputSchema,
+  CreateNoteInputSchema,
 } from '../schema/types.js';
 
 export class ToolHandler {
@@ -408,6 +411,87 @@ export class ToolHandler {
           },
         },
       },
+      // Write tools (require HELPSCOUT_ENABLE_WRITES=true)
+      ...(config.writes.enabled ? [
+        {
+          name: 'createReply',
+          description: 'Send a reply on an existing conversation. IMPORTANT: Defaults to draft mode (draft=true) so a human can review before sending. Set draft=false to send immediately — this sends a real email to the customer and CANNOT be undone. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to reply to',
+              },
+              text: {
+                type: 'string',
+                description: 'The reply body text (HTML supported)',
+              },
+              customer: {
+                type: 'object',
+                description: 'Customer object with email address',
+                properties: {
+                  email: { type: 'string', description: 'Customer email address' },
+                },
+                required: ['email'],
+              },
+              draft: {
+                type: 'boolean',
+                description: 'Create as draft for human review (default: true). Set to false to send immediately — THIS SENDS A REAL EMAIL.',
+                default: true,
+              },
+              cc: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'CC email addresses',
+              },
+              bcc: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'BCC email addresses',
+              },
+            },
+            required: ['conversationId', 'text', 'customer'],
+          },
+        },
+        {
+          name: 'updateConversationStatus',
+          description: 'Update a conversation\'s status to active, pending, or closed. WARNING: Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to update',
+              },
+              status: {
+                type: 'string',
+                enum: ['active', 'pending', 'closed'],
+                description: 'New status for the conversation',
+              },
+            },
+            required: ['conversationId', 'status'],
+          },
+        },
+        {
+          name: 'createNote',
+          description: 'Add an internal note to a conversation. Notes are only visible to support agents and are NOT sent to the customer. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to add a note to',
+              },
+              text: {
+                type: 'string',
+                description: 'The note text (HTML supported)',
+              },
+            },
+            required: ['conversationId', 'text'],
+          },
+        },
+      ] : []),
     ];
   }
 
@@ -491,6 +575,15 @@ export class ToolHandler {
           break;
         case 'structuredConversationFilter':
           result = await this.structuredConversationFilter(request.params.arguments || {});
+          break;
+        case 'createReply':
+          result = await this.createReply(request.params.arguments || {});
+          break;
+        case 'updateConversationStatus':
+          result = await this.updateConversationStatus(request.params.arguments || {});
+          break;
+        case 'createNote':
+          result = await this.createNote(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -1433,6 +1526,126 @@ export class ToolHandler {
           nextCursor: response._links?.next?.href,
           clientSideFiltering: clientSideFiltered ? `createdBefore filter removed ${originalCount - conversations.length} of ${originalCount} results` : undefined,
           note: 'Structural filtering applied. For content-based search or rep activity, use comprehensiveConversationSearch.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // --- Write Operations ---
+
+  private checkWritesEnabled(): void {
+    // Check env var directly to support runtime toggling (e.g., in tests)
+    if (process.env.HELPSCOUT_ENABLE_WRITES !== 'true') {
+      throw new Error(
+        'Write operations are disabled. Set HELPSCOUT_ENABLE_WRITES=true to enable reply, note, and status update tools.'
+      );
+    }
+  }
+
+  private async createReply(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateReplyInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating reply', {
+      conversationId,
+      draft: input.draft,
+      hasCC: !!(input.cc && input.cc.length > 0),
+      hasBCC: !!(input.bcc && input.bcc.length > 0),
+      // Never log the text content for PII safety
+    });
+
+    const requestBody: Record<string, unknown> = {
+      customer: { email: input.customer.email },
+      text: input.text,
+      draft: input.draft,
+    };
+
+    if (input.cc && input.cc.length > 0) {
+      requestBody.cc = input.cc;
+    }
+    if (input.bcc && input.bcc.length > 0) {
+      requestBody.bcc = input.bcc;
+    }
+
+    await helpScoutClient.post(`/conversations/${conversationId}/reply`, requestBody);
+
+    const mode = input.draft ? 'draft' : 'sent';
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'reply_created',
+          mode,
+          message: input.draft
+            ? `Draft reply created on conversation ${conversationId}. A human must review and send it from the Help Scout UI.`
+            : `Reply sent on conversation ${conversationId}. The email has been delivered to the customer.`,
+          warning: input.draft ? undefined : 'This reply has been sent to the customer and cannot be undone.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async updateConversationStatus(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = UpdateConversationStatusInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Updating conversation status', {
+      conversationId,
+      newStatus: input.status,
+    });
+
+    // Help Scout uses JSON Patch format for updates
+    await helpScoutClient.patch(`/conversations/${conversationId}`, {
+      op: 'replace',
+      path: '/status',
+      value: input.status,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'status_updated',
+          newStatus: input.status,
+          message: `Conversation ${conversationId} status updated to "${input.status}".`,
+          warning: input.status === 'closed' ? 'Closing a conversation may trigger automations such as satisfaction surveys.' : undefined,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async createNote(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateNoteInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating note', {
+      conversationId,
+      // Never log the text content for PII safety
+    });
+
+    await helpScoutClient.post(`/conversations/${conversationId}/notes`, {
+      text: input.text,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'note_created',
+          message: `Internal note added to conversation ${conversationId}. This note is only visible to support agents.`,
         }, null, 2),
       }],
     };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,7 +4,40 @@ import { createMcpToolError, isApiError } from '../utils/mcp-errors.js';
 import { HelpScoutAPIConstraints, ToolCallContext } from '../utils/api-constraints.js';
 import { logger } from '../utils/logger.js';
 import { config } from '../utils/config.js';
+import { PII_REDACTED_BODY } from '../utils/constants.js';
 import { z } from 'zod';
+import {
+  Inbox,
+  Conversation,
+  Thread,
+  Customer,
+  CustomerAddress,
+  Organization,
+  ServerTime,
+  SearchInboxesInputSchema,
+  SearchConversationsInputSchema,
+  GetThreadsInputSchema,
+  GetConversationSummaryInputSchema,
+  AdvancedConversationSearchInputSchema,
+  MultiStatusConversationSearchInputSchema,
+  StructuredConversationFilterInputSchema,
+  GetCustomerInputSchema,
+  ListCustomersInputSchema,
+  SearchCustomersByEmailInputSchema,
+  GetCustomerContactsInputSchema,
+  ListAllInboxesInputSchema,
+  GetOrganizationInputSchema,
+  ListOrganizationsInputSchema,
+  GetOrganizationMembersInputSchema,
+  GetOrganizationConversationsInputSchema,
+  CreateReplyInputSchema,
+  UpdateConversationStatusInputSchema,
+  CreateNoteInputSchema,
+  CreateConversationInputSchema,
+  AssignConversationInputSchema,
+  ListUsersInputSchema,
+  ListMailboxesInputSchema,
+} from '../schema/types.js';
 
 /**
  * Constants for tool operations
@@ -15,26 +48,26 @@ const TOOL_CONSTANTS = {
   MAX_PAGE_SIZE: 100,
   MAX_THREAD_SIZE: 200,
   DEFAULT_THREAD_SIZE: 200,
-  
+
   // Search limits
   MAX_SEARCH_TERMS: 10,
   DEFAULT_TIMEFRAME_DAYS: 60,
   DEFAULT_LIMIT_PER_STATUS: 25,
-  
+
   // Sort configuration
   DEFAULT_SORT_FIELD: 'createdAt',
   DEFAULT_SORT_ORDER: 'desc',
-  
+
   // Cache and performance
   MAX_CONVERSATION_ID_LENGTH: 20,
-  
+
   // Search locations
   SEARCH_LOCATIONS: {
     BODY: 'body',
-    SUBJECT: 'subject', 
+    SUBJECT: 'subject',
     BOTH: 'both'
   } as const,
-  
+
   // Conversation statuses
   STATUSES: {
     ACTIVE: 'active',
@@ -43,22 +76,6 @@ const TOOL_CONSTANTS = {
     SPAM: 'spam'
   } as const
 } as const;
-import {
-  Inbox,
-  Conversation,
-  Thread,
-  ServerTime,
-  SearchInboxesInputSchema,
-  SearchConversationsInputSchema,
-  GetThreadsInputSchema,
-  GetConversationSummaryInputSchema,
-  AdvancedConversationSearchInputSchema,
-  MultiStatusConversationSearchInputSchema,
-  StructuredConversationFilterInputSchema,
-  CreateReplyInputSchema,
-  UpdateConversationStatusInputSchema,
-  CreateNoteInputSchema,
-} from '../schema/types.js';
 
 export class ToolHandler {
   private callHistory: string[] = [];
@@ -90,7 +107,7 @@ export class ToolHandler {
     if (!createdAfter && !createdBefore) return existingQuery;
 
     // Validate date format to prevent query injection and match Help Scout expectations
-    const isoDatePattern = /^\d{4}-\d{2}-\d{2}(T[\d:.]+Z?)?$/;
+    const isoDatePattern = /^\d{4}-\d{2}-\d{2}(T[\d:.]+([+-]\d{2}:\d{2}|Z)?)?$/;
     if (createdAfter && !isoDatePattern.test(createdAfter)) {
       throw new Error(`Invalid createdAfter date format: ${createdAfter}. Expected ISO 8601 (e.g., 2024-01-15T00:00:00Z)`);
     }
@@ -99,7 +116,7 @@ export class ToolHandler {
     }
 
     // Strip milliseconds (Help Scout rejects .xxx format)
-    const normalize = (d: string) => d.replace(/\.\d{3}Z$/, 'Z');
+    const normalize = (d: string) => d.replace(/\.\d{3}(Z|[+-]\d{2}:\d{2})$/, '$1');
     const start = createdAfter ? normalize(createdAfter) : '*';
     const end = createdBefore ? normalize(createdBefore) : '*';
     const clause = `(createdAt:[${start} TO ${end}])`;
@@ -116,7 +133,7 @@ export class ToolHandler {
   }
 
   async listTools(): Promise<Tool[]> {
-    return [
+    const tools: Tool[] = [
       {
         name: 'searchInboxes',
         description: 'List or search inboxes by name. Deprecated: inbox IDs now in server instructions. Only needed to refresh list mid-session.',
@@ -188,7 +205,7 @@ export class ToolHandler {
             },
             sort: {
               type: 'string',
-              enum: ['createdAt', 'updatedAt', 'number'],
+              enum: ['createdAt', 'modifiedAt', 'number'],
               default: TOOL_CONSTANTS.DEFAULT_SORT_FIELD,
               description: 'Sort field',
             },
@@ -379,11 +396,6 @@ export class ToolHandler {
               maximum: TOOL_CONSTANTS.MAX_PAGE_SIZE,
               default: TOOL_CONSTANTS.DEFAULT_LIMIT_PER_STATUS,
             },
-            includeVariations: {
-              type: 'boolean',
-              description: 'Include common variations of search terms',
-              default: true,
-            },
           },
           required: ['searchTerms'],
         },
@@ -411,88 +423,233 @@ export class ToolHandler {
           },
         },
       },
-      // Write tools (require HELPSCOUT_ENABLE_WRITES=true)
-      ...(config.writes.enabled ? [
+      // Customer tools (NAS-680, NAS-727, NAS-728)
+      {
+        name: 'getCustomer',
+        description: 'Get a customer profile by ID. Returns profile with contact details (emails, phones, chat handles, social profiles, websites) plus address from a separate lookup.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            customerId: {
+              type: 'string',
+              description: 'Customer ID',
+            },
+          },
+          required: ['customerId'],
+        },
+      },
+      {
+        name: 'listCustomers',
+        description: 'List or search customers by name, query syntax, or modification date. Page-based pagination (v2 API).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string', description: 'Filter by first name' },
+            lastName: { type: 'string', description: 'Filter by last name' },
+            query: { type: 'string', description: 'Advanced query syntax, e.g. (email:"john@example.com")' },
+            mailbox: { type: 'number', description: 'Filter by inbox ID' },
+            modifiedSince: { type: 'string', description: 'ISO 8601 date - only customers modified after this date' },
+            sortField: { type: 'string', enum: ['createdAt', 'firstName', 'lastName', 'modifiedAt'], default: 'createdAt' },
+            sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number (API returns 50 results per page)' },
+          },
+        },
+      },
+      {
+        name: 'searchCustomersByEmail',
+        description: 'Search customers by email address using the v3 API. Provides email as a dedicated filter parameter (vs query syntax in v2) and cursor-based pagination.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', description: 'Email address to search for' },
+            firstName: { type: 'string', description: 'Filter by first name' },
+            lastName: { type: 'string', description: 'Filter by last name' },
+            query: { type: 'string', description: 'Advanced query syntax' },
+            modifiedSince: { type: 'string', description: 'ISO 8601 date' },
+            createdSince: { type: 'string', description: 'ISO 8601 date - only in v3' },
+            cursor: { type: 'string', description: 'Cursor for pagination (from nextCursor in previous response)' },
+          },
+          required: ['email'],
+        },
+      },
+      // NAS-727: Customer sub-resource tools
+      {
+        name: 'getCustomerContacts',
+        description: 'Get all contact details for a customer: emails, phones, chat handles, social profiles, websites, and address. Calls dedicated sub-resource endpoints for complete data. Use after getCustomer or listCustomers.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            customerId: {
+              type: 'string',
+              description: 'Customer ID',
+            },
+          },
+          required: ['customerId'],
+        },
+      },
+      // Organization tools (NAS-684, NAS-712)
+      {
+        name: 'getOrganization',
+        description: 'Get an organization by ID with optional customer/conversation counts.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            organizationId: { type: 'string', description: 'Organization ID' },
+            includeCounts: { type: 'boolean', default: true, description: 'Include customerCount and conversationCount' },
+            includeProperties: { type: 'boolean', default: false, description: 'Include organization property values' },
+          },
+          required: ['organizationId'],
+        },
+      },
+      {
+        name: 'listOrganizations',
+        description: 'List all organizations with sorting options. Use for discovering organizations before drilling into members or conversations. Returns 50 per page.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            sortField: { type: 'string', enum: ['name', 'customerCount', 'conversationCount', 'lastInteractionAt'], default: 'lastInteractionAt' },
+            sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number (50 results per page)' },
+          },
+        },
+      },
+      {
+        name: 'getOrganizationMembers',
+        description: 'Get all customers belonging to an organization. Use after getOrganization to see who is in the org. Returns 50 per page.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            organizationId: { type: 'string', description: 'Organization ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number (50 results per page)' },
+          },
+          required: ['organizationId'],
+        },
+      },
+      {
+        name: 'getOrganizationConversations',
+        description: 'Get all conversations associated with an organization. Traverses org-to-conversations without needing individual customer lookups. Returns 50 per page.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            organizationId: { type: 'string', description: 'Organization ID' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number (50 results per page)' },
+          },
+          required: ['organizationId'],
+        },
+      },
+    ];
+
+    // Conditionally add write tools when HELPSCOUT_ENABLE_WRITES=true
+    if (process.env.HELPSCOUT_ENABLE_WRITES === 'true') {
+      tools.push(
         {
           name: 'createReply',
-          description: 'Send a reply on an existing conversation. IMPORTANT: Defaults to draft mode (draft=true) so a human can review before sending. Set draft=false to send immediately — this sends a real email to the customer and CANNOT be undone. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          description: 'Create a reply on a conversation. Defaults to draft mode (draft: true) so a human must review and send from the Help Scout UI. Set draft: false to send immediately (IRREVERSIBLE).',
           inputSchema: {
-            type: 'object' as const,
+            type: 'object',
             properties: {
-              conversationId: {
-                type: 'string',
-                description: 'The conversation ID to reply to',
-              },
-              text: {
-                type: 'string',
-                description: 'The reply body text (HTML supported)',
-              },
+              conversationId: { type: 'string', description: 'Conversation ID to reply to' },
+              text: { type: 'string', description: 'Reply text (HTML supported)' },
               customer: {
                 type: 'object',
-                description: 'Customer object with email address',
                 properties: {
                   email: { type: 'string', description: 'Customer email address' },
                 },
                 required: ['email'],
               },
-              draft: {
-                type: 'boolean',
-                description: 'Create as draft for human review (default: true). Set to false to send immediately — THIS SENDS A REAL EMAIL.',
-                default: true,
-              },
-              cc: {
-                type: 'array',
-                items: { type: 'string' },
-                description: 'CC email addresses',
-              },
-              bcc: {
-                type: 'array',
-                items: { type: 'string' },
-                description: 'BCC email addresses',
-              },
+              draft: { type: 'boolean', description: 'If true (default), creates an unsent draft. If false, sends the reply immediately.', default: true },
+              cc: { type: 'array', items: { type: 'string' }, description: 'CC email addresses' },
+              bcc: { type: 'array', items: { type: 'string' }, description: 'BCC email addresses' },
             },
             required: ['conversationId', 'text', 'customer'],
           },
         },
         {
-          name: 'updateConversationStatus',
-          description: 'Update a conversation\'s status to active, pending, or closed. WARNING: Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          name: 'createNote',
+          description: 'Add an internal note to a conversation. Notes are only visible to support agents, never to customers.',
           inputSchema: {
-            type: 'object' as const,
+            type: 'object',
             properties: {
-              conversationId: {
-                type: 'string',
-                description: 'The conversation ID to update',
-              },
-              status: {
-                type: 'string',
-                enum: ['active', 'pending', 'closed'],
-                description: 'New status for the conversation',
-              },
+              conversationId: { type: 'string', description: 'Conversation ID' },
+              text: { type: 'string', description: 'Note text (HTML supported)' },
+            },
+            required: ['conversationId', 'text'],
+          },
+        },
+        {
+          name: 'updateConversationStatus',
+          description: 'Change the status of a conversation. WARNING: Closing a conversation may trigger Help Scout automations (e.g., satisfaction surveys).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              conversationId: { type: 'string', description: 'Conversation ID' },
+              status: { type: 'string', enum: ['active', 'pending', 'closed'], description: 'New status' },
             },
             required: ['conversationId', 'status'],
           },
         },
         {
-          name: 'createNote',
-          description: 'Add an internal note to a conversation. Notes are only visible to support agents and are NOT sent to the customer. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          name: 'createConversation',
+          description: 'Create a new conversation (ticket). Defaults to draft mode. Requires a mailbox ID (use listMailboxes to find IDs).',
           inputSchema: {
-            type: 'object' as const,
+            type: 'object',
             properties: {
-              conversationId: {
-                type: 'string',
-                description: 'The conversation ID to add a note to',
+              subject: { type: 'string', description: 'Conversation subject' },
+              customer: {
+                type: 'object',
+                properties: {
+                  email: { type: 'string', description: 'Customer email address' },
+                  firstName: { type: 'string', description: 'Customer first name' },
+                  lastName: { type: 'string', description: 'Customer last name' },
+                },
+                required: ['email'],
               },
-              text: {
-                type: 'string',
-                description: 'The note text (HTML supported)',
-              },
+              mailboxId: { type: 'number', description: 'Mailbox ID (use listMailboxes to find)' },
+              text: { type: 'string', description: 'Initial message text (HTML supported)' },
+              draft: { type: 'boolean', description: 'If true (default), creates as draft. If false, sends immediately.', default: true },
+              tags: { type: 'array', items: { type: 'string' }, description: 'Tag names to apply' },
+              assignTo: { type: 'number', description: 'User ID to assign to (use listUsers to find)' },
             },
-            required: ['conversationId', 'text'],
+            required: ['subject', 'customer', 'mailboxId', 'text'],
           },
         },
-      ] : []),
-    ];
+        {
+          name: 'assignConversation',
+          description: 'Assign a conversation to a team member. Use listUsers to find user IDs.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              conversationId: { type: 'string', description: 'Conversation ID' },
+              assigneeId: { type: 'number', description: 'User ID to assign to (use listUsers to find)' },
+            },
+            required: ['conversationId', 'assigneeId'],
+          },
+        },
+        {
+          name: 'listUsers',
+          description: 'List Help Scout users (team members). Use to find user IDs for assignConversation.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+              limit: { type: 'number', minimum: 1, maximum: 100, default: 50, description: 'Results per page' },
+            },
+          },
+        },
+        {
+          name: 'listMailboxes',
+          description: 'List all mailboxes with IDs. Use to find mailbox IDs for createConversation.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              limit: { type: 'number', minimum: 1, maximum: 100, default: 100, description: 'Maximum results' },
+            },
+          },
+        },
+      );
+    }
+
+    return tools;
   }
 
   async callTool(request: CallToolRequest): Promise<CallToolResult> {
@@ -528,7 +685,7 @@ export class ToolHandler {
         validation: errorDetails
       });
       
-      // Return helpful error with API constraint guidance
+      // Return helpful error with API constraint guidance (NAS-472: isError per MCP spec)
       return {
         content: [{
           type: 'text',
@@ -541,7 +698,8 @@ export class ToolHandler {
               suggestions: validation.suggestions
             }
           }, null, 2)
-        }]
+        }],
+        isError: true,
       };
     }
 
@@ -576,14 +734,51 @@ export class ToolHandler {
         case 'structuredConversationFilter':
           result = await this.structuredConversationFilter(request.params.arguments || {});
           break;
+        case 'getCustomer':
+          result = await this.getCustomer(request.params.arguments || {});
+          break;
+        case 'listCustomers':
+          result = await this.listCustomers(request.params.arguments || {});
+          break;
+        case 'searchCustomersByEmail':
+          result = await this.searchCustomersByEmail(request.params.arguments || {});
+          break;
+        case 'getCustomerContacts':
+          result = await this.getCustomerContacts(request.params.arguments || {});
+          break;
+        case 'getOrganization':
+          result = await this.getOrganization(request.params.arguments || {});
+          break;
+        case 'listOrganizations':
+          result = await this.listOrganizations(request.params.arguments || {});
+          break;
+        case 'getOrganizationMembers':
+          result = await this.getOrganizationMembers(request.params.arguments || {});
+          break;
+        case 'getOrganizationConversations':
+          result = await this.getOrganizationConversations(request.params.arguments || {});
+          break;
+        // Write tools
         case 'createReply':
           result = await this.createReply(request.params.arguments || {});
+          break;
+        case 'createNote':
+          result = await this.createNote(request.params.arguments || {});
           break;
         case 'updateConversationStatus':
           result = await this.updateConversationStatus(request.params.arguments || {});
           break;
-        case 'createNote':
-          result = await this.createNote(request.params.arguments || {});
+        case 'createConversation':
+          result = await this.createConversation(request.params.arguments || {});
+          break;
+        case 'assignConversation':
+          result = await this.assignConversation(request.params.arguments || {});
+          break;
+        case 'listUsers':
+          result = await this.listUsers(request.params.arguments || {});
+          break;
+        case 'listMailboxes':
+          result = await this.listMailboxes(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -593,20 +788,30 @@ export class ToolHandler {
       // Add to call history for future validation
       this.callHistory.push(request.params.name);
       
-      // Enhance result with API constraint guidance
-      const guidance = HelpScoutAPIConstraints.generateToolGuidance(
-        request.params.name, 
-        JSON.parse((result.content[0] as any).text), 
-        validationContext
-      );
-      
-      if (guidance.length > 0) {
+      // Enhance result with API constraint guidance (best-effort: never turn a success into a failure)
+      let guidanceProvided = false;
+      try {
         const originalContent = JSON.parse((result.content[0] as any).text);
-        originalContent.apiGuidance = guidance;
-        result.content[0] = {
-          type: 'text',
-          text: JSON.stringify(originalContent, null, 2)
-        };
+        const guidance = HelpScoutAPIConstraints.generateToolGuidance(
+          request.params.name,
+          originalContent,
+          validationContext
+        );
+
+        if (guidance.length > 0) {
+          originalContent.apiGuidance = guidance;
+          result.content[0] = {
+            type: 'text',
+            text: JSON.stringify(originalContent, null, 2)
+          };
+          guidanceProvided = true;
+        }
+      } catch (guidanceError) {
+        logger.warn('Failed to inject API guidance into tool response', {
+          requestId,
+          toolName: request.params.name,
+          error: guidanceError instanceof Error ? guidanceError.message : String(guidanceError),
+        });
       }
 
       logger.info('Tool call completed', {
@@ -614,7 +819,7 @@ export class ToolHandler {
         toolName: request.params.name,
         duration,
         validationPassed: true,
-        guidanceProvided: guidance.length > 0
+        guidanceProvided
       });
 
       return result;
@@ -760,8 +965,6 @@ export class ToolHandler {
           }
 
           // Critical API errors should abort, not return partial results.
-          // Note: currently blocked by validateStatus < 500 (NAS-465) which
-          // prevents 4xx from reaching this path. Will activate once fixed.
           if (errorCode === 'UNAUTHORIZED' || errorCode === 'INVALID_INPUT') {
             throw reason;
           }
@@ -927,21 +1130,41 @@ export class ToolHandler {
         status: conversation.status,
         createdAt: conversation.createdAt,
         updatedAt: conversation.updatedAt,
-        customer: conversation.customer,
-        assignee: conversation.assignee,
+        customer: config.security.allowPii ? conversation.customer : (conversation.customer ? {
+          id: conversation.customer.id,
+          email: conversation.customer.email != null ? '[redacted]' : conversation.customer.email,
+          firstName: conversation.customer.firstName != null ? '[redacted]' : conversation.customer.firstName,
+          lastName: conversation.customer.lastName != null ? '[redacted]' : conversation.customer.lastName,
+        } : null),
+        assignee: config.security.allowPii ? conversation.assignee : (conversation.assignee ? {
+          id: conversation.assignee.id,
+          firstName: '[redacted]',
+          lastName: '[redacted]',
+          email: '[redacted]',
+        } : null),
         tags: conversation.tags,
       },
       firstCustomerMessage: firstCustomerMessage ? {
         id: firstCustomerMessage.id,
-        body: config.security.allowPii ? firstCustomerMessage.body : '[Content hidden - set REDACT_MESSAGE_CONTENT=false to view]',
+        body: config.security.allowPii ? firstCustomerMessage.body : PII_REDACTED_BODY,
         createdAt: firstCustomerMessage.createdAt,
-        customer: firstCustomerMessage.customer,
+        customer: config.security.allowPii ? firstCustomerMessage.customer : (firstCustomerMessage.customer ? {
+          id: firstCustomerMessage.customer.id,
+          email: firstCustomerMessage.customer.email != null ? '[redacted]' : firstCustomerMessage.customer.email,
+          firstName: firstCustomerMessage.customer.firstName != null ? '[redacted]' : firstCustomerMessage.customer.firstName,
+          lastName: firstCustomerMessage.customer.lastName != null ? '[redacted]' : firstCustomerMessage.customer.lastName,
+        } : null),
       } : null,
       latestStaffReply: latestStaffReply ? {
         id: latestStaffReply.id,
-        body: config.security.allowPii ? latestStaffReply.body : '[Content hidden - set REDACT_MESSAGE_CONTENT=false to view]',
+        body: config.security.allowPii ? latestStaffReply.body : PII_REDACTED_BODY,
         createdAt: latestStaffReply.createdAt,
-        createdBy: latestStaffReply.createdBy,
+        createdBy: config.security.allowPii ? latestStaffReply.createdBy : (latestStaffReply.createdBy ? {
+          id: latestStaffReply.createdBy.id,
+          firstName: '[redacted]',
+          lastName: '[redacted]',
+          email: '[redacted]',
+        } : null),
       } : null,
     };
 
@@ -971,7 +1194,7 @@ export class ToolHandler {
     // Redact PII if configured
     const processedThreads = threads.map(thread => ({
       ...thread,
-      body: config.security.allowPii ? thread.body : '[Content hidden - set REDACT_MESSAGE_CONTENT=false to view]',
+      body: config.security.allowPii ? thread.body : PII_REDACTED_BODY,
     }));
 
     return {
@@ -1007,7 +1230,7 @@ export class ToolHandler {
   }
 
   private async listAllInboxes(args: unknown): Promise<CallToolResult> {
-    const input = args as { limit?: number };
+    const input = ListAllInboxesInputSchema.parse(args);
     const limit = input.limit || 100;
 
     const response = await helpScoutClient.get<PaginatedResponse<Inbox>>('/mailboxes', {
@@ -1244,6 +1467,7 @@ export class ToolHandler {
       conversations: Conversation[];
       searchQuery: string;
       filteredByCreatedBefore?: boolean;
+      error?: string;
     }> = [];
 
     for (const status of input.statuses) {
@@ -1269,9 +1493,6 @@ export class ToolHandler {
         }
 
         // Critical API errors should fail the entire operation.
-        // Note: currently blocked by validateStatus < 500 (NAS-465) which
-        // treats 4xx as successful responses in axios, so they never reach
-        // this catch block. Will activate once validateStatus is fixed.
         if (error.code === 'UNAUTHORIZED' || error.code === 'INVALID_INPUT') {
           logger.error('Critical API error in multi-status search - aborting', {
             status,
@@ -1294,6 +1515,7 @@ export class ToolHandler {
           totalCount: 0,
           conversations: [],
           searchQuery,
+          error: `Search failed (${error.code}): ${error.message}`,
         });
       }
     }
@@ -1417,6 +1639,7 @@ export class ToolHandler {
       conversations: Conversation[];
       searchQuery: string;
       filteredByCreatedBefore?: boolean;
+      error?: string;
     }>,
     context: {
       input: z.infer<typeof MultiStatusConversationSearchInputSchema>;
@@ -1448,6 +1671,7 @@ export class ToolHandler {
       totalBeforeClientSideFiltering: totalBeforeFilter,
       clientSideFilteringApplied: hasClientSideFiltering ?
         `createdBefore filter applied - totalConversationsFound (${totalConversations}) reflects filtered results, totalBeforeClientSideFiltering (${totalBeforeFilter}) shows pre-filter API totals` : undefined,
+      failedStatuses: allResults.filter(r => r.error).map(r => `[WARNING] Status "${r.status}" search failed: ${r.error}`),
       resultsByStatus: allResults,
       searchTips: totalConversations === 0 ? [
         'Try broader search terms or increase the timeframe',
@@ -1531,10 +1755,443 @@ export class ToolHandler {
     };
   }
 
-  // --- Write Operations ---
+  // ── Customer Tools (NAS-680, NAS-727) ──
+
+  private redactAddress(address: CustomerAddress): Record<string, unknown> {
+    if (config.security.allowPii) return address as unknown as Record<string, unknown>;
+    return {
+      city: address.city != null ? '[redacted]' : address.city,
+      state: address.state != null ? '[redacted]' : address.state,
+      postalCode: address.postalCode != null ? '[redacted]' : address.postalCode,
+      lines: address.lines ? address.lines.map(() => '[redacted]') : undefined,
+      country: address.country, // Country is not PII
+    };
+  }
+
+  private redactCustomer(customer: Customer): Record<string, unknown> {
+    if (config.security.allowPii) return customer as unknown as Record<string, unknown>;
+
+    const { background, firstName, lastName, jobTitle, location, photoUrl, age, _embedded, ...rest } = customer;
+    const redacted: Record<string, unknown> = {
+      ...rest,
+      firstName: firstName != null ? '[redacted]' : firstName,
+      lastName: lastName != null ? '[redacted]' : lastName,
+      jobTitle: jobTitle != null ? '[redacted]' : jobTitle,
+      location: location != null ? '[redacted]' : location,
+      photoUrl: photoUrl != null ? '[redacted]' : photoUrl,
+      age: age != null ? '[redacted]' : age,
+      background: background != null ? '[redacted]' : background,
+    };
+
+    if (_embedded) {
+      const embeddedCopy = { ..._embedded };
+      for (const key of ['emails', 'phones', 'chats', 'social_profiles', 'websites'] as const) {
+        const entries = embeddedCopy[key];
+        if (entries) {
+          (embeddedCopy as Record<string, unknown>)[key] = entries.map(item => ({
+            ...item,
+            value: '[redacted]',
+          }));
+        }
+      }
+      if (embeddedCopy.properties) {
+        embeddedCopy.properties = embeddedCopy.properties.map(prop => ({
+          ...prop,
+          value: prop.value != null ? '[redacted]' : prop.value,
+          text: prop.text != null ? '[redacted]' : prop.text,
+        }));
+      }
+      redacted._embedded = embeddedCopy;
+    }
+
+    return redacted;
+  }
+
+  private async getCustomer(args: unknown): Promise<CallToolResult> {
+    const input = GetCustomerInputSchema.parse(args);
+
+    // Fetch customer profile and address in parallel
+    const [customerResponse, addressResponse] = await Promise.allSettled([
+      helpScoutClient.get<Customer>(`/customers/${input.customerId}`),
+      helpScoutClient.get<CustomerAddress>(`/customers/${input.customerId}/address`),
+    ]);
+
+    if (customerResponse.status === 'rejected') {
+      throw customerResponse.reason;
+    }
+
+    const customer = customerResponse.value;
+
+    // Handle address response: 404 means no address on file (expected), all other errors should surface
+    let address: CustomerAddress | null = null;
+    let addressNote: string | undefined;
+    if (addressResponse.status === 'fulfilled') {
+      address = addressResponse.value;
+    } else {
+      const reason = addressResponse.reason;
+      const is404 = isApiError(reason) && reason.code === 'NOT_FOUND';
+      if (!is404) {
+        // Critical errors (auth, rate limit) should abort entirely
+        if (isApiError(reason) && (reason.code === 'UNAUTHORIZED' || reason.code === 'RATE_LIMIT')) {
+          throw reason;
+        }
+        // Non-API errors (TypeError, network) should propagate
+        if (!isApiError(reason)) {
+          throw reason;
+        }
+        // Other API errors: log and surface in response
+        const errorMessage = reason.message || String(reason);
+        logger.error('Address fetch failed for customer', { customerId: input.customerId, error: errorMessage });
+        addressNote = `Address lookup failed: ${errorMessage}`;
+      }
+    }
+
+    const result: Record<string, unknown> = this.redactCustomer(customer);
+    if (address) {
+      result.address = this.redactAddress(address);
+    }
+    if (addressNote) {
+      result.addressNote = addressNote;
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          customer: result,
+          usage: 'NEXT STEPS: Use organizationId to explore their org with getOrganization. Use customer.id with structuredConversationFilter(customerIds) to find their conversations.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listCustomers(args: unknown): Promise<CallToolResult> {
+    const input = ListCustomersInputSchema.parse(args);
+
+    // v2 API: page size is fixed at 50, 'size' param is not documented/supported
+    const params: Record<string, unknown> = {
+      page: input.page,
+      sortField: input.sortField,
+      sortOrder: input.sortOrder,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      query: input.query,
+      mailbox: input.mailbox,
+      modifiedSince: input.modifiedSince,
+    };
+
+    const response = await helpScoutClient.get<PaginatedResponse<Customer>>('/customers', params);
+    const customers = response._embedded?.customers || [];
+
+    // Slim view: strip _links and _embedded to keep response concise for browsing.
+    // Use getCustomer for the full profile with all sub-resources.
+    const slimResults = customers.map(c => {
+      const redacted = this.redactCustomer(c);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { _links, _embedded, ...slim } = redacted;
+      // Extract primary email from _embedded for slim view (redacted if PII protection is on)
+      const emails = (_embedded as Record<string, unknown[]> | undefined)?.emails;
+      if (Array.isArray(emails) && emails.length > 0) {
+        slim.primaryEmail = (emails[0] as Record<string, unknown>).value;
+      }
+      return slim;
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          results: slimResults,
+          returnedCount: customers.length,
+          pagination: response.page,
+          usage: 'Use customer.id with getCustomer for full profile (includes emails, phones, address, etc.), or with structuredConversationFilter(customerIds) for their conversations.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // NAS-728: v3 Customer search with email filter
+  private async searchCustomersByEmail(args: unknown): Promise<CallToolResult> {
+    const input = SearchCustomersByEmailInputSchema.parse(args);
+
+    const params: Record<string, unknown> = {
+      email: input.email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      query: input.query,
+      modifiedSince: input.modifiedSince,
+      createdSince: input.createdSince,
+      cursor: input.cursor,
+    };
+
+    // v3 endpoint: construct absolute URL from configured base URL
+    const v3Url = config.helpscout.baseUrl.replace(/\/v2\/?$/, '/v3/customers');
+    if (v3Url === config.helpscout.baseUrl) {
+      logger.warn('v3 URL construction: baseUrl did not match /v2/ pattern, URL may be incorrect', { baseUrl: config.helpscout.baseUrl, v3Url });
+    }
+    const v3Response = await helpScoutClient.get<{
+      _embedded: { customers: Customer[] };
+      _links?: { next?: { href: string } };
+    }>(v3Url, params);
+
+    const customers = v3Response._embedded?.customers || [];
+
+    // Extract cursor token from v3 next link (full URL -> just the cursor param value)
+    let nextCursor: string | undefined;
+    const nextHref = v3Response._links?.next?.href;
+    if (nextHref) {
+      try {
+        const url = new URL(nextHref);
+        nextCursor = url.searchParams.get('cursor') || nextHref;
+      } catch (parseError) {
+        logger.debug('Could not parse v3 next link as URL, using raw href as cursor', {
+          nextHref,
+          error: parseError instanceof Error ? parseError.message : String(parseError),
+        });
+        nextCursor = nextHref;
+      }
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          results: customers.map(c => this.redactCustomer(c)),
+          returnedCount: customers.length,
+          searchedEmail: config.security.allowPii ? input.email : '[redacted]',
+          nextCursor,
+          note: 'v3 API uses cursor-based pagination. Pass nextCursor value back as cursor parameter for more results.',
+          usage: 'Use customer.id with getCustomer for full profile with sub-resources.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // NAS-727: Customer sub-resource contacts tool
+  private async getCustomerContacts(args: unknown): Promise<CallToolResult> {
+    const input = GetCustomerContactsInputSchema.parse(args);
+    const cid = input.customerId;
+
+    // Fetch all 6 sub-resources in parallel via dedicated endpoints
+    const [emailsRes, phonesRes, chatsRes, socialRes, websitesRes, addressRes] = await Promise.allSettled([
+      helpScoutClient.get<{ _embedded?: { emails?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/emails`),
+      helpScoutClient.get<{ _embedded?: { phones?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/phones`),
+      helpScoutClient.get<{ _embedded?: { chats?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/chats`),
+      helpScoutClient.get<{ _embedded?: { social_profiles?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/social-profiles`),
+      helpScoutClient.get<{ _embedded?: { websites?: Array<{ id: number; value: string }> } }>(`/customers/${cid}/websites`),
+      helpScoutClient.get<CustomerAddress>(`/customers/${cid}/address`),
+    ]);
+
+    // Helper: extract data or note the error
+    const extract = <T>(settled: PromiseSettledResult<T>, label: string): { data: T | null; error?: string } => {
+      if (settled.status === 'fulfilled') return { data: settled.value };
+      const reason = settled.reason;
+      // 404 = no data on file (normal)
+      if (isApiError(reason) && reason.code === 'NOT_FOUND') return { data: null };
+      // Auth/rate limit errors should abort
+      if (isApiError(reason) && (reason.code === 'UNAUTHORIZED' || reason.code === 'RATE_LIMIT')) throw reason;
+      // Non-API errors (TypeError, ReferenceError, etc.) are programming bugs; propagate them
+      if (!isApiError(reason)) throw reason;
+      return { data: null, error: `${label} fetch failed (${reason.code}): ${reason.message}` };
+    };
+
+    const emails = extract(emailsRes, 'emails');
+    const phones = extract(phonesRes, 'phones');
+    const chats = extract(chatsRes, 'chats');
+    const social = extract(socialRes, 'social profiles');
+    const websites = extract(websitesRes, 'websites');
+    const address = extract(addressRes, 'address');
+
+    const redactValue = (v: string) => config.security.allowPii ? v : '[redacted]';
+    const redactEntry = (e: { id: number; value: string; type?: string }) => ({
+      id: e.id, value: redactValue(e.value), ...(e.type ? { type: e.type } : {}),
+    });
+
+    const result: Record<string, unknown> = {
+      customerId: cid,
+      emails: emails.data ? (emails.data._embedded?.emails || []).map(redactEntry) : [],
+      phones: phones.data ? (phones.data._embedded?.phones || []).map(redactEntry) : [],
+      chats: chats.data ? (chats.data._embedded?.chats || []).map(redactEntry) : [],
+      socialProfiles: social.data ? (social.data._embedded?.social_profiles || []).map(redactEntry) : [],
+      websites: websites.data ? (websites.data._embedded?.websites || []).map(e => ({ id: e.id, value: redactValue(e.value) })) : [],
+      address: address.data ? this.redactAddress(address.data as CustomerAddress) : null,
+    };
+
+    // Collect any partial errors
+    const errors = [emails, phones, chats, social, websites, address]
+      .map(r => r.error).filter(Boolean);
+    if (errors.length > 0) {
+      logger.error('getCustomerContacts returned partial results', {
+        customerId: cid,
+        failedResources: errors,
+        successCount: 6 - errors.length,
+      });
+      result.partialErrors = errors;
+    }
+
+    // Warn if all sub-resources returned no data (likely invalid customerId)
+    const allEmpty = !emails.data && !phones.data && !chats.data && !social.data && !websites.data && !address.data;
+    if (allEmpty && errors.length === 0) {
+      result.warning = 'No contact data found. Verify the customerId exists using getCustomer.';
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          ...result,
+          usage: 'This returns all contact channels for a customer. Use getCustomer for the full profile with demographics.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // ── Organization Tools (NAS-684, NAS-712) ──
+
+  private redactOrganization(org: Organization): Record<string, unknown> {
+    if (config.security.allowPii) return org as unknown as Record<string, unknown>;
+
+    return {
+      ...org,
+      website: org.website != null ? '[redacted]' : org.website,
+      domains: org.domains ? org.domains.map(() => '[redacted]') : org.domains,
+      phones: org.phones ? org.phones.map(() => '[redacted]') : org.phones,
+      location: org.location != null ? '[redacted]' : org.location,
+      note: org.note != null ? '[redacted]' : org.note,
+      description: org.description != null ? '[redacted]' : org.description,
+    };
+  }
+
+  private async getOrganization(args: unknown): Promise<CallToolResult> {
+    const input = GetOrganizationInputSchema.parse(args);
+
+    const params: Record<string, unknown> = {};
+    if (input.includeCounts) params.includeCounts = true;
+    if (input.includeProperties) params.includeProperties = true;
+
+    const org = await helpScoutClient.get<Organization>(
+      `/organizations/${input.organizationId}`,
+      params
+    );
+
+    const orgResult = this.redactOrganization(org);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          organization: orgResult,
+          usage: 'NEXT STEPS: Use getOrganizationMembers to see customers in this org. Use getOrganizationConversations to see all conversations.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listOrganizations(args: unknown): Promise<CallToolResult> {
+    const input = ListOrganizationsInputSchema.parse(args);
+
+    // v2 API: page size is fixed at 50
+    const response = await helpScoutClient.get<PaginatedResponse<Organization>>('/organizations', {
+      page: input.page,
+      sort: `${input.sortField},${input.sortOrder}`,
+    });
+
+    const organizations = response._embedded?.organizations || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          results: organizations.map(org => this.redactOrganization(org)),
+          returnedCount: organizations.length,
+          pagination: response.page,
+          nextCursor: response._links?.next?.href,
+          nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
+          usage: 'Use organization.id with getOrganization for details, getOrganizationMembers for customers, or getOrganizationConversations for support history.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // NAS-712: Customer-Org relational traversal
+  private async getOrganizationMembers(args: unknown): Promise<CallToolResult> {
+    const input = GetOrganizationMembersInputSchema.parse(args);
+
+    // v2 API: page size is fixed at 50
+    const response = await helpScoutClient.get<PaginatedResponse<Customer>>(
+      `/organizations/${input.organizationId}/customers`,
+      { page: input.page }
+    );
+
+    const customers = response._embedded?.customers || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          organizationId: input.organizationId,
+          members: customers.map(c => this.redactCustomer(c)),
+          returnedCount: customers.length,
+          pagination: response.page,
+          nextCursor: response._links?.next?.href,
+          nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
+          usage: 'Use customer.id with getCustomer for full profile or structuredConversationFilter(customerIds) for their conversations.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getOrganizationConversations(args: unknown): Promise<CallToolResult> {
+    const input = GetOrganizationConversationsInputSchema.parse(args);
+
+    // v2 API: page size is fixed at 50
+    const response = await helpScoutClient.get<PaginatedResponse<Conversation>>(
+      `/organizations/${input.organizationId}/conversations`,
+      { page: input.page }
+    );
+
+    const conversations = response._embedded?.conversations || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          organizationId: input.organizationId,
+          conversations: conversations.map(c => ({
+            id: c.id,
+            number: c.number,
+            subject: c.subject,
+            status: c.status,
+            customer: config.security.allowPii ? c.customer : (c.customer ? {
+              id: c.customer.id,
+              email: c.customer.email != null ? '[redacted]' : c.customer.email,
+              firstName: c.customer.firstName != null ? '[redacted]' : c.customer.firstName,
+              lastName: c.customer.lastName != null ? '[redacted]' : c.customer.lastName,
+            } : null),
+            assignee: config.security.allowPii ? c.assignee : (c.assignee ? {
+              id: c.assignee.id,
+              firstName: '[redacted]',
+              lastName: '[redacted]',
+              email: '[redacted]',
+            } : null),
+            createdAt: c.createdAt,
+            updatedAt: c.updatedAt,
+            closedAt: c.closedAt,
+            tags: c.tags,
+          })),
+          returnedCount: conversations.length,
+          pagination: response.page,
+          nextCursor: response._links?.next?.href,
+          nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
+          usage: 'Use conversation.id with getThreads to read full message history, or getConversationSummary for a quick overview.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // ── Write Operations ──
 
   private checkWritesEnabled(): void {
-    // Check env var directly to support runtime toggling (e.g., in tests)
     if (process.env.HELPSCOUT_ENABLE_WRITES !== 'true') {
       throw new Error(
         'Write operations are disabled. Set HELPSCOUT_ENABLE_WRITES=true to enable reply, note, and status update tools.'
@@ -1542,7 +2199,7 @@ export class ToolHandler {
     }
   }
 
-  private async createReply(args: Record<string, unknown>): Promise<CallToolResult> {
+  private async createReply(args: unknown): Promise<CallToolResult> {
     this.checkWritesEnabled();
 
     const input = CreateReplyInputSchema.parse(args);
@@ -1590,7 +2247,35 @@ export class ToolHandler {
     };
   }
 
-  private async updateConversationStatus(args: Record<string, unknown>): Promise<CallToolResult> {
+  private async createNote(args: unknown): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateNoteInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating note', {
+      conversationId,
+      // Never log the text content for PII safety
+    });
+
+    await helpScoutClient.post(`/conversations/${conversationId}/notes`, {
+      text: input.text,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'note_created',
+          message: `Internal note added to conversation ${conversationId}. This note is only visible to support agents.`,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async updateConversationStatus(args: unknown): Promise<CallToolResult> {
     this.checkWritesEnabled();
 
     const input = UpdateConversationStatusInputSchema.parse(args);
@@ -1623,19 +2308,79 @@ export class ToolHandler {
     };
   }
 
-  private async createNote(args: Record<string, unknown>): Promise<CallToolResult> {
+  private async createConversation(args: unknown): Promise<CallToolResult> {
     this.checkWritesEnabled();
 
-    const input = CreateNoteInputSchema.parse(args);
-    const conversationId = input.conversationId;
+    const input = CreateConversationInputSchema.parse(args);
 
-    logger.info('Creating note', {
-      conversationId,
-      // Never log the text content for PII safety
+    logger.info('Creating conversation', {
+      mailboxId: input.mailboxId,
+      draft: input.draft,
+      hasAssignment: !!input.assignTo,
+      hasTags: !!(input.tags && input.tags.length > 0),
+      // Never log subject or text for PII safety
     });
 
-    await helpScoutClient.post(`/conversations/${conversationId}/notes`, {
-      text: input.text,
+    const requestBody: Record<string, unknown> = {
+      subject: input.subject,
+      customer: input.customer,
+      mailboxId: input.mailboxId,
+      type: 'email',
+      status: input.draft ? 'active' : 'active',
+      threads: [{
+        type: 'customer',
+        customer: { email: input.customer.email },
+        text: input.text,
+      }],
+    };
+
+    if (input.draft) {
+      requestBody.status = 'active';
+      // Draft conversations use draft threads
+      (requestBody.threads as Record<string, unknown>[])[0].draft = true;
+    }
+
+    if (input.tags && input.tags.length > 0) {
+      requestBody.tags = input.tags.map(tag => ({ tag }));
+    }
+
+    if (input.assignTo) {
+      requestBody.assignTo = input.assignTo;
+    }
+
+    await helpScoutClient.post('/conversations', requestBody);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          action: 'conversation_created',
+          mode: input.draft ? 'draft' : 'sent',
+          message: input.draft
+            ? 'Draft conversation created. A human must review and send it from the Help Scout UI.'
+            : 'Conversation created and sent to the customer.',
+          warning: input.draft ? undefined : 'This message has been sent to the customer and cannot be undone.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async assignConversation(args: unknown): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = AssignConversationInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Assigning conversation', {
+      conversationId,
+      assigneeId: input.assigneeId,
+    });
+
+    await helpScoutClient.patch(`/conversations/${conversationId}`, {
+      op: 'replace',
+      path: '/assignTo',
+      value: input.assigneeId,
     });
 
     return {
@@ -1644,8 +2389,69 @@ export class ToolHandler {
         text: JSON.stringify({
           success: true,
           conversationId,
-          action: 'note_created',
-          message: `Internal note added to conversation ${conversationId}. This note is only visible to support agents.`,
+          action: 'conversation_assigned',
+          assigneeId: input.assigneeId,
+          message: `Conversation ${conversationId} assigned to user ${input.assigneeId}.`,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listUsers(args: unknown): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = ListUsersInputSchema.parse(args);
+
+    const response = await helpScoutClient.get<PaginatedResponse<{ id: number; firstName: string; lastName: string; email: string; role: string; type: string }>>('/users', {
+      page: input.page,
+      size: input.limit,
+    });
+
+    const users = response._embedded?.users || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          results: users.map(u => ({
+            id: u.id,
+            firstName: config.security.allowPii ? u.firstName : '[redacted]',
+            lastName: config.security.allowPii ? u.lastName : '[redacted]',
+            email: config.security.allowPii ? u.email : '[redacted]',
+            role: u.role,
+            type: u.type,
+          })),
+          returnedCount: users.length,
+          pagination: response.page,
+          usage: 'Use user.id with assignConversation to assign conversations to team members.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listMailboxes(args: unknown): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = ListMailboxesInputSchema.parse(args);
+
+    const response = await helpScoutClient.get<PaginatedResponse<Inbox>>('/mailboxes', {
+      page: 1,
+      size: input.limit,
+    });
+
+    const inboxes = response._embedded?.mailboxes || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          results: inboxes.map(inbox => ({
+            id: inbox.id,
+            name: inbox.name,
+            email: inbox.email,
+          })),
+          returnedCount: inboxes.length,
+          usage: 'Use mailbox.id with createConversation to create new tickets in a specific mailbox.',
         }, null, 2),
       }],
     };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,6 +23,9 @@ export interface Config {
   security: {
     allowPii: boolean;
   };
+  writes: {
+    enabled: boolean;
+  };
   connectionPool: {
     maxSockets: number;
     maxFreeSockets: number;
@@ -52,6 +55,9 @@ export const config: Config = {
     // Default: show content. Set REDACT_MESSAGE_CONTENT=true to hide message bodies
     // ALLOW_PII=true is backwards compat (always shows content)
     allowPii: process.env.REDACT_MESSAGE_CONTENT !== 'true' || process.env.ALLOW_PII === 'true',
+  },
+  writes: {
+    enabled: process.env.HELPSCOUT_ENABLE_WRITES === 'true',
   },
   connectionPool: {
     maxSockets: parseInt(process.env.HTTP_MAX_SOCKETS || '50', 10),
@@ -90,6 +96,11 @@ export function validateConfig(): void {
       'Optional configuration:\n' +
       '  - HELPSCOUT_DEFAULT_INBOX_ID: Default inbox for scoped searches (improves LLM context)'
     );
+  }
+
+  // Log write access status
+  if (config.writes.enabled) {
+    console.error('Help Scout write access ENABLED (HELPSCOUT_ENABLE_WRITES=true)');
   }
 
   // Enforce HTTPS for API base URL to prevent credential exposure

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,6 +13,10 @@ export interface Config {
     baseUrl: string;
     defaultInboxId?: string; // Optional: default inbox for scoped searches
   };
+  docs?: {
+    apiKey: string;          // Docs API key (HTTP Basic Auth)
+    baseUrl: string;         // Docs API base URL
+  };
   cache: {
     ttlSeconds: number;
     maxSize: number;
@@ -59,6 +63,10 @@ export const config: Config = {
   writes: {
     enabled: process.env.HELPSCOUT_ENABLE_WRITES === 'true',
   },
+  docs: process.env.HELPSCOUT_DOCS_API_KEY ? {
+    apiKey: process.env.HELPSCOUT_DOCS_API_KEY,
+    baseUrl: process.env.HELPSCOUT_DOCS_BASE_URL || 'https://docsapi.helpscout.net/v1',
+  } : undefined,
   connectionPool: {
     maxSockets: parseInt(process.env.HTTP_MAX_SOCKETS || '50', 10),
     maxFreeSockets: parseInt(process.env.HTTP_MAX_FREE_SOCKETS || '10', 10),
@@ -110,5 +118,19 @@ export function validateConfig(): void {
       `Current value: ${config.helpscout.baseUrl}\n` +
       'Please use: https://api.helpscout.net/v2/'
     );
+  }
+
+  // Log Docs API status
+  if (config.docs) {
+    console.error('Help Scout Docs API ENABLED (HELPSCOUT_DOCS_API_KEY is set)');
+
+    // Enforce HTTPS for Docs API base URL
+    if (!config.docs.baseUrl.startsWith('https://')) {
+      throw new Error(
+        'Security Error: HELPSCOUT_DOCS_BASE_URL must use HTTPS to protect credentials in transit.\n' +
+        `Current value: ${config.docs.baseUrl}\n` +
+        'Please use: https://docsapi.helpscout.net/v1'
+      );
+    }
   }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared constants used across tools and resources.
+ */
+
+/** Placeholder text shown when PII redaction hides message body content. */
+export const PII_REDACTED_BODY = '[Content hidden - set REDACT_MESSAGE_CONTENT=false to view]';

--- a/src/utils/docs-client.ts
+++ b/src/utils/docs-client.ts
@@ -269,7 +269,28 @@ export class DocsClient {
   }
 
   /**
-   * GET a paginated list of resources.
+   * GET a paginated list of resources, unwrapping the response envelope.
+   * Docs API returns lists as { "collections": { "items": [...], "page": 1, ... } }, etc.
+   */
+  async getList<T>(endpoint: string, key: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<DocsPaginatedResponse<T>> {
+    const cacheKey = `DOCS:GET:${endpoint}`;
+    const cachedResult = cache.get<DocsPaginatedResponse<T>>(cacheKey, params);
+    if (cachedResult) return cachedResult;
+
+    const response = await this.executeWithRetry<Record<string, DocsPaginatedResponse<T>>>(() =>
+      this.client.get<Record<string, DocsPaginatedResponse<T>>>(endpoint, { params }),
+    );
+
+    const data = response.data[key] || { items: [], page: 0, pages: 0, count: 0 };
+
+    const ttl = cacheOptions?.ttl ?? this.getDefaultCacheTtl(endpoint);
+    cache.set(cacheKey, params, data, { ttl });
+
+    return data;
+  }
+
+  /**
+   * GET a paginated list of resources (raw, no envelope unwrapping).
    */
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
     const cacheKey = `DOCS:GET:${endpoint}`;

--- a/src/utils/docs-client.ts
+++ b/src/utils/docs-client.ts
@@ -1,0 +1,383 @@
+import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
+import { config } from './config.js';
+import { logger } from './logger.js';
+import { cache } from './cache.js';
+import { ApiError } from '../schema/types.js';
+
+/**
+ * Paginated response shape for the Help Scout Docs API.
+ * Different from the main API's _embedded / _links / page format.
+ */
+export interface DocsPaginatedResponse<T> {
+  items: T[];
+  page: number;
+  pages: number;
+  count: number;
+}
+
+interface RetryConfig {
+  retries: number;
+  retryDelay: number;
+  maxRetryDelay: number;
+  retryCondition?: (error: AxiosError) => boolean;
+}
+
+interface RequestMetadata {
+  requestId: string;
+  startTime: number;
+}
+
+declare module 'axios' {
+  interface InternalAxiosRequestConfig {
+    metadata?: RequestMetadata;
+  }
+}
+
+export class DocsClient {
+  private client: AxiosInstance;
+  private httpAgent: HttpAgent;
+  private httpsAgent: HttpsAgent;
+
+  private defaultRetryConfig: RetryConfig = {
+    retries: 3,
+    retryDelay: 1000,
+    maxRetryDelay: 10000,
+    retryCondition: (error: AxiosError) => {
+      return !error.response ||
+             error.code === 'ECONNABORTED' ||
+             (error.response.status >= 500 && error.response.status < 600) ||
+             error.response.status === 429;
+    },
+  };
+
+  private noRetryConfig: RetryConfig = {
+    retries: 0,
+    retryDelay: 0,
+    maxRetryDelay: 0,
+  };
+
+  constructor() {
+    if (!config.docs) {
+      throw new Error('Docs API configuration not available. Set HELPSCOUT_DOCS_API_KEY.');
+    }
+
+    const poolConfig = config.connectionPool;
+
+    this.httpAgent = new HttpAgent({
+      keepAlive: poolConfig.keepAlive,
+      keepAliveMsecs: poolConfig.keepAliveMsecs,
+      maxSockets: poolConfig.maxSockets,
+      maxFreeSockets: poolConfig.maxFreeSockets,
+      timeout: poolConfig.timeout,
+    });
+
+    this.httpsAgent = new HttpsAgent({
+      keepAlive: poolConfig.keepAlive,
+      keepAliveMsecs: poolConfig.keepAliveMsecs,
+      maxSockets: poolConfig.maxSockets,
+      maxFreeSockets: poolConfig.maxFreeSockets,
+      timeout: poolConfig.timeout,
+    });
+
+    this.client = axios.create({
+      baseURL: config.docs.baseUrl,
+      timeout: 30000,
+      httpAgent: this.httpAgent,
+      httpsAgent: this.httpsAgent,
+      auth: {
+        username: config.docs.apiKey,
+        password: 'X',
+      },
+      maxRedirects: 5,
+      validateStatus: (status) => status >= 200 && status < 300,
+    });
+
+    this.setupInterceptors();
+
+    logger.info('Docs API HTTP client initialized', {
+      baseUrl: config.docs.baseUrl,
+    });
+  }
+
+  private setupInterceptors(): void {
+    this.client.interceptors.request.use((reqConfig) => {
+      const requestId = Math.random().toString(36).substring(7);
+      reqConfig.metadata = { requestId, startTime: Date.now() };
+
+      logger.debug('Docs API request', {
+        requestId,
+        method: reqConfig.method?.toUpperCase(),
+        url: reqConfig.url,
+      });
+
+      return reqConfig;
+    });
+
+    this.client.interceptors.response.use(
+      (response: AxiosResponse) => {
+        const duration = response.config.metadata ? Date.now() - response.config.metadata.startTime : 0;
+        logger.debug('Docs API response', {
+          requestId: response.config.metadata?.requestId || 'unknown',
+          status: response.status,
+          duration,
+        });
+        return response;
+      },
+      (error: AxiosError) => {
+        const duration = error.config?.metadata ? Date.now() - error.config.metadata.startTime : 0;
+        logger.error('Docs API error', {
+          requestId: error.config?.metadata?.requestId || 'unknown',
+          status: error.response?.status,
+          message: error.message,
+          duration,
+        });
+        return Promise.reject(error);
+      },
+    );
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private calculateRetryDelay(attempt: number, baseDelay: number, maxDelay: number): number {
+    const exponentialDelay = baseDelay * Math.pow(2, attempt);
+    const jitter = Math.random() * 0.1 * exponentialDelay;
+    return Math.min(exponentialDelay + jitter, maxDelay);
+  }
+
+  private async executeWithRetry<T>(
+    operation: () => Promise<AxiosResponse<T>>,
+    retryConfig: RetryConfig = this.defaultRetryConfig,
+  ): Promise<AxiosResponse<T>> {
+    let lastError: AxiosError | undefined;
+
+    for (let attempt = 0; attempt <= retryConfig.retries; attempt++) {
+      try {
+        return await operation();
+      } catch (error) {
+        lastError = error as AxiosError;
+
+        if (attempt === retryConfig.retries) break;
+        if (!retryConfig.retryCondition?.(lastError)) break;
+
+        if (lastError.response?.status === 429) {
+          const retryAfter = parseInt(lastError.response.headers['retry-after'] || '60', 10) * 1000;
+          const delay = Math.min(retryAfter, retryConfig.maxRetryDelay);
+          logger.warn('Docs API rate limit hit, waiting before retry', {
+            attempt: attempt + 1,
+            retryAfter: delay,
+          });
+          await this.sleep(delay);
+        } else {
+          const delay = this.calculateRetryDelay(attempt, retryConfig.retryDelay, retryConfig.maxRetryDelay);
+          logger.warn('Docs API request failed, retrying', {
+            attempt: attempt + 1,
+            totalAttempts: retryConfig.retries + 1,
+            delay,
+            error: lastError.message,
+            status: lastError.response?.status,
+          });
+          await this.sleep(delay);
+        }
+      }
+    }
+
+    if (lastError) {
+      throw this.transformError(lastError);
+    }
+    throw new Error('Docs API request failed without error details');
+  }
+
+  private transformError(error: AxiosError): ApiError {
+    const requestId = error.config?.metadata?.requestId || 'unknown';
+
+    logger.error('Docs API request failed', {
+      requestId,
+      url: error.config?.url,
+      method: error.config?.method?.toUpperCase(),
+      status: error.response?.status,
+    });
+
+    if (error.response?.status === 401) {
+      return {
+        code: 'UNAUTHORIZED',
+        message: 'Docs API authentication failed. Check your HELPSCOUT_DOCS_API_KEY.',
+        details: { requestId },
+      };
+    }
+
+    if (error.response?.status === 403) {
+      return {
+        code: 'UNAUTHORIZED',
+        message: 'Docs API access forbidden. Insufficient permissions.',
+        details: { requestId },
+      };
+    }
+
+    if (error.response?.status === 404) {
+      return {
+        code: 'NOT_FOUND',
+        message: 'Docs API resource not found.',
+        details: { requestId },
+      };
+    }
+
+    if (error.response?.status === 429) {
+      const retryAfter = parseInt(error.response.headers['retry-after'] || '60', 10);
+      return {
+        code: 'RATE_LIMIT',
+        message: `Docs API rate limit exceeded. Wait ${retryAfter} seconds.`,
+        retryAfter,
+        details: { requestId },
+      };
+    }
+
+    if (error.response?.status === 422) {
+      const responseData = error.response.data as Record<string, any> || {};
+      return {
+        code: 'INVALID_INPUT',
+        message: `Docs API validation error: ${responseData.message || 'Invalid request data'}`,
+        details: { requestId, validationErrors: responseData },
+      };
+    }
+
+    if (error.response?.status && error.response.status >= 400 && error.response.status < 500) {
+      const responseData = error.response.data as Record<string, any> || {};
+      return {
+        code: 'INVALID_INPUT',
+        message: `Docs API client error: ${responseData.message || 'Invalid request'}`,
+        details: { requestId, statusCode: error.response.status },
+      };
+    }
+
+    if (error.response?.status && error.response.status >= 500) {
+      return {
+        code: 'UPSTREAM_ERROR',
+        message: `Docs API server error (${error.response.status}).`,
+        details: { requestId },
+      };
+    }
+
+    return {
+      code: 'UPSTREAM_ERROR',
+      message: `Docs API error: ${error.message || 'Unknown error'}`,
+      details: { requestId, errorCode: error.code },
+    };
+  }
+
+  /**
+   * GET a paginated list of resources.
+   */
+  async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
+    const cacheKey = `DOCS:GET:${endpoint}`;
+    const cachedResult = cache.get<T>(cacheKey, params);
+    if (cachedResult) return cachedResult;
+
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.get<T>(endpoint, { params }),
+    );
+
+    const ttl = cacheOptions?.ttl ?? this.getDefaultCacheTtl(endpoint);
+    cache.set(cacheKey, params, response.data, { ttl });
+
+    return response.data;
+  }
+
+  /**
+   * GET a single resource, unwrapping the response envelope.
+   * Docs API returns single resources as { "article": {...} }, { "collection": {...} }, etc.
+   */
+  async getOne<T>(endpoint: string, key: string, cacheOptions?: { ttl?: number }): Promise<T> {
+    const cacheKey = `DOCS:GET:${endpoint}`;
+    const cachedResult = cache.get<T>(cacheKey, { key });
+    if (cachedResult) return cachedResult;
+
+    const response = await this.executeWithRetry<Record<string, T>>(() =>
+      this.client.get<Record<string, T>>(endpoint),
+    );
+
+    const data = response.data[key];
+    if (!data) {
+      throw {
+        code: 'NOT_FOUND',
+        message: `Docs API: unexpected response shape, missing key "${key}"`,
+        details: {},
+      } as ApiError;
+    }
+
+    const ttl = cacheOptions?.ttl ?? this.getDefaultCacheTtl(endpoint);
+    cache.set(cacheKey, { key }, data, { ttl });
+
+    return data;
+  }
+
+  /**
+   * POST a new resource. No retries (non-idempotent).
+   */
+  async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(
+      () => this.client.post<T>(endpoint, data),
+      this.noRetryConfig,
+    );
+    this.invalidateCache(endpoint);
+    return response.data;
+  }
+
+  /**
+   * PUT (full update) an existing resource. Retries enabled (idempotent).
+   */
+  async put<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(
+      () => this.client.put<T>(endpoint, data),
+    );
+    this.invalidateCache(endpoint);
+    return response.data;
+  }
+
+  /**
+   * DELETE a resource. Retries enabled (idempotent).
+   */
+  async delete(endpoint: string): Promise<void> {
+    await this.executeWithRetry<void>(
+      () => this.client.delete(endpoint),
+    );
+    this.invalidateCache(endpoint);
+  }
+
+  private invalidateCache(endpoint: string): void {
+    logger.debug('Invalidating Docs cache after write', { endpoint });
+    cache.clear();
+  }
+
+  private getDefaultCacheTtl(endpoint: string): number {
+    if (endpoint.includes('/sites')) return 86400;       // 24 hours
+    if (endpoint.includes('/collections')) return 3600;  // 1 hour
+    if (endpoint.includes('/categories')) return 3600;   // 1 hour
+    if (endpoint.includes('/articles')) return 600;      // 10 minutes
+    if (endpoint.includes('/search')) return 300;        // 5 minutes
+    return 300;
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.get('/collections', { page: 1 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async closePool(): Promise<void> {
+    logger.info('Closing Docs API HTTP connection pool');
+    this.httpAgent.destroy();
+    this.httpsAgent.destroy();
+    await this.sleep(100);
+    logger.info('Docs API HTTP connections closed');
+  }
+}
+
+// Conditionally create client — only when Docs API key is configured
+export const docsClient = config.docs ? new DocsClient() : null;

--- a/src/utils/docs-client.ts
+++ b/src/utils/docs-client.ts
@@ -311,13 +311,14 @@ export class DocsClient {
    * GET a single resource, unwrapping the response envelope.
    * Docs API returns single resources as { "article": {...} }, { "collection": {...} }, etc.
    */
-  async getOne<T>(endpoint: string, key: string, cacheOptions?: { ttl?: number }): Promise<T> {
+  async getOne<T>(endpoint: string, key: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
     const cacheKey = `DOCS:GET:${endpoint}`;
-    const cachedResult = cache.get<T>(cacheKey, { key });
+    const cacheData = { key, ...params };
+    const cachedResult = cache.get<T>(cacheKey, cacheData);
     if (cachedResult) return cachedResult;
 
     const response = await this.executeWithRetry<Record<string, T>>(() =>
-      this.client.get<Record<string, T>>(endpoint),
+      this.client.get<Record<string, T>>(endpoint, { params }),
     );
 
     const data = response.data[key];
@@ -330,7 +331,7 @@ export class DocsClient {
     }
 
     const ttl = cacheOptions?.ttl ?? this.getDefaultCacheTtl(endpoint);
-    cache.set(cacheKey, { key }, data, { ttl });
+    cache.set(cacheKey, cacheData, data, { ttl });
 
     return data;
   }

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -345,6 +345,18 @@ export class HelpScoutClient {
       };
     }
 
+    if (error.response?.status === 412) {
+      return {
+        code: 'INVALID_INPUT',
+        message: 'Help Scout precondition failed. The conversation may have reached the 100-thread limit, or a company policy prevents updates to old conversations.',
+        details: {
+          requestId,
+          statusCode: 412,
+          suggestion: 'Check the conversation thread count and company policies in Help Scout settings',
+        },
+      };
+    }
+
     if (error.response?.status === 422) {
       const responseData = error.response.data as Record<string, any> || {};
       return {
@@ -404,6 +416,52 @@ export class HelpScoutClient {
         suggestion: 'Check your network connection and Help Scout service status',
       },
     };
+  }
+
+  /**
+   * Check response status and throw a structured error for 4xx responses.
+   * Needed because validateStatus allows 4xx through without throwing.
+   */
+  private checkResponseStatus(response: AxiosResponse): void {
+    if (response.status >= 400 && response.status < 500) {
+      const error = new Error(`Request failed with status ${response.status}`) as any;
+      error.response = response;
+      error.config = response.config;
+      throw this.transformError(error as AxiosError);
+    }
+  }
+
+  async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.post<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
+  async patch<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.patch<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
+  /**
+   * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
+   */
+  private invalidateCacheAfterWrite(endpoint: string): void {
+    const match = endpoint.match(/\/conversations\/(\d+)/);
+    if (match) {
+      logger.debug('Invalidating cache after write operation', { endpoint });
+      cache.clear();
+    }
   }
 
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -74,17 +74,24 @@ export class HelpScoutClient {
     maxRetryDelay: 10000, // 10 seconds
     retryCondition: (error: AxiosError) => {
       // Retry on network errors, timeouts, and 5xx responses
-      return !error.response || 
+      return !error.response ||
              error.code === 'ECONNABORTED' ||
              (error.response.status >= 500 && error.response.status < 600) ||
              error.response.status === 429; // Rate limits
     }
   };
 
+  // No-retry config for non-idempotent POST operations (prevent duplicate creates)
+  private noRetryConfig: RetryConfig = {
+    retries: 0,
+    retryDelay: 0,
+    maxRetryDelay: 0,
+  };
+
   constructor(poolConfig: Partial<ConnectionPoolConfig> = {}) {
     // Merge default pool config with any custom settings
     const finalPoolConfig = { ...DEFAULT_POOL_CONFIG, ...poolConfig };
-    
+
     // Create HTTP agents with connection pooling
     this.httpAgent = new HttpAgent({
       keepAlive: finalPoolConfig.keepAlive,
@@ -110,11 +117,11 @@ export class HelpScoutClient {
       httpsAgent: this.httpsAgent,
       // Additional connection optimizations
       maxRedirects: 5,
-      validateStatus: (status) => status < 500, // Don't throw on 4xx errors, handle them in transformError
+      validateStatus: (status) => status >= 200 && status < 300, // Only accept 2xx; non-2xx errors throw as AxiosError for retry logic and transformError
     });
 
     this.setupInterceptors();
-    
+
     logger.info('HTTP connection pool initialized', {
       maxSockets: finalPoolConfig.maxSockets,
       maxFreeSockets: finalPoolConfig.maxFreeSockets,
@@ -139,39 +146,39 @@ export class HelpScoutClient {
     retryConfig: RetryConfig = this.defaultRetryConfig
   ): Promise<AxiosResponse<T>> {
     let lastError: AxiosError | undefined;
-    
+
     for (let attempt = 0; attempt <= retryConfig.retries; attempt++) {
       try {
         return await operation();
       } catch (error) {
         lastError = error as AxiosError;
-        
+
         // Don't retry if it's the last attempt
         if (attempt === retryConfig.retries) {
           break;
         }
-        
+
         // Check if we should retry this error
         if (!retryConfig.retryCondition?.(lastError)) {
           break;
         }
-        
+
         // Handle rate limits specially
         if (lastError.response?.status === 429) {
           const retryAfter = parseInt(lastError.response.headers['retry-after'] || '60', 10) * 1000;
           const delay = Math.min(retryAfter, retryConfig.maxRetryDelay);
-          
+
           logger.warn('Rate limit hit, waiting before retry', {
             attempt: attempt + 1,
             retryAfter: delay,
             requestId: lastError.config?.metadata?.requestId,
           });
-          
+
           await this.sleep(delay);
         } else {
           // Standard exponential backoff
           const delay = this.calculateRetryDelay(attempt, retryConfig.retryDelay, retryConfig.maxRetryDelay);
-          
+
           logger.warn('Request failed, retrying', {
             attempt: attempt + 1,
             totalAttempts: retryConfig.retries + 1,
@@ -180,14 +187,18 @@ export class HelpScoutClient {
             status: lastError.response?.status,
             requestId: lastError.config?.metadata?.requestId,
           });
-          
+
           await this.sleep(delay);
         }
       }
     }
-    
-    // lastError should always be defined here since we only reach this point after catching an error
-    throw lastError || new Error('Request failed without error details');
+
+    // All errors arrive here as raw AxiosError (interceptor passes them through unchanged).
+    // Transform to structured ApiError at this boundary, after all retries are exhausted.
+    if (lastError) {
+      throw this.transformError(lastError);
+    }
+    throw new Error('Request failed without error details');
   }
 
   private setupInterceptors(): void {
@@ -197,16 +208,16 @@ export class HelpScoutClient {
       if (this.accessToken) {
         config.headers.Authorization = `Bearer ${this.accessToken}`;
       }
-      
+
       const requestId = Math.random().toString(36).substring(7);
       config.metadata = { requestId, startTime: Date.now() };
-      
+
       logger.debug('API request', {
         requestId,
         method: config.method?.toUpperCase(),
         url: config.url,
       });
-      
+
       return config;
     });
 
@@ -224,15 +235,18 @@ export class HelpScoutClient {
       (error: AxiosError) => {
         const duration = error.config?.metadata ? Date.now() - error.config.metadata.startTime : 0;
         const requestId = error.config?.metadata?.requestId || 'unknown';
-        
+
         logger.error('API error', {
           requestId,
           status: error.response?.status,
           message: error.message,
           duration,
         });
-        
-        return Promise.reject(this.transformError(error));
+
+        // Pass all errors through as raw AxiosError so executeWithRetry can
+        // inspect .response.status for retry decisions. transformError is called
+        // only after retries are exhausted (in executeWithRetry).
+        return Promise.reject(error);
       }
     );
   }
@@ -332,6 +346,18 @@ export class HelpScoutClient {
       };
     }
 
+    if (error.response?.status === 412) {
+      return {
+        code: 'INVALID_INPUT',
+        message: 'Help Scout precondition failed. The conversation may have reached the 100-thread limit, or a company policy prevents updates to old conversations.',
+        details: {
+          requestId,
+          statusCode: 412,
+          suggestion: 'Check the conversation thread count and company policies in Help Scout settings',
+        },
+      };
+    }
+
     if (error.response?.status === 429) {
       const retryAfter = parseInt(error.response.headers['retry-after'] || '60', 10);
       return {
@@ -341,18 +367,6 @@ export class HelpScoutClient {
         details: {
           requestId,
           suggestion: 'Reduce request frequency or implement request batching',
-        },
-      };
-    }
-
-    if (error.response?.status === 412) {
-      return {
-        code: 'INVALID_INPUT',
-        message: 'Help Scout precondition failed. The conversation may have reached the 100-thread limit, or a company policy prevents updates to old conversations.',
-        details: {
-          requestId,
-          statusCode: 412,
-          suggestion: 'Check the conversation thread count and company policies in Help Scout settings',
         },
       };
     }
@@ -418,38 +432,52 @@ export class HelpScoutClient {
     };
   }
 
-  /**
-   * Check response status and throw a structured error for 4xx responses.
-   * Needed because validateStatus allows 4xx through without throwing.
-   */
-  private checkResponseStatus(response: AxiosResponse): void {
-    if (response.status >= 400 && response.status < 500) {
-      const error = new Error(`Request failed with status ${response.status}`) as any;
-      error.response = response;
-      error.config = response.config;
-      throw this.transformError(error as AxiosError);
-    }
-  }
+  async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
+    const cacheKey = `GET:${endpoint}`;
+    const cachedResult = cache.get<T>(cacheKey, params);
 
-  async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    if (cachedResult) {
+      return cachedResult;
+    }
+
     const response = await this.executeWithRetry<T>(() =>
-      this.client.post<T>(endpoint, data)
+      this.client.get<T>(endpoint, { params })
     );
 
-    this.checkResponseStatus(response);
-    this.invalidateCacheAfterWrite(endpoint);
+    if (cacheOptions?.ttl || cacheOptions?.ttl === 0) {
+      cache.set(cacheKey, params, response.data, { ttl: cacheOptions.ttl });
+    } else {
+      // Default cache TTL based on endpoint
+      const defaultTtl = this.getDefaultCacheTtl(endpoint);
+      cache.set(cacheKey, params, response.data, { ttl: defaultTtl });
+    }
 
     return response.data;
   }
 
-  async patch<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
-    const response = await this.executeWithRetry<T>(() =>
-      this.client.patch<T>(endpoint, data)
+  /**
+   * POST a new resource. Non-idempotent: retries are disabled to prevent duplicates.
+   */
+  async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(
+      () => this.client.post<T>(endpoint, data),
+      this.noRetryConfig
     );
 
-    this.checkResponseStatus(response);
     this.invalidateCacheAfterWrite(endpoint);
+    return response.data;
+  }
 
+  /**
+   * PATCH an existing resource. Idempotent: retries are enabled.
+   */
+  async patch<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(
+      () => this.client.patch<T>(endpoint, data),
+      this.defaultRetryConfig
+    );
+
+    this.invalidateCacheAfterWrite(endpoint);
     return response.data;
   }
 
@@ -464,32 +492,9 @@ export class HelpScoutClient {
     }
   }
 
-  async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
-    const cacheKey = `GET:${endpoint}`;
-    const cachedResult = cache.get<T>(cacheKey, params);
-    
-    if (cachedResult) {
-      return cachedResult;
-    }
-
-    const response = await this.executeWithRetry<T>(() => 
-      this.client.get<T>(endpoint, { params })
-    );
-    
-    if (cacheOptions?.ttl || cacheOptions?.ttl === 0) {
-      cache.set(cacheKey, params, response.data, { ttl: cacheOptions.ttl });
-    } else {
-      // Default cache TTL based on endpoint
-      const defaultTtl = this.getDefaultCacheTtl(endpoint);
-      cache.set(cacheKey, params, response.data, { ttl: defaultTtl });
-    }
-    
-    return response.data;
-  }
-
   private getDefaultCacheTtl(endpoint: string): number {
     if (endpoint.includes('/conversations')) return 300; // 5 minutes
-    if (endpoint.includes('/mailboxes')) return 1440; // 24 hours
+    if (endpoint.includes('/mailboxes')) return 86400; // 24 hours
     if (endpoint.includes('/threads')) return 300; // 5 minutes
     return 300; // Default 5 minutes
   }
@@ -538,15 +543,15 @@ export class HelpScoutClient {
    */
   async closePool(): Promise<void> {
     logger.info('Closing HTTP connection pool');
-    
+
     // Agent.destroy() is synchronous and immediately closes connections
     // so we don't need to wait for async callbacks
     this.httpAgent.destroy();
     this.httpsAgent.destroy();
-    
+
     // Give a small delay to ensure connections are cleaned up
     await this.sleep(100);
-    
+
     logger.info('All HTTP connections closed');
   }
 
@@ -555,11 +560,11 @@ export class HelpScoutClient {
    */
   clearIdleConnections(): void {
     const stats = this.getPoolStats();
-    
+
     // Force destroy all agent connections by recreating them
     this.httpAgent.destroy();
     this.httpsAgent.destroy();
-    
+
     // Recreate agents with same configuration
     const poolConfig = {
       keepAlive: true,
@@ -568,11 +573,15 @@ export class HelpScoutClient {
       maxFreeSockets: 10,
       timeout: 30000,
     };
-    
+
     this.httpAgent = new HttpAgent(poolConfig);
     this.httpsAgent = new HttpsAgent(poolConfig);
 
-    logger.debug('Cleared idle connections', { 
+    // Update Axios instance to use the new agents
+    this.client.defaults.httpAgent = this.httpAgent;
+    this.client.defaults.httpsAgent = this.httpsAgent;
+
+    logger.debug('Cleared idle connections', {
       clearedHttp: stats.http.freeSockets,
       clearedHttps: stats.https.freeSockets,
     });

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -485,7 +485,7 @@ export class HelpScoutClient {
    * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
    */
   private invalidateCacheAfterWrite(endpoint: string): void {
-    const match = endpoint.match(/\/conversations\/(\d+)/);
+    const match = endpoint.match(/\/conversations/);
     if (match) {
       logger.debug('Invalidating cache after write operation', { endpoint });
       cache.clear();


### PR DESCRIPTION
## Summary
This PR significantly expands the Help Scout MCP server with three major feature additions: customer management tools, organization tools, and a complete Help Scout Docs API integration. It also introduces write operation support (gated behind `HELPSCOUT_ENABLE_WRITES` environment variable) and improves date handling for timezone-aware ISO 8601 formats.

## Key Changes

### Customer Management Tools (NAS-680, NAS-727, NAS-728)
- Added `getCustomer` - retrieve customer profile by ID
- Added `listCustomers` - search/list customers with pagination and filtering
- Added `searchCustomersByEmail` - dedicated email search using v3 API with cursor pagination
- Added `getCustomerContacts` - fetch all contact details (emails, phones, chats, social profiles, websites, address) from sub-resource endpoints
- Added customer schema types with embedded contact data structures

### Organization Tools (NAS-684, NAS-712)
- Added `getOrganization` - retrieve org details with optional customer/conversation counts
- Added `listOrganizations` - list all organizations with sorting options
- Added `getOrganizationMembers` - get customers belonging to an organization
- Added `getOrganizationConversations` - traverse org-to-conversations relationships
- Added organization schema types

### Help Scout Docs API Integration
- Created new `DocsToolHandler` class in `src/tools/docs.ts` with full CRUD operations
- Added `DocsClient` HTTP client with retry logic, connection pooling, and Basic Auth
- Implemented 20+ Docs tools: sites, collections, categories, articles, revisions, redirects
- Added comprehensive Docs schema types in `src/schema/docs-types.ts`
- Docs tools are conditionally listed based on `HELPSCOUT_DOCS_API_KEY` configuration

### Write Operations Support
- Gated all write tools behind `HELPSCOUT_ENABLE_WRITES=true` environment variable
- Added write tools: `createReply`, `createNote`, `updateConversationStatus`, `createConversation`, `assignConversation`
- Added utility tools: `listUsers`, `listMailboxes`
- Write tools default to draft mode for safety (e.g., `createReply` with `draft: true`)
- Added comprehensive test suite for write operations in `src/__tests__/write-tools.test.ts`
- Implemented no-retry config for non-idempotent POST operations to prevent duplicate creates

### Date Handling Improvements
- Updated ISO 8601 date regex to support timezone offsets: `[+-]HH:MM` and `Z`
- Fixed date normalization to preserve timezone information when stripping milliseconds
- Improved `buildDateQuery` to handle timezone-aware dates correctly

### API & Schema Updates
- Fixed conversation sort field from `updatedAt` to `modifiedAt` (Help Scout API change)
- Removed `includeVariations` parameter from multi-status search (no longer supported)
- Added numeric validation for conversation IDs (must be numeric strings)
- Reorganized imports in `src/tools/index.ts` for better maintainability
- Updated `HelpScoutClient` to only accept 2xx responses (stricter validation)

### Configuration & Infrastructure
- Extended `Config` interface to support Docs API configuration
- Added `PII_REDACTED_BODY` constant for message content redaction
- Updated version to 1.7.0
- Improved connection pool configuration consistency across clients

## Implementation Details
- Both `HelpScoutClient` and `DocsClient` use exponential backoff with jitter for retries
- Docs API uses HTTP Basic Auth (API key as username, 'X' as password)
- Write operations include detailed warnings about irreversible actions
- All tools include comprehensive input validation via Zod schemas
- Conditional tool registration based on environment variables ensures clean API surface

https://claude.ai/code/session_018XCk9FyQ14VYtDigfECAFE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
