### PR TITLE
feat: add getThreadOriginalSource tool for raw email headers (SUP-974)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ docker run -e HELPSCOUT_APP_ID="your-app-id" \
 
 1. Go to **Help Scout** > **My Apps** > **Create Private App**
 2. Select at minimum: **Read** access to Mailboxes, Conversations, Customers, and Organizations
-3. Copy your **App ID** and **App Secret**
+3. For write tools: also grant **Write** access to Conversations
+4. Copy your **App ID** and **App Secret**
 
 > Help Scout uses OAuth2 Client Credentials flow exclusively. Personal Access Tokens are not supported.
 
@@ -110,6 +111,22 @@ Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `
 | Full message history | `getThreads` | "Show me the complete thread" |
 | Current server time | `getServerTime` | Used for time-relative searches |
 
+### Write Tools (Opt-in)
+
+These tools require `HELPSCOUT_ENABLE_WRITES=true` and are hidden when writes are disabled.
+
+| Task | Tool | Example |
+|------|------|---------|
+| Reply to a conversation | `createReply` | "Draft a reply to ticket #123" |
+| Change ticket status | `updateConversationStatus` | "Close ticket #123" |
+| Add internal note | `createNote` | "Add a note to ticket #123" |
+
+**Safety defaults:**
+- `createReply` defaults to **draft mode** (`draft: true`). Drafts must be manually sent from the Help Scout UI.
+- Setting `draft: false` sends a real email immediately and **cannot be undone**.
+- `createNote` creates internal notes only visible to support agents, never sent to customers.
+- Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close).
+
 Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in their instructions automatically, so no lookup step is needed.
 
 ## Configuration
@@ -120,6 +137,7 @@ Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in
 | `HELPSCOUT_APP_SECRET` | App Secret from Help Scout My Apps | Required |
 | `HELPSCOUT_DEFAULT_INBOX_ID` | Scope searches to a specific inbox | None (all inboxes) |
 | `HELPSCOUT_BASE_URL` | Help Scout API endpoint | `https://api.helpscout.net/v2/` |
+| `HELPSCOUT_ENABLE_WRITES` | Enable write tools (reply, note, status update) | `false` |
 | `REDACT_MESSAGE_CONTENT` | Hide message bodies in responses | `false` |
 | `CACHE_TTL_SECONDS` | Cache duration for API responses | `300` |
 | `LOG_LEVEL` | Logging verbosity (`error`, `warn`, `info`, `debug`) | `info` |

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ export default {
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.ts$': ['ts-jest', {
       useESM: true,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,9 @@
+// jest setup: runs once before any test module loads.
+// Required because src/utils/config.ts reads process.env at module-init time;
+// setting env in a test's beforeEach is too late — by then the config singleton
+// has already frozen empty credential strings, causing OAuth auth to fail
+// before nock-mocked endpoints can ever respond.
+process.env.NODE_ENV = 'test';
+process.env.HELPSCOUT_CLIENT_ID = 'test-client-id';
+process.env.HELPSCOUT_CLIENT_SECRET = 'test-client-secret';
+process.env.HELPSCOUT_BASE_URL = 'https://api.helpscout.net/v2/';

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,6 +1,28 @@
 // Mock all dependencies BEFORE importing the module under test
 jest.mock('../utils/config.js', () => ({
   validateConfig: jest.fn(),
+  // production code reads config.writes.enabled (added in PR #23) and other config branches —
+  // the mock must mirror that shape or the SUT crashes on undefined property reads
+  config: {
+    helpscout: {
+      apiKey: '',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      baseUrl: 'https://api.helpscout.net/v2/',
+      defaultInboxId: undefined,
+    },
+    cache: { ttlSeconds: 300, maxSize: 10000 },
+    logging: { level: 'info' },
+    security: { allowPii: true },
+    writes: { enabled: false },
+    connectionPool: {
+      maxSockets: 50,
+      maxFreeSockets: 10,
+      timeout: 30000,
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+    },
+  },
 }));
 
 jest.mock('../utils/logger.js', () => ({

--- a/src/__tests__/rfc822.test.ts
+++ b/src/__tests__/rfc822.test.ts
@@ -1,0 +1,109 @@
+import { parseRfc822 } from '../utils/rfc822.js';
+
+describe('parseRfc822', () => {
+  it('parses a basic message with CRLF line endings', () => {
+    const raw = [
+      'From: alice@example.com',
+      'To: bob@example.com',
+      'Subject: hello',
+      '',
+      'Hi there.',
+    ].join('\r\n');
+
+    const result = parseRfc822(raw);
+
+    expect(result.headers['From']).toBe('alice@example.com');
+    expect(result.headers['To']).toBe('bob@example.com');
+    expect(result.headers['Subject']).toBe('hello');
+    expect(result.body).toBe('Hi there.');
+  });
+
+  it('handles LF-only line endings', () => {
+    const raw = 'Subject: lf-only\n\nbody';
+    expect(parseRfc822(raw).headers['Subject']).toBe('lf-only');
+    expect(parseRfc822(raw).body).toBe('body');
+  });
+
+  it('handles CR-only line endings', () => {
+    const raw = 'Subject: cr-only\r\rbody';
+    expect(parseRfc822(raw).headers['Subject']).toBe('cr-only');
+    expect(parseRfc822(raw).body).toBe('body');
+  });
+
+  it('unfolds continuation lines (single space and tab)', () => {
+    const raw = [
+      'Subject: a very long subject',
+      ' that wraps to',
+      '\ta third physical line',
+      '',
+      '',
+    ].join('\r\n');
+
+    const result = parseRfc822(raw);
+    expect(result.headers['Subject']).toBe('a very long subject that wraps to a third physical line');
+  });
+
+  it('collapses repeated headers into an array preserving order', () => {
+    const raw = [
+      'Received: from a',
+      'Received: from b',
+      'Received: from c',
+      '',
+      '',
+    ].join('\r\n');
+
+    const result = parseRfc822(raw);
+    expect(result.headers['Received']).toEqual(['from a', 'from b', 'from c']);
+  });
+
+  it('captures auto-reply headers used by the noise gate', () => {
+    const raw = [
+      'From: noreply@foo.com',
+      'Auto-Submitted: auto-replied',
+      'Precedence: bulk',
+      'X-Autoreply: yes',
+      '',
+      '',
+    ].join('\r\n');
+
+    const result = parseRfc822(raw);
+    expect(result.headers['Auto-Submitted']).toBe('auto-replied');
+    expect(result.headers['Precedence']).toBe('bulk');
+    expect(result.headers['X-Autoreply']).toBe('yes');
+  });
+
+  it('returns an empty body when no separator blank line is present', () => {
+    const raw = 'Subject: only-headers';
+    const result = parseRfc822(raw);
+    expect(result.headers['Subject']).toBe('only-headers');
+    expect(result.body).toBe('');
+  });
+
+  it('preserves blank lines inside the body', () => {
+    const raw = ['Subject: x', '', 'line1', '', 'line2'].join('\r\n');
+    const result = parseRfc822(raw);
+    expect(result.body).toBe('line1\n\nline2');
+  });
+
+  it('skips malformed header lines without a colon', () => {
+    // `From bob@example.com ...` is the unix-mbox envelope line and has no colon
+    const raw = [
+      'From bob@example.com Thu May  8 10:00:00 2026',
+      'From: bob@example.com',
+      'Subject: hi',
+      '',
+      'body',
+    ].join('\r\n');
+
+    const result = parseRfc822(raw);
+    // the envelope line is dropped; the real From: header survives
+    expect(result.headers['From']).toBe('bob@example.com');
+    expect(result.headers['Subject']).toBe('hi');
+  });
+
+  it('preserves header values that contain colons', () => {
+    const raw = ['Date: Thu, 8 May 2026 10:00:00 +0000', '', ''].join('\r\n');
+    const result = parseRfc822(raw);
+    expect(result.headers['Date']).toBe('Thu, 8 May 2026 10:00:00 +0000');
+  });
+});

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -38,8 +38,8 @@ describe('ToolHandler', () => {
       delete process.env.HELPSCOUT_ENABLE_WRITES;
       const tools = await toolHandler.listTools();
 
-      // 17 read-only tools when writes are disabled
-      expect(tools).toHaveLength(17);
+      // 18 read-only tools when writes are disabled
+      expect(tools).toHaveLength(18);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -47,6 +47,7 @@ describe('ToolHandler', () => {
         'getThreads',
         'getServerTime',
         'listAllInboxes',
+        'listTags',
         'advancedConversationSearch',
         'comprehensiveConversationSearch',
         'structuredConversationFilter',
@@ -63,6 +64,7 @@ describe('ToolHandler', () => {
       expect(tools.map(t => t.name)).not.toContain('createReply');
       expect(tools.map(t => t.name)).not.toContain('createNote');
       expect(tools.map(t => t.name)).not.toContain('updateConversationStatus');
+      expect(tools.map(t => t.name)).not.toContain('updateConversationTags');
     });
 
     it('should have proper tool schemas', async () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -34,9 +34,11 @@ describe('ToolHandler', () => {
   });
 
   describe('listTools', () => {
-    it('should return all available tools', async () => {
+    it('should return all available tools (read-only when writes disabled)', async () => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
       const tools = await toolHandler.listTools();
-      
+
+      // 17 read-only tools when writes are disabled
       expect(tools).toHaveLength(17);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
@@ -57,6 +59,10 @@ describe('ToolHandler', () => {
         'getOrganizationMembers',
         'getOrganizationConversations',
       ]);
+      // Write tools should NOT be present
+      expect(tools.map(t => t.name)).not.toContain('createReply');
+      expect(tools.map(t => t.name)).not.toContain('createNote');
+      expect(tools.map(t => t.name)).not.toContain('updateConversationStatus');
     });
 
     it('should have proper tool schemas', async () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { ToolHandler } from '../tools/index.js';
+import { config } from '../utils/config.js';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
 describe('ToolHandler', () => {
@@ -38,13 +39,14 @@ describe('ToolHandler', () => {
       delete process.env.HELPSCOUT_ENABLE_WRITES;
       const tools = await toolHandler.listTools();
 
-      // 18 read-only tools when writes are disabled
-      expect(tools).toHaveLength(18);
+      // 19 read-only tools when writes are disabled
+      expect(tools).toHaveLength(19);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
         'getConversationSummary',
         'getThreads',
+        'getThreadOriginalSource',
         'getServerTime',
         'listAllInboxes',
         'listTags',
@@ -685,6 +687,111 @@ describe('ToolHandler', () => {
         const response = JSON.parse(textContent.text);
         expect(response.conversationId).toBe(conversationId);
         expect(response.threads).toHaveLength(2);
+      }
+    });
+  });
+
+  describe('getThreadOriginalSource', () => {
+    // a small but realistic raw message exercising header folding (Subject)
+    // and a repeated header (Received) to verify the parser handles both
+    const rawMessage = [
+      'Received: from mx1.example.com by inbound.example.net',
+      '\twith ESMTPS id ABC123 for <support@cloud66.com>;',
+      '\tThu, 8 May 2026 10:00:00 +0000',
+      'Received: from sender.example.com by mx1.example.com',
+      '\twith ESMTPS id DEF456;',
+      '\tThu, 8 May 2026 09:59:55 +0000',
+      'From: noreply@vendor.example.com',
+      'To: support@cloud66.com',
+      'Subject: Re: Out of office',
+      ' (auto-reply)',
+      'Auto-Submitted: auto-replied',
+      'Precedence: bulk',
+      'X-Autoreply: yes',
+      '',
+      'I am out of the office until next week.',
+      '',
+      '-- vendor team',
+    ].join('\r\n');
+
+    it('should fetch RFC 822 source and return parsed headers', async () => {
+      const conversationId = '888';
+      const threadId = '777';
+
+      // Help Scout requires Accept: message/rfc822 for the raw source endpoint
+      const scope = nock(baseURL, {
+        reqheaders: {
+          accept: 'message/rfc822',
+        },
+      })
+        .get(`/conversations/${conversationId}/threads/${threadId}/original-source`)
+        .reply(200, rawMessage, { 'Content-Type': 'message/rfc822' });
+
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'getThreadOriginalSource',
+          arguments: { conversationId, threadId },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+
+      expect(result.isError).toBeFalsy();
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+
+      expect(response.conversationId).toBe(conversationId);
+      expect(response.threadId).toBe(threadId);
+      // headers the noise gate Stage 1A actually checks
+      expect(response.headers['Auto-Submitted']).toBe('auto-replied');
+      expect(response.headers['Precedence']).toBe('bulk');
+      expect(response.headers['X-Autoreply']).toBe('yes');
+      // folded Subject: continuation must be merged into the original line
+      expect(response.headers['Subject']).toBe('Re: Out of office (auto-reply)');
+      // repeated header collapses to an array preserving order
+      expect(Array.isArray(response.headers['Received'])).toBe(true);
+      expect(response.headers['Received']).toHaveLength(2);
+      // body is excluded by default
+      expect(response.body).toBeUndefined();
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('should redact body when includeBody=true and PII redaction is enabled', async () => {
+      const conversationId = '866';
+      const threadId = '755';
+
+      // toggle redaction directly on the loaded config — env vars are read once
+      // at module load time, so other tests in the file follow this same pattern
+      const originalAllowPii = config.security.allowPii;
+      config.security.allowPii = false;
+
+      try {
+        nock(baseURL, { reqheaders: { accept: 'message/rfc822' } })
+          .get(`/conversations/${conversationId}/threads/${threadId}/original-source`)
+          .reply(200, rawMessage, { 'Content-Type': 'message/rfc822' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'getThreadOriginalSource',
+            arguments: { conversationId, threadId, includeBody: true },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBeFalsy();
+        const textContent = result.content[0] as { type: 'text'; text: string };
+        const response = JSON.parse(textContent.text);
+
+        // headers always returned in the clear (no message-content PII risk
+        // beyond what getThreads already exposes via customer.email)
+        expect(response.headers['Auto-Submitted']).toBe('auto-replied');
+        // body present but redacted to the placeholder string
+        expect(response.body).toBe('[Content hidden - set REDACT_MESSAGE_CONTENT=false to view]');
+      } finally {
+        config.security.allowPii = originalAllowPii;
       }
     });
   });

--- a/src/__tests__/write-tools.test.ts
+++ b/src/__tests__/write-tools.test.ts
@@ -44,6 +44,23 @@ describe('Write Tools', () => {
       expect(toolNames).not.toContain('createReply');
       expect(toolNames).not.toContain('updateConversationStatus');
       expect(toolNames).not.toContain('createNote');
+      expect(toolNames).not.toContain('updateConversationTags');
+    });
+
+    it('should return error when calling updateConversationTags with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'updateConversationTags',
+          arguments: {
+            conversationId: '123',
+            tags: ['billing'],
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
     });
 
     it('should return error when calling createReply with writes disabled', async () => {
@@ -349,6 +366,262 @@ describe('Write Tools', () => {
 
         const result = await toolHandler.callTool(request);
         expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('updateConversationTags', () => {
+      it('should add tags to existing set by default (mode=add)', async () => {
+        // GET conversation returns existing tags as objects
+        nock(baseURL)
+          .get('/conversations/123')
+          .reply(200, {
+            id: 123,
+            number: 9001,
+            subject: 'Existing convo',
+            status: 'active',
+            tags: [
+              { id: 1, name: 'billing', color: '#ff0000' },
+              { id: 2, name: 'urgent', color: '#000000' },
+            ],
+            mailbox: { id: 99, name: 'Support' },
+            threads: 3,
+          });
+
+        const putScope = nock(baseURL)
+          .put('/conversations/123/tags', (body: any) => {
+            // expect union of existing + new, in existing-order then additions
+            expect(body.tags).toEqual(['billing', 'urgent', 'refund-requested']);
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationTags',
+            arguments: {
+              conversationId: '123',
+              tags: ['refund-requested'],
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.action).toBe('tags_updated');
+        expect(parsed.mode).toBe('add');
+        expect(parsed.previousTags).toEqual(['billing', 'urgent']);
+        expect(parsed.appliedTags).toEqual(['billing', 'urgent', 'refund-requested']);
+        expect(parsed.warning).toBeUndefined();
+        expect(putScope.isDone()).toBe(true);
+      });
+
+      it('should not duplicate tags when adding one that already exists', async () => {
+        nock(baseURL)
+          .get('/conversations/123')
+          .reply(200, {
+            id: 123,
+            number: 9001,
+            subject: 'x',
+            status: 'active',
+            tags: [{ id: 1, name: 'billing', color: '#ff0000' }],
+            mailbox: { id: 99, name: 'Support' },
+            threads: 1,
+          });
+
+        const putScope = nock(baseURL)
+          .put('/conversations/123/tags', (body: any) => {
+            expect(body.tags).toEqual(['billing']);
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationTags',
+            arguments: {
+              conversationId: '123',
+              tags: ['billing'],
+              mode: 'add',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+        expect(parsed.appliedTags).toEqual(['billing']);
+        expect(putScope.isDone()).toBe(true);
+      });
+
+      it('should remove tags from existing set in remove mode', async () => {
+        nock(baseURL)
+          .get('/conversations/456')
+          .reply(200, {
+            id: 456,
+            number: 9002,
+            subject: 'x',
+            status: 'active',
+            tags: [
+              { id: 1, name: 'billing', color: '#ff0000' },
+              { id: 2, name: 'urgent', color: '#000000' },
+              { id: 3, name: 'vip', color: '#00ff00' },
+            ],
+            mailbox: { id: 99, name: 'Support' },
+            threads: 2,
+          });
+
+        const putScope = nock(baseURL)
+          .put('/conversations/456/tags', (body: any) => {
+            expect(body.tags).toEqual(['billing', 'vip']);
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationTags',
+            arguments: {
+              conversationId: '456',
+              tags: ['urgent'],
+              mode: 'remove',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('remove');
+        expect(parsed.appliedTags).toEqual(['billing', 'vip']);
+        expect(putScope.isDone()).toBe(true);
+      });
+
+      it('should replace all tags in replace mode without reading existing', async () => {
+        // crucially, replace mode should NOT issue a GET — only a PUT
+        const putScope = nock(baseURL)
+          .put('/conversations/789/tags', (body: any) => {
+            expect(body.tags).toEqual(['handled', 'closed-no-action']);
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationTags',
+            arguments: {
+              conversationId: '789',
+              tags: ['handled', 'closed-no-action'],
+              mode: 'replace',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('replace');
+        expect(parsed.appliedTags).toEqual(['handled', 'closed-no-action']);
+        expect(parsed.previousTags).toBeUndefined();
+        expect(parsed.warning).toContain('discarded');
+        expect(putScope.isDone()).toBe(true);
+        // verify no pending GET mocks were left over
+        expect(nock.pendingMocks().filter(m => m.includes('GET'))).toHaveLength(0);
+      });
+
+      it('should reject empty tags array', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationTags',
+            arguments: {
+              conversationId: '123',
+              tags: [],
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should reject invalid mode', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationTags',
+            arguments: {
+              conversationId: '123',
+              tags: ['x'],
+              mode: 'nuke',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('listTags', () => {
+      // listTags is a pure read operation — should work even with writes disabled,
+      // but we test it here alongside the other tag-related tools for cohesion
+      it('should list tags from /tags endpoint and surface name/slug/color/ticketCount', async () => {
+        const scope = nock(baseURL)
+          .get('/tags')
+          .query({ page: 1 })
+          .reply(200, {
+            _embedded: {
+              tags: [
+                { id: 1, name: 'billing', slug: 'billing', color: '#ff0000', ticketCount: 42 },
+                { id: 2, name: 'urgent', slug: 'urgent', color: '#000000', ticketCount: 7 },
+              ],
+            },
+            page: { size: 50, totalElements: 2, totalPages: 1, number: 1 },
+          });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: { name: 'listTags', arguments: {} },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.returnedCount).toBe(2);
+        expect(parsed.tags[0]).toEqual({
+          id: 1,
+          name: 'billing',
+          slug: 'billing',
+          color: '#ff0000',
+          ticketCount: 42,
+        });
+        expect(parsed.usage).toContain('updateConversationTags');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should accept an explicit page parameter', async () => {
+        const scope = nock(baseURL)
+          .get('/tags')
+          .query({ page: 3 })
+          .reply(200, { _embedded: { tags: [] }, page: { size: 50, totalElements: 0, totalPages: 0, number: 3 } });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: { name: 'listTags', arguments: { page: 3 } },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.returnedCount).toBe(0);
+        expect(scope.isDone()).toBe(true);
       });
     });
 

--- a/src/__tests__/write-tools.test.ts
+++ b/src/__tests__/write-tools.test.ts
@@ -125,7 +125,7 @@ describe('Write Tools', () => {
     });
 
     describe('createReply', () => {
-      it('should create a draft reply by default', async () => {
+      it('should always send draft=true to Help Scout (no parameter to override)', async () => {
         const scope = nock(baseURL)
           .post('/conversations/123/reply', (body: any) => {
             expect(body.text).toBe('Hello customer');
@@ -153,13 +153,17 @@ describe('Write Tools', () => {
         expect(parsed.success).toBe(true);
         expect(parsed.mode).toBe('draft');
         expect(parsed.action).toBe('reply_created');
+        expect(parsed.message).toContain('cannot send mail directly');
         expect(scope.isDone()).toBe(true);
       });
 
-      it('should create a sent reply when draft=false', async () => {
+      // defence in depth: a confused agent should not be able to send a real email
+      // by passing draft:false. The schema strips unknown keys (zod default) and the
+      // handler hardcodes draft:true regardless of input.
+      it('should ignore draft=false in input and still send draft=true to Help Scout', async () => {
         const scope = nock(baseURL)
           .post('/conversations/456/reply', (body: any) => {
-            expect(body.draft).toBe(false);
+            expect(body.draft).toBe(true);
             return true;
           })
           .reply(201);
@@ -170,7 +174,7 @@ describe('Write Tools', () => {
             name: 'createReply',
             arguments: {
               conversationId: '456',
-              text: 'Sent reply',
+              text: 'Attempted send',
               customer: { email: 'customer@example.com' },
               draft: false,
             },
@@ -181,8 +185,7 @@ describe('Write Tools', () => {
         const parsed = JSON.parse((result.content[0] as any).text);
 
         expect(parsed.success).toBe(true);
-        expect(parsed.mode).toBe('sent');
-        expect(parsed.warning).toContain('cannot be undone');
+        expect(parsed.mode).toBe('draft');
         expect(scope.isDone()).toBe(true);
       });
 
@@ -566,6 +569,75 @@ describe('Write Tools', () => {
 
         const result = await toolHandler.callTool(request);
         expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('createConversation', () => {
+      it('should always create with status=pending (draft) regardless of input', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations', (body: any) => {
+            expect(body.subject).toBe('Test subject');
+            expect(body.status).toBe('pending');
+            expect(body.type).toBe('email');
+            expect(body.customer.email).toBe('new@example.com');
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createConversation',
+            arguments: {
+              subject: 'Test subject',
+              customer: { email: 'new@example.com' },
+              mailboxId: '99',
+              text: 'Body text',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.action).toBe('conversation_created');
+        expect(parsed.mode).toBe('draft');
+        expect(parsed.message).toContain('cannot send mail directly');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      // defence in depth: a confused agent should not be able to send a real email
+      // by passing draft:false. zod strips the unknown key and the handler hardcodes
+      // status='pending'.
+      it('should ignore draft=false in input and still create as pending', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations', (body: any) => {
+            expect(body.status).toBe('pending');
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createConversation',
+            arguments: {
+              subject: 'Test subject',
+              customer: { email: 'new@example.com' },
+              mailboxId: '99',
+              text: 'Body text',
+              draft: false,
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('draft');
+        expect(scope.isDone()).toBe(true);
       });
     });
 

--- a/src/__tests__/write-tools.test.ts
+++ b/src/__tests__/write-tools.test.ts
@@ -1,0 +1,420 @@
+import nock from 'nock';
+import { ToolHandler } from '../tools/index.js';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+describe('Write Tools', () => {
+  let toolHandler: ToolHandler;
+  const baseURL = 'https://api.helpscout.net/v2';
+
+  beforeEach(() => {
+    process.env.HELPSCOUT_CLIENT_ID = 'test-client-id';
+    process.env.HELPSCOUT_CLIENT_SECRET = 'test-client-secret';
+    process.env.HELPSCOUT_BASE_URL = `${baseURL}/`;
+
+    nock.cleanAll();
+
+    // Mock OAuth2 authentication
+    // The auth endpoint is hardcoded to https://api.helpscout.net/v2/oauth2/token
+    nock(baseURL)
+      .persist()
+      .post('/oauth2/token')
+      .reply(200, {
+        access_token: 'mock-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+    toolHandler = new ToolHandler();
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  describe('when writes are disabled', () => {
+    beforeEach(() => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
+    });
+
+    it('should not list write tools when writes are disabled', async () => {
+      const tools = await toolHandler.listTools();
+      const toolNames = tools.map(t => t.name);
+
+      expect(toolNames).not.toContain('createReply');
+      expect(toolNames).not.toContain('updateConversationStatus');
+      expect(toolNames).not.toContain('createNote');
+    });
+
+    it('should return error when calling createReply with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'createReply',
+          arguments: {
+            conversationId: '123',
+            text: 'Hello',
+            customer: { email: 'test@example.com' },
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.error.message).toContain('Write operations are disabled');
+    });
+
+    it('should return error when calling createNote with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'createNote',
+          arguments: {
+            conversationId: '123',
+            text: 'Internal note',
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return error when calling updateConversationStatus with writes disabled', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'updateConversationStatus',
+          arguments: {
+            conversationId: '123',
+            status: 'closed',
+          },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('when writes are enabled', () => {
+    beforeEach(() => {
+      process.env.HELPSCOUT_ENABLE_WRITES = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.HELPSCOUT_ENABLE_WRITES;
+    });
+
+    describe('createReply', () => {
+      it('should create a draft reply by default', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/reply', (body: any) => {
+            expect(body.text).toBe('Hello customer');
+            expect(body.customer.email).toBe('test@example.com');
+            expect(body.draft).toBe(true);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello customer',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('draft');
+        expect(parsed.action).toBe('reply_created');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should create a sent reply when draft=false', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/456/reply', (body: any) => {
+            expect(body.draft).toBe(false);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '456',
+              text: 'Sent reply',
+              customer: { email: 'customer@example.com' },
+              draft: false,
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.mode).toBe('sent');
+        expect(parsed.warning).toContain('cannot be undone');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should include cc and bcc when provided', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/reply', (body: any) => {
+            expect(body.cc).toEqual(['cc@example.com']);
+            expect(body.bcc).toEqual(['bcc@example.com']);
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Reply with cc',
+              customer: { email: 'test@example.com' },
+              cc: ['cc@example.com'],
+              bcc: ['bcc@example.com'],
+            },
+          },
+        };
+
+        await toolHandler.callTool(request);
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject invalid customer email', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello',
+              customer: { email: 'not-an-email' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should reject empty text', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: '',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('updateConversationStatus', () => {
+      it('should update conversation status to closed', async () => {
+        const scope = nock(baseURL)
+          .patch('/conversations/123', (body: any) => {
+            expect(body.op).toBe('replace');
+            expect(body.path).toBe('/status');
+            expect(body.value).toBe('closed');
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '123',
+              status: 'closed',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.newStatus).toBe('closed');
+        expect(parsed.warning).toContain('automations');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should update conversation status to active', async () => {
+        const scope = nock(baseURL)
+          .patch('/conversations/789', (body: any) => {
+            expect(body.value).toBe('active');
+            return true;
+          })
+          .reply(204);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '789',
+              status: 'active',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.warning).toBeUndefined();
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject invalid status', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '123',
+              status: 'spam',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('createNote', () => {
+      it('should create an internal note', async () => {
+        const scope = nock(baseURL)
+          .post('/conversations/123/notes', (body: any) => {
+            expect(body.text).toBe('Internal note text');
+            return true;
+          })
+          .reply(201);
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: 'Internal note text',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        const parsed = JSON.parse((result.content[0] as any).text);
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.action).toBe('note_created');
+        expect(parsed.message).toContain('only visible to support agents');
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it('should reject empty note text', async () => {
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: '',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle 412 precondition failed (thread limit)', async () => {
+        nock(baseURL)
+          .post('/conversations/123/notes')
+          .reply(412, { message: 'Thread limit exceeded' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createNote',
+            arguments: {
+              conversationId: '123',
+              text: 'Note',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse((result.content[0] as any).text);
+        expect(parsed.error.message).toContain('precondition failed');
+      });
+
+      it('should handle 422 validation error', async () => {
+        nock(baseURL)
+          .post('/conversations/123/reply')
+          .reply(422, { message: 'Invalid request' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'createReply',
+            arguments: {
+              conversationId: '123',
+              text: 'Hello',
+              customer: { email: 'test@example.com' },
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+
+      it('should handle 404 not found', async () => {
+        nock(baseURL)
+          .patch('/conversations/999')
+          .reply(404, { message: 'Not found' });
+
+        const request: CallToolRequest = {
+          method: 'tools/call',
+          params: {
+            name: 'updateConversationStatus',
+            arguments: {
+              conversationId: '999',
+              status: 'active',
+            },
+          },
+        };
+
+        const result = await toolHandler.callTool(request);
+        expect(result.isError).toBe(true);
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { validateConfig } from './utils/config.js';
+import { validateConfig, config } from './utils/config.js';
 import { logger } from './utils/logger.js';
 import { helpScoutClient, type PaginatedResponse } from './utils/helpscout-client.js';
 import { resourceHandler } from './resources/index.js';
@@ -108,7 +108,21 @@ ${inboxes.length > 0 ? inboxList : '  No inboxes found - check API credentials'}
 ## Notes
 - Always use inbox IDs from the list above (not names)
 - All search tools default to active+pending+closed statuses
-- Use getServerTime for date-relative queries`;
+- Use getServerTime for date-relative queries
+${config.writes.enabled ? `
+## Write Tools (ENABLED)
+| Task | Tool |
+|------|------|
+| Reply to a conversation | createReply (defaults to draft mode) |
+| Change ticket status | updateConversationStatus |
+| Add internal note | createNote |
+
+### Safety
+- **createReply defaults to draft=true** — drafts must be sent manually from Help Scout UI
+- Setting draft=false sends a real email immediately and CANNOT be undone
+- Notes are internal only and never visible to customers
+- Status changes may trigger Help Scout automations` : ''}`;
+
 
       logger.info('Inbox discovery successful', { inboxCount: inboxes.length });
       return { instructions, inboxes };

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -314,11 +314,25 @@ export const AssignConversationInputSchema = z.object({
   assigneeId: z.string().min(1, 'Assignee user ID is required'),
 });
 
+// Tag amendment input. mode controls how `tags` interacts with the conversation's existing tags:
+//   add     → union of existing + provided (default: matches "amend" intent)
+//   remove  → existing minus provided
+//   replace → exactly the provided list, discarding everything else (destructive)
+export const UpdateConversationTagsInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  tags: z.array(z.string().min(1, 'Tag names cannot be empty')).min(1, 'At least one tag is required'),
+  mode: z.enum(['add', 'remove', 'replace']).default('add'),
+});
+
 export const ListUsersInputSchema = z.object({
   page: z.number().min(1).default(1),
 });
 
 export const ListMailboxesInputSchema = z.object({
+  page: z.number().min(1).default(1),
+});
+
+export const ListTagsInputSchema = z.object({
   page: z.number().min(1).default(1),
 });
 
@@ -371,8 +385,10 @@ export type UpdateConversationStatusInput = z.infer<typeof UpdateConversationSta
 export type CreateNoteInput = z.infer<typeof CreateNoteInputSchema>;
 export type CreateConversationInput = z.infer<typeof CreateConversationInputSchema>;
 export type AssignConversationInput = z.infer<typeof AssignConversationInputSchema>;
+export type UpdateConversationTagsInput = z.infer<typeof UpdateConversationTagsInputSchema>;
 export type ListUsersInput = z.infer<typeof ListUsersInputSchema>;
 export type ListMailboxesInput = z.infer<typeof ListMailboxesInputSchema>;
+export type ListTagsInput = z.infer<typeof ListTagsInputSchema>;
 export type User = z.infer<typeof UserSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -274,13 +274,15 @@ export const ListAllInboxesInputSchema = z.object({
 });
 
 // Write Operation Input Schemas
+// Draft-only reply: the `draft` flag is intentionally NOT in this schema.
+// The handler unconditionally sends draft=true to Help Scout, so the agent
+// has no way to send a real email through this tool.
 export const CreateReplyInputSchema = z.object({
   conversationId: z.string().min(1, 'conversationId is required'),
   text: z.string().min(1, 'Reply text is required'),
   customer: z.object({
     email: z.string().email('Valid customer email is required'),
   }),
-  draft: z.boolean().default(true),
   cc: z.array(z.string().email('Each CC entry must be a valid email')).optional(),
   bcc: z.array(z.string().email('Each BCC entry must be a valid email')).optional(),
 });
@@ -295,6 +297,10 @@ export const CreateNoteInputSchema = z.object({
   text: z.string().min(1, 'Note text is required'),
 });
 
+// Draft-only conversation: same lockdown as CreateReplyInputSchema. The `draft`
+// flag is intentionally absent so the agent has no parameter to flip; the
+// handler unconditionally creates the conversation in draft (status='pending')
+// state for human review in the Help Scout UI.
 export const CreateConversationInputSchema = z.object({
   subject: z.string().min(1, 'Subject is required'),
   customer: z.object({
@@ -304,7 +310,6 @@ export const CreateConversationInputSchema = z.object({
   }),
   mailboxId: z.string().min(1, 'Mailbox ID is required'),
   text: z.string().min(1, 'Message text is required'),
-  draft: z.boolean().default(true),
   tags: z.array(z.string()).optional(),
   assignTo: z.string().optional().describe('User ID to assign the conversation to'),
 });

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -273,6 +273,64 @@ export const ListAllInboxesInputSchema = z.object({
   limit: z.number().min(1).max(100).default(100),
 });
 
+// Write Operation Input Schemas
+export const CreateReplyInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  text: z.string().min(1, 'Reply text is required'),
+  customer: z.object({
+    email: z.string().email('Valid customer email is required'),
+  }),
+  draft: z.boolean().default(true),
+  cc: z.array(z.string().email('Each CC entry must be a valid email')).optional(),
+  bcc: z.array(z.string().email('Each BCC entry must be a valid email')).optional(),
+});
+
+export const UpdateConversationStatusInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  status: z.enum(['active', 'pending', 'closed']),
+});
+
+export const CreateNoteInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  text: z.string().min(1, 'Note text is required'),
+});
+
+export const CreateConversationInputSchema = z.object({
+  subject: z.string().min(1, 'Subject is required'),
+  customer: z.object({
+    email: z.string().email('Valid customer email is required'),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+  }),
+  mailboxId: z.string().min(1, 'Mailbox ID is required'),
+  text: z.string().min(1, 'Message text is required'),
+  draft: z.boolean().default(true),
+  tags: z.array(z.string()).optional(),
+  assignTo: z.string().optional().describe('User ID to assign the conversation to'),
+});
+
+export const AssignConversationInputSchema = z.object({
+  conversationId: z.string().min(1, 'conversationId is required'),
+  assigneeId: z.string().min(1, 'Assignee user ID is required'),
+});
+
+export const ListUsersInputSchema = z.object({
+  page: z.number().min(1).default(1),
+});
+
+export const ListMailboxesInputSchema = z.object({
+  page: z.number().min(1).default(1),
+});
+
+export const UserSchema = z.object({
+  id: z.number(),
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string(),
+  role: z.string().optional(),
+  type: z.string().optional(),
+});
+
 // Response Types
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
@@ -308,5 +366,13 @@ export type GetOrganizationMembersInput = z.infer<typeof GetOrganizationMembersI
 export type GetOrganizationConversationsInput = z.infer<typeof GetOrganizationConversationsInputSchema>;
 export type GetCustomerContactsInput = z.infer<typeof GetCustomerContactsInputSchema>;
 export type ListAllInboxesInput = z.infer<typeof ListAllInboxesInputSchema>;
+export type CreateReplyInput = z.infer<typeof CreateReplyInputSchema>;
+export type UpdateConversationStatusInput = z.infer<typeof UpdateConversationStatusInputSchema>;
+export type CreateNoteInput = z.infer<typeof CreateNoteInputSchema>;
+export type CreateConversationInput = z.infer<typeof CreateConversationInputSchema>;
+export type AssignConversationInput = z.infer<typeof AssignConversationInputSchema>;
+export type ListUsersInput = z.infer<typeof ListUsersInputSchema>;
+export type ListMailboxesInput = z.infer<typeof ListMailboxesInputSchema>;
+export type User = z.infer<typeof UserSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -106,6 +106,17 @@ export const GetThreadsInputSchema = z.object({
   cursor: z.string().optional(),
 });
 
+// SUP-974: expose raw email headers (Auto-Submitted, X-Autoreply, Precedence, etc.)
+// via Help Scout's per-thread original-source endpoint, so the support-triage
+// noise gate can run header-based auto-reply detection.
+export const GetThreadOriginalSourceInputSchema = z.object({
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
+  threadId: z.string().regex(/^\d+$/, 'Thread ID must be numeric'),
+  // body is excluded by default — most callers (noise gate, classifiers) only
+  // want headers, and the body is already available via getThreads
+  includeBody: z.boolean().default(false),
+});
+
 export const GetConversationSummaryInputSchema = z.object({
   conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -553,7 +553,7 @@ export class ToolHandler {
       ...(config.writes.enabled ? [
         {
           name: 'createReply',
-          description: 'Send a reply on an existing conversation. IMPORTANT: Defaults to draft mode (draft=true) so a human can review before sending. Set draft=false to send immediately — this sends a real email to the customer and CANNOT be undone. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          description: 'Create a DRAFT reply on an existing conversation. The reply is saved as a draft and is NEVER sent — a human must review and send it from the Help Scout UI. There is no parameter to override this; this tool cannot send mail. Requires HELPSCOUT_ENABLE_WRITES=true.',
           inputSchema: {
             type: 'object' as const,
             properties: {
@@ -572,11 +572,6 @@ export class ToolHandler {
                   email: { type: 'string', description: 'Customer email address' },
                 },
                 required: ['email'],
-              },
-              draft: {
-                type: 'boolean',
-                description: 'Create as draft for human review (default: true). Set to false to send immediately — THIS SENDS A REAL EMAIL.',
-                default: true,
               },
               cc: {
                 type: 'array',
@@ -631,7 +626,7 @@ export class ToolHandler {
         },
         {
           name: 'createConversation',
-          description: 'Create a new conversation. Defaults to draft mode (draft=true). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          description: 'Create a new conversation as a DRAFT. The conversation is staged in pending state and is NEVER sent — a human must review and send it from the Help Scout UI. There is no parameter to override this; this tool cannot send mail. Requires HELPSCOUT_ENABLE_WRITES=true.',
           inputSchema: {
             type: 'object' as const,
             properties: {
@@ -648,7 +643,6 @@ export class ToolHandler {
               },
               mailboxId: { type: 'string', description: 'Mailbox ID to create conversation in' },
               text: { type: 'string', description: 'Message body text (HTML supported)' },
-              draft: { type: 'boolean', description: 'Create as draft (default: true)', default: true },
               tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply' },
               assignTo: { type: 'string', description: 'User ID to assign to' },
             },
@@ -2275,17 +2269,18 @@ export class ToolHandler {
     const input = CreateReplyInputSchema.parse(args);
     const conversationId = input.conversationId;
 
-    logger.info('Creating reply', {
+    logger.info('Creating draft reply', {
       conversationId,
-      draft: input.draft,
       hasCC: !!(input.cc && input.cc.length > 0),
       hasBCC: !!(input.bcc && input.bcc.length > 0),
     });
 
+    // draft is hardcoded to true and is NOT taken from input — this tool cannot send mail,
+    // it can only stage a draft for human review in the Help Scout UI
     const requestBody: Record<string, unknown> = {
       customer: { email: input.customer.email },
       text: input.text,
-      draft: input.draft,
+      draft: true,
     };
 
     if (input.cc && input.cc.length > 0) {
@@ -2297,8 +2292,6 @@ export class ToolHandler {
 
     await helpScoutClient.post(`/conversations/${conversationId}/reply`, requestBody);
 
-    const mode = input.draft ? 'draft' : 'sent';
-
     return {
       content: [{
         type: 'text',
@@ -2306,11 +2299,8 @@ export class ToolHandler {
           success: true,
           conversationId,
           action: 'reply_created',
-          mode,
-          message: input.draft
-            ? `Draft reply created on conversation ${conversationId}. A human must review and send it from the Help Scout UI.`
-            : `Reply sent on conversation ${conversationId}. The email has been delivered to the customer.`,
-          warning: input.draft ? undefined : 'This reply has been sent to the customer and cannot be undone.',
+          mode: 'draft',
+          message: `Draft reply created on conversation ${conversationId}. A human must review and send it from the Help Scout UI. This tool cannot send mail directly.`,
         }, null, 2),
       }],
     };
@@ -2380,9 +2370,8 @@ export class ToolHandler {
 
     const input = CreateConversationInputSchema.parse(args);
 
-    logger.info('Creating conversation', {
+    logger.info('Creating draft conversation', {
       mailboxId: input.mailboxId,
-      draft: input.draft,
       hasTags: !!(input.tags && input.tags.length > 0),
       hasAssignTo: !!input.assignTo,
     });
@@ -2393,12 +2382,14 @@ export class ToolHandler {
       text: input.text,
     };
 
+    // status is hardcoded to 'pending' — there is no parameter to flip it to 'active'.
+    // This tool cannot send mail; it can only stage a draft for human review.
     const requestBody: Record<string, unknown> = {
       subject: input.subject,
       customer: input.customer,
       mailboxId: Number(input.mailboxId),
       type: 'email',
-      status: input.draft ? 'pending' : 'active',
+      status: 'pending',
       threads: [thread],
     };
 
@@ -2417,10 +2408,8 @@ export class ToolHandler {
         text: JSON.stringify({
           success: true,
           action: 'conversation_created',
-          draft: input.draft,
-          message: input.draft
-            ? 'Draft conversation created. A human must review and send it from the Help Scout UI.'
-            : 'Conversation created and active.',
+          mode: 'draft',
+          message: 'Draft conversation created (status=pending). A human must review and send it from the Help Scout UI. This tool cannot send mail directly.',
         }, null, 2),
       }],
     };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -30,6 +30,13 @@ import {
   ListOrganizationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetOrganizationConversationsInputSchema,
+  CreateReplyInputSchema,
+  UpdateConversationStatusInputSchema,
+  CreateNoteInputSchema,
+  CreateConversationInputSchema,
+  AssignConversationInputSchema,
+  ListUsersInputSchema,
+  ListMailboxesInputSchema,
 } from '../schema/types.js';
 
 /**
@@ -530,6 +537,145 @@ export class ToolHandler {
           required: ['organizationId'],
         },
       },
+      // Write tools (require HELPSCOUT_ENABLE_WRITES=true)
+      ...(config.writes.enabled ? [
+        {
+          name: 'createReply',
+          description: 'Send a reply on an existing conversation. IMPORTANT: Defaults to draft mode (draft=true) so a human can review before sending. Set draft=false to send immediately — this sends a real email to the customer and CANNOT be undone. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to reply to',
+              },
+              text: {
+                type: 'string',
+                description: 'The reply body text (HTML supported)',
+              },
+              customer: {
+                type: 'object',
+                description: 'Customer object with email address',
+                properties: {
+                  email: { type: 'string', description: 'Customer email address' },
+                },
+                required: ['email'],
+              },
+              draft: {
+                type: 'boolean',
+                description: 'Create as draft for human review (default: true). Set to false to send immediately — THIS SENDS A REAL EMAIL.',
+                default: true,
+              },
+              cc: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'CC email addresses',
+              },
+              bcc: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'BCC email addresses',
+              },
+            },
+            required: ['conversationId', 'text', 'customer'],
+          },
+        },
+        {
+          name: 'updateConversationStatus',
+          description: 'Update a conversation\'s status to active, pending, or closed. WARNING: Status changes may trigger Help Scout automations (e.g., satisfaction surveys on close). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to update',
+              },
+              status: {
+                type: 'string',
+                enum: ['active', 'pending', 'closed'],
+                description: 'New status for the conversation',
+              },
+            },
+            required: ['conversationId', 'status'],
+          },
+        },
+        {
+          name: 'createNote',
+          description: 'Add an internal note to a conversation. Notes are only visible to support agents and are NOT sent to the customer. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID to add a note to',
+              },
+              text: {
+                type: 'string',
+                description: 'The note text (HTML supported)',
+              },
+            },
+            required: ['conversationId', 'text'],
+          },
+        },
+        {
+          name: 'createConversation',
+          description: 'Create a new conversation. Defaults to draft mode (draft=true). Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              subject: { type: 'string', description: 'Conversation subject line' },
+              customer: {
+                type: 'object',
+                description: 'Customer details',
+                properties: {
+                  email: { type: 'string', description: 'Customer email address' },
+                  firstName: { type: 'string', description: 'Customer first name (optional)' },
+                  lastName: { type: 'string', description: 'Customer last name (optional)' },
+                },
+                required: ['email'],
+              },
+              mailboxId: { type: 'string', description: 'Mailbox ID to create conversation in' },
+              text: { type: 'string', description: 'Message body text (HTML supported)' },
+              draft: { type: 'boolean', description: 'Create as draft (default: true)', default: true },
+              tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply' },
+              assignTo: { type: 'string', description: 'User ID to assign to' },
+            },
+            required: ['subject', 'customer', 'mailboxId', 'text'],
+          },
+        },
+        {
+          name: 'assignConversation',
+          description: 'Assign a conversation to a team member. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: { type: 'string', description: 'The conversation ID' },
+              assigneeId: { type: 'string', description: 'User ID to assign to (use listUsers to find IDs)' },
+            },
+            required: ['conversationId', 'assigneeId'],
+          },
+        },
+        {
+          name: 'listUsers',
+          description: 'List Help Scout users (agents). Useful for finding user IDs for assignment.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            },
+          },
+        },
+        {
+          name: 'listMailboxes',
+          description: 'List available mailboxes. Useful for finding mailbox IDs for creating conversations.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            },
+          },
+        },
+      ] : []),
     ];
   }
 
@@ -638,6 +784,27 @@ export class ToolHandler {
           break;
         case 'getOrganizationConversations':
           result = await this.getOrganizationConversations(request.params.arguments || {});
+          break;
+        case 'createReply':
+          result = await this.createReply(request.params.arguments || {});
+          break;
+        case 'updateConversationStatus':
+          result = await this.updateConversationStatus(request.params.arguments || {});
+          break;
+        case 'createNote':
+          result = await this.createNote(request.params.arguments || {});
+          break;
+        case 'createConversation':
+          result = await this.createConversation(request.params.arguments || {});
+          break;
+        case 'assignConversation':
+          result = await this.assignConversation(request.params.arguments || {});
+          break;
+        case 'listUsers':
+          result = await this.listUsers(request.params.arguments || {});
+          break;
+        case 'listMailboxes':
+          result = await this.listMailboxes(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -2043,6 +2210,256 @@ export class ToolHandler {
           nextCursor: response._links?.next?.href,
           nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
           usage: 'Use conversation.id with getThreads to read full message history, or getConversationSummary for a quick overview.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  // --- Write Operations ---
+
+  private checkWritesEnabled(): void {
+    if (process.env.HELPSCOUT_ENABLE_WRITES !== 'true') {
+      throw new Error(
+        'Write operations are disabled. Set HELPSCOUT_ENABLE_WRITES=true to enable reply, note, and status update tools.'
+      );
+    }
+  }
+
+  private async createReply(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateReplyInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating reply', {
+      conversationId,
+      draft: input.draft,
+      hasCC: !!(input.cc && input.cc.length > 0),
+      hasBCC: !!(input.bcc && input.bcc.length > 0),
+    });
+
+    const requestBody: Record<string, unknown> = {
+      customer: { email: input.customer.email },
+      text: input.text,
+      draft: input.draft,
+    };
+
+    if (input.cc && input.cc.length > 0) {
+      requestBody.cc = input.cc;
+    }
+    if (input.bcc && input.bcc.length > 0) {
+      requestBody.bcc = input.bcc;
+    }
+
+    await helpScoutClient.post(`/conversations/${conversationId}/reply`, requestBody);
+
+    const mode = input.draft ? 'draft' : 'sent';
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'reply_created',
+          mode,
+          message: input.draft
+            ? `Draft reply created on conversation ${conversationId}. A human must review and send it from the Help Scout UI.`
+            : `Reply sent on conversation ${conversationId}. The email has been delivered to the customer.`,
+          warning: input.draft ? undefined : 'This reply has been sent to the customer and cannot be undone.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async updateConversationStatus(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = UpdateConversationStatusInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Updating conversation status', {
+      conversationId,
+      newStatus: input.status,
+    });
+
+    await helpScoutClient.patch(`/conversations/${conversationId}`, {
+      op: 'replace',
+      path: '/status',
+      value: input.status,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'status_updated',
+          newStatus: input.status,
+          message: `Conversation ${conversationId} status updated to "${input.status}".`,
+          warning: input.status === 'closed' ? 'Closing a conversation may trigger automations such as satisfaction surveys.' : undefined,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async createNote(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateNoteInputSchema.parse(args);
+    const conversationId = input.conversationId;
+
+    logger.info('Creating note', {
+      conversationId,
+    });
+
+    await helpScoutClient.post(`/conversations/${conversationId}/notes`, {
+      text: input.text,
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'note_created',
+          message: `Internal note added to conversation ${conversationId}. This note is only visible to support agents.`,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async createConversation(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = CreateConversationInputSchema.parse(args);
+
+    logger.info('Creating conversation', {
+      mailboxId: input.mailboxId,
+      draft: input.draft,
+      hasTags: !!(input.tags && input.tags.length > 0),
+      hasAssignTo: !!input.assignTo,
+    });
+
+    const thread = {
+      type: 'customer',
+      customer: { email: input.customer.email },
+      text: input.text,
+    };
+
+    const requestBody: Record<string, unknown> = {
+      subject: input.subject,
+      customer: input.customer,
+      mailboxId: Number(input.mailboxId),
+      type: 'email',
+      status: input.draft ? 'pending' : 'active',
+      threads: [thread],
+    };
+
+    if (input.tags && input.tags.length > 0) {
+      requestBody.tags = input.tags;
+    }
+    if (input.assignTo) {
+      requestBody.assignTo = Number(input.assignTo);
+    }
+
+    await helpScoutClient.post('/conversations', requestBody);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          action: 'conversation_created',
+          draft: input.draft,
+          message: input.draft
+            ? 'Draft conversation created. A human must review and send it from the Help Scout UI.'
+            : 'Conversation created and active.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async assignConversation(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = AssignConversationInputSchema.parse(args);
+
+    logger.info('Assigning conversation', {
+      conversationId: input.conversationId,
+      assigneeId: input.assigneeId,
+    });
+
+    await helpScoutClient.patch(`/conversations/${input.conversationId}`, {
+      op: 'replace',
+      path: '/assignTo',
+      value: Number(input.assigneeId),
+    });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId: input.conversationId,
+          action: 'conversation_assigned',
+          assigneeId: input.assigneeId,
+          message: `Conversation ${input.conversationId} assigned to user ${input.assigneeId}.`,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listUsers(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = ListUsersInputSchema.parse(args);
+
+    const response = await helpScoutClient.get<PaginatedResponse<Record<string, unknown>>>('/users', {
+      page: input.page,
+    });
+
+    const users = response._embedded?.users || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          users: users.map((u: Record<string, unknown>) => ({
+            id: u.id,
+            firstName: u.firstName,
+            lastName: u.lastName,
+            email: u.email,
+            role: u.role,
+            type: u.type,
+          })),
+          returnedCount: users.length,
+          pagination: response.page,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listMailboxes(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = ListMailboxesInputSchema.parse(args);
+
+    const response = await helpScoutClient.get<PaginatedResponse<Record<string, unknown>>>('/mailboxes', {
+      page: input.page,
+    });
+
+    const mailboxes = response._embedded?.mailboxes || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          mailboxes: mailboxes.map((m: Record<string, unknown>) => ({
+            id: m.id,
+            name: m.name,
+            email: m.email,
+          })),
+          returnedCount: mailboxes.length,
+          pagination: response.page,
         }, null, 2),
       }],
     };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,8 +35,10 @@ import {
   CreateNoteInputSchema,
   CreateConversationInputSchema,
   AssignConversationInputSchema,
+  UpdateConversationTagsInputSchema,
   ListUsersInputSchema,
   ListMailboxesInputSchema,
+  ListTagsInputSchema,
 } from '../schema/types.js';
 
 /**
@@ -283,6 +285,16 @@ export class ToolHandler {
               maximum: 100,
               default: 100,
             },
+          },
+        },
+      },
+      {
+        name: 'listTags',
+        description: 'List all tags used across all Help Scout inboxes, sorted alphabetically. Returns id, name, slug, color, ticket count, and timestamps for each tag. Useful before calling updateConversationTags to confirm exact existing tag spellings/slugs.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number (50 results per page)' },
           },
         },
       },
@@ -644,6 +656,32 @@ export class ToolHandler {
           },
         },
         {
+          name: 'updateConversationTags',
+          description: 'Add, remove, or replace tags on a conversation. Defaults to mode="add" which AMENDS the existing tag set (union). mode="remove" subtracts the given tags. mode="replace" discards ALL existing tags and sets exactly the provided list — use with care. Requires HELPSCOUT_ENABLE_WRITES=true.',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              conversationId: {
+                type: 'string',
+                description: 'The conversation ID whose tags should be updated',
+              },
+              tags: {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+                description: 'Tag names to apply, remove, or replace with',
+              },
+              mode: {
+                type: 'string',
+                enum: ['add', 'remove', 'replace'],
+                default: 'add',
+                description: 'How to apply tags: add = union with existing (default, safe). remove = subtract from existing. replace = discard existing and use exactly this list (destructive).',
+              },
+            },
+            required: ['conversationId', 'tags'],
+          },
+        },
+        {
           name: 'assignConversation',
           description: 'Assign a conversation to a team member. Requires HELPSCOUT_ENABLE_WRITES=true.',
           inputSchema: {
@@ -800,11 +838,17 @@ export class ToolHandler {
         case 'assignConversation':
           result = await this.assignConversation(request.params.arguments || {});
           break;
+        case 'updateConversationTags':
+          result = await this.updateConversationTags(request.params.arguments || {});
+          break;
         case 'listUsers':
           result = await this.listUsers(request.params.arguments || {});
           break;
         case 'listMailboxes':
           result = await this.listMailboxes(request.params.arguments || {});
+          break;
+        case 'listTags':
+          result = await this.listTags(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -2382,6 +2426,63 @@ export class ToolHandler {
     };
   }
 
+  private async updateConversationTags(args: Record<string, unknown>): Promise<CallToolResult> {
+    this.checkWritesEnabled();
+
+    const input = UpdateConversationTagsInputSchema.parse(args);
+    const { conversationId, tags: requestedTags, mode } = input;
+
+    // help scout's PUT /conversations/{id}/tags fully replaces the tag set,
+    // so for add/remove we must first read the current tags and merge client-side
+    let previousTags: string[] = [];
+    let finalTags: string[];
+
+    if (mode === 'replace') {
+      // de-duplicate but keep input order
+      finalTags = Array.from(new Set(requestedTags));
+    } else {
+      // fetch current tags off the conversation; tags are objects of shape {id, name, color}
+      const conversation = await helpScoutClient.get<Conversation>(`/conversations/${conversationId}`);
+      previousTags = (conversation.tags || []).map(t => t.name);
+
+      if (mode === 'add') {
+        // union, preserving existing order then appending new tags not already present
+        const existing = new Set(previousTags);
+        const additions = requestedTags.filter(t => !existing.has(t));
+        finalTags = [...previousTags, ...additions];
+      } else {
+        // remove: filter out the requested names from the existing set
+        const removeSet = new Set(requestedTags);
+        finalTags = previousTags.filter(t => !removeSet.has(t));
+      }
+    }
+
+    logger.info('Updating conversation tags', {
+      conversationId,
+      mode,
+      previousTagCount: previousTags.length,
+      finalTagCount: finalTags.length,
+    });
+
+    // help scout returns 204 no content on success; PUT replaces all tags
+    await helpScoutClient.put(`/conversations/${conversationId}/tags`, { tags: finalTags });
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          conversationId,
+          action: 'tags_updated',
+          mode,
+          previousTags: mode === 'replace' ? undefined : previousTags,
+          appliedTags: finalTags,
+          warning: mode === 'replace' ? 'All previous tags were discarded by replace mode.' : undefined,
+        }, null, 2),
+      }],
+    };
+  }
+
   private async assignConversation(args: Record<string, unknown>): Promise<CallToolResult> {
     this.checkWritesEnabled();
 
@@ -2460,6 +2561,35 @@ export class ToolHandler {
           })),
           returnedCount: mailboxes.length,
           pagination: response.page,
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listTags(args: Record<string, unknown>): Promise<CallToolResult> {
+    const input = ListTagsInputSchema.parse(args);
+
+    // GET /v2/tags returns all tags used across all inboxes, sorted alphabetically
+    const response = await helpScoutClient.get<PaginatedResponse<Record<string, unknown>>>('/tags', {
+      page: input.page,
+    });
+
+    const tags = response._embedded?.tags || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          tags: tags.map((t: Record<string, unknown>) => ({
+            id: t.id,
+            name: t.name,
+            slug: t.slug,
+            color: t.color,
+            ticketCount: t.ticketCount,
+          })),
+          returnedCount: tags.length,
+          pagination: response.page,
+          usage: 'Use the exact "name" value with updateConversationTags to avoid creating near-duplicate tags.',
         }, null, 2),
       }],
     };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,6 +5,7 @@ import { HelpScoutAPIConstraints, ToolCallContext } from '../utils/api-constrain
 import { logger } from '../utils/logger.js';
 import { config } from '../utils/config.js';
 import { PII_REDACTED_BODY } from '../utils/constants.js';
+import { parseRfc822 } from '../utils/rfc822.js';
 import { z } from 'zod';
 import {
   Inbox,
@@ -17,6 +18,7 @@ import {
   SearchInboxesInputSchema,
   SearchConversationsInputSchema,
   GetThreadsInputSchema,
+  GetThreadOriginalSourceInputSchema,
   GetConversationSummaryInputSchema,
   AdvancedConversationSearchInputSchema,
   MultiStatusConversationSearchInputSchema,
@@ -262,6 +264,29 @@ export class ToolHandler {
             },
           },
           required: ['conversationId'],
+        },
+      },
+      {
+        name: 'getThreadOriginalSource',
+        description: 'Get parsed email headers (Auto-Submitted, X-Autoreply, Precedence, From, Subject, etc.) from a thread\'s raw RFC 822 source. Use for auto-reply / bulk-mail detection where the thread body alone is insufficient. Body is excluded by default — pass includeBody=true to include it (subject to PII redaction).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            conversationId: {
+              type: 'string',
+              description: 'The conversation ID',
+            },
+            threadId: {
+              type: 'string',
+              description: 'The thread ID (from getThreads response)',
+            },
+            includeBody: {
+              type: 'boolean',
+              default: false,
+              description: 'Include the parsed message body alongside headers (redacted when REDACT_MESSAGE_CONTENT is set)',
+            },
+          },
+          required: ['conversationId', 'threadId'],
         },
       },
       {
@@ -778,6 +803,9 @@ export class ToolHandler {
         case 'getThreads':
           result = await this.getThreads(request.params.arguments || {});
           break;
+        case 'getThreadOriginalSource':
+          result = await this.getThreadOriginalSource(request.params.arguments || {});
+          break;
         case 'getServerTime':
           result = await this.getServerTime();
           break;
@@ -1244,7 +1272,7 @@ export class ToolHandler {
 
   private async getThreads(args: unknown): Promise<CallToolResult> {
     const input = GetThreadsInputSchema.parse(args);
-    
+
     const response = await helpScoutClient.get<PaginatedResponse<Thread>>(
       `/conversations/${input.conversationId}/threads`,
       {
@@ -1254,7 +1282,7 @@ export class ToolHandler {
     );
 
     const threads = response._embedded?.threads || [];
-    
+
     // Redact PII if configured
     const processedThreads = threads.map(thread => ({
       ...thread,
@@ -1270,6 +1298,42 @@ export class ToolHandler {
             threads: processedThreads,
             pagination: response.page,
             nextCursor: response._links?.next?.href,
+          }, null, 2),
+        },
+      ],
+    };
+  }
+
+  // SUP-974: surface raw email headers via Help Scout's per-thread
+  // original-source endpoint. Headers (Auto-Submitted, X-Autoreply, Precedence, etc.)
+  // are not part of the standard threads list response, but are needed by the
+  // support-triage noise gate's Stage 1A header checks.
+  private async getThreadOriginalSource(args: unknown): Promise<CallToolResult> {
+    const input = GetThreadOriginalSourceInputSchema.parse(args);
+
+    // Help Scout returns the raw RFC 822 message when Accept: message/rfc822 is set
+    const raw = await helpScoutClient.getRaw(
+      `/conversations/${input.conversationId}/threads/${input.threadId}/original-source`,
+      { accept: 'message/rfc822' }
+    );
+
+    const parsed = parseRfc822(raw);
+
+    // body is opt-in to keep responses small and to avoid surfacing message
+    // content callers don't need; redaction policy mirrors getThreads
+    const bodyField = input.includeBody
+      ? { body: config.security.allowPii ? parsed.body : PII_REDACTED_BODY }
+      : {};
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            conversationId: input.conversationId,
+            threadId: input.threadId,
+            headers: parsed.headers,
+            ...bodyField,
           }, null, 2),
         },
       ],

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,6 +23,9 @@ export interface Config {
   security: {
     allowPii: boolean;
   };
+  writes: {
+    enabled: boolean;
+  };
   connectionPool: {
     maxSockets: number;
     maxFreeSockets: number;
@@ -52,6 +55,9 @@ export const config: Config = {
     // Default: show content. Set REDACT_MESSAGE_CONTENT=true to hide message bodies
     // ALLOW_PII=true is backwards compat (always shows content)
     allowPii: process.env.REDACT_MESSAGE_CONTENT !== 'true' || process.env.ALLOW_PII === 'true',
+  },
+  writes: {
+    enabled: process.env.HELPSCOUT_ENABLE_WRITES === 'true',
   },
   connectionPool: {
     maxSockets: parseInt(process.env.HTTP_MAX_SOCKETS || '50', 10),
@@ -90,6 +96,11 @@ export function validateConfig(): void {
       'Optional configuration:\n' +
       '  - HELPSCOUT_DEFAULT_INBOX_ID: Default inbox for scoped searches (improves LLM context)'
     );
+  }
+
+  // Log write access status
+  if (config.writes.enabled) {
+    console.error('Help Scout write access ENABLED (HELPSCOUT_ENABLE_WRITES=true)');
   }
 
   // Enforce HTTPS for API base URL to prevent credential exposure

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -352,6 +352,18 @@ export class HelpScoutClient {
       };
     }
 
+    if (error.response?.status === 412) {
+      return {
+        code: 'INVALID_INPUT',
+        message: 'Help Scout precondition failed. The conversation may have reached the 100-thread limit, or a company policy prevents updates to old conversations.',
+        details: {
+          requestId,
+          statusCode: 412,
+          suggestion: 'Check the conversation thread count and company policies in Help Scout settings',
+        },
+      };
+    }
+
     if (error.response?.status === 422) {
       const responseData = error.response.data as Record<string, any> || {};
       return {
@@ -411,6 +423,52 @@ export class HelpScoutClient {
         suggestion: 'Check your network connection and Help Scout service status',
       },
     };
+  }
+
+  /**
+   * Check response status and throw a structured error for 4xx responses.
+   * Needed because validateStatus allows 4xx through without throwing.
+   */
+  private checkResponseStatus(response: AxiosResponse): void {
+    if (response.status >= 400 && response.status < 500) {
+      const error = new Error(`Request failed with status ${response.status}`) as any;
+      error.response = response;
+      error.config = response.config;
+      throw this.transformError(error as AxiosError);
+    }
+  }
+
+  async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.post<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
+  async patch<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.patch<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
+  /**
+   * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
+   */
+  private invalidateCacheAfterWrite(endpoint: string): void {
+    const match = endpoint.match(/\/conversations\/(\d+)/);
+    if (match) {
+      logger.debug('Invalidating cache after write operation', { endpoint });
+      cache.clear();
+    }
   }
 
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -463,6 +463,19 @@ export class HelpScoutClient {
     return response.data;
   }
 
+  // PUT is idempotent (replaces a resource with the same payload yields the same state),
+  // so retries are safe — unlike POST. Used by tag updates which fully replace the tag set.
+  async put<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+    const response = await this.executeWithRetry<T>(() =>
+      this.client.put<T>(endpoint, data)
+    );
+
+    this.checkResponseStatus(response);
+    this.invalidateCacheAfterWrite(endpoint);
+
+    return response.data;
+  }
+
   /**
    * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
    */

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -467,7 +467,7 @@ export class HelpScoutClient {
    * Invalidate cache after a write operation to ensure subsequent reads return fresh data.
    */
   private invalidateCacheAfterWrite(endpoint: string): void {
-    const match = endpoint.match(/\/conversations\/(\d+)/);
+    const match = endpoint.match(/\/conversations/);
     if (match) {
       logger.debug('Invalidating cache after write operation', { endpoint });
       cache.clear();

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -439,8 +439,11 @@ export class HelpScoutClient {
   }
 
   async post<T = void>(endpoint: string, data: Record<string, unknown>): Promise<T> {
-    const response = await this.executeWithRetry<T>(() =>
-      this.client.post<T>(endpoint, data)
+    // POST is not idempotent — never retry to prevent duplicate creates (emails, notes, conversations)
+    const noRetryConfig: RetryConfig = { retries: 0, retryDelay: 0, maxRetryDelay: 0 };
+    const response = await this.executeWithRetry<T>(
+      () => this.client.post<T>(endpoint, data),
+      noRetryConfig
     );
 
     this.checkResponseStatus(response);

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -490,15 +490,15 @@ export class HelpScoutClient {
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
     const cacheKey = `GET:${endpoint}`;
     const cachedResult = cache.get<T>(cacheKey, params);
-    
+
     if (cachedResult) {
       return cachedResult;
     }
 
-    const response = await this.executeWithRetry<T>(() => 
+    const response = await this.executeWithRetry<T>(() =>
       this.client.get<T>(endpoint, { params })
     );
-    
+
     if (cacheOptions?.ttl || cacheOptions?.ttl === 0) {
       cache.set(cacheKey, params, response.data, { ttl: cacheOptions.ttl });
     } else {
@@ -506,7 +506,28 @@ export class HelpScoutClient {
       const defaultTtl = this.getDefaultCacheTtl(endpoint);
       cache.set(cacheKey, params, response.data, { ttl: defaultTtl });
     }
-    
+
+    return response.data;
+  }
+
+  /**
+   * GET an endpoint that returns a non-JSON payload (e.g. raw RFC 822 email source).
+   * Bypasses JSON parsing and lets the caller specify the Accept header.
+   * Reuses the auth, retry, and connection-pool plumbing of `get`. Not cached —
+   * raw blobs are typically large and only fetched on demand.
+   */
+  async getRaw(endpoint: string, options: { accept: string }): Promise<string> {
+    const response = await this.executeWithRetry<string>(() =>
+      this.client.get<string>(endpoint, {
+        headers: { Accept: options.accept },
+        // tell axios to leave the body as a string instead of trying to JSON.parse it
+        responseType: 'text',
+        transformResponse: (data) => data,
+      })
+    );
+
+    this.checkResponseStatus(response);
+
     return response.data;
   }
 

--- a/src/utils/rfc822.ts
+++ b/src/utils/rfc822.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal RFC 822 / RFC 5322 parser for email source returned by the
+ * Help Scout `original-source` endpoint. We only need the header block
+ * for auto-reply / bulk-mail detection, so this is intentionally small —
+ * no MIME decoding, no transfer-encoding handling, no body parsing.
+ *
+ * Handles:
+ *  - CRLF, LF, or CR line endings (normalised to LF)
+ *  - Header folding (continuation lines starting with whitespace)
+ *  - Repeated headers (collapsed to an array, e.g. multiple `Received:`)
+ *  - The blank-line header/body separator
+ */
+
+export interface ParsedMessage {
+  // header name preserved with original case from the wire; values trimmed
+  headers: Record<string, string | string[]>;
+  body: string;
+}
+
+export function parseRfc822(raw: string): ParsedMessage {
+  // normalise line endings so we can scan for a blank line consistently
+  const normalised = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  // headers and body are separated by the first blank line
+  const sepIdx = normalised.indexOf('\n\n');
+  const headerBlock = sepIdx === -1 ? normalised : normalised.slice(0, sepIdx);
+  const body = sepIdx === -1 ? '' : normalised.slice(sepIdx + 2);
+
+  // unfold continuation lines: any line starting with whitespace belongs to
+  // the previous header. Per RFC 5322 §2.2.3 the leading WSP is significant
+  // but a single space is the conventional join.
+  const rawLines = headerBlock.split('\n');
+  const unfolded: string[] = [];
+  for (const line of rawLines) {
+    if (line.length > 0 && /^[ \t]/.test(line) && unfolded.length > 0) {
+      unfolded[unfolded.length - 1] += ' ' + line.replace(/^[ \t]+/, '');
+    } else {
+      unfolded.push(line);
+    }
+  }
+
+  const headers: Record<string, string | string[]> = {};
+  for (const line of unfolded) {
+    if (line === '') continue;
+
+    const colonIdx = line.indexOf(':');
+    // skip malformed lines (e.g. the unix mbox `From ` envelope line has no colon)
+    if (colonIdx === -1) continue;
+
+    const name = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+    if (!name) continue;
+
+    if (Object.prototype.hasOwnProperty.call(headers, name)) {
+      const existing = headers[name];
+      headers[name] = Array.isArray(existing)
+        ? [...existing, value]
+        : [existing as string, value];
+    } else {
+      headers[name] = value;
+    }
+  }
+
+  return { headers, body };
+}


### PR DESCRIPTION
## Summary

- Adds a new MCP tool `getThreadOriginalSource(conversationId, threadId, includeBody?)` that fetches a thread's raw RFC 822 source from Help Scout's `/v2/conversations/{cid}/threads/{tid}/original-source` endpoint and returns parsed email headers (`Auto-Submitted`, `X-Autoreply`, `Precedence`, `From`, `Subject`, etc.).
- Closes the gap captured in [SUP-974](https://linear.app/cloud66/issue/SUP-974/helpscout-mcp-getthreads-expose-raw-email-headers-auto-submitted-x): the support-triage noise gate's Stage 1A header checks couldn't fire because the standard `getThreads` response doesn't surface headers. They aren't available there upstream either — Help Scout only exposes them via the per-thread `original-source` endpoint, so a dedicated tool is the right shape (augmenting `getThreads` would add N extra API calls per conversation for every existing caller).

## Implementation notes

- `HelpScoutClient.getRaw(endpoint, { accept })` — new method that reuses auth/retry/connection-pool plumbing but sets a custom `Accept` header and bypasses JSON parsing (`responseType: 'text'`, identity `transformResponse`). Not cached — these blobs are large and only fetched on demand.
- `src/utils/rfc822.ts` — minimal hand-rolled parser (~60 LOC). Handles CRLF/LF/CR, header folding (continuation lines starting with WSP), repeated headers (collapsed to array, e.g. multiple `Received:`), envelope `From ` line skipping, blank-line header/body separator. No MIME, no transfer-encoding, no body parsing — none of which we need for header-based detection.
- `getThreadOriginalSource` body is excluded by default (`includeBody: false`); when set, the existing `config.security.allowPii` flag governs redaction, matching `getThreads`.
- Read-only tool count: 18 → 19.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` — 306 passed, 3 pre-existing skipped (no regressions)
- [x] 10 new parser unit tests in `src/__tests__/rfc822.test.ts` cover folding, repeated headers, mixed line endings, envelope-line handling, header values containing colons
- [x] 2 new integration tests in `src/__tests__/tools.test.ts` cover endpoint URL + `Accept: message/rfc822` header + parsed response shape, and PII redaction when `includeBody=true`
- [ ] Smoke against a real Help Scout conversation post-merge to confirm the upstream endpoint behaves as documented (low risk — endpoint shape is documented and the parser is independent of network shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->