### PR TITLE
fix(NAS-988): align pagination and harden MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package*.json ./
 COPY tsconfig.json ./
 
 # Install all dependencies (including dev dependencies for build)
-RUN npm ci && npm cache clean --force
+RUN npm ci --ignore-scripts && npm cache clean --force
 
 # Copy source code and config
 COPY src/ ./src/
@@ -32,7 +32,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install only production dependencies
-RUN npm ci --omit=dev && npm cache clean --force
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `
 | List organization conversations | `getOrganizationConversations` | "Show support history for organization 456" |
 | Quick conversation overview | `getConversationSummary` | "Summarize this conversation" |
 | Full message history | `getThreads` | "Show me the complete thread" |
-| Current server time | `getServerTime` | Used for time-relative searches |
+| Current MCP host time | `getServerTime` | Used for time-relative searches |
 
 Inboxes are auto-discovered when the server connects. AI agents get inbox IDs in their instructions automatically, so no lookup step is needed.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "version:patch": "node scripts/bump-version.cjs patch",
     "version:minor": "node scripts/bump-version.cjs minor",
     "version:major": "node scripts/bump-version.cjs major",
+    "prepare": "node scripts/prepare.cjs",
     "prepublishOnly": "npm run clean && npm run build",
     "prepack": "npm run clean && npm run build",
     "mcpb:build": "node scripts/build-mcpb.js",

--- a/scripts/prepare.cjs
+++ b/scripts/prepare.cjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const hasTypeScript = existsSync(join(__dirname, '..', 'node_modules', 'typescript', 'bin', 'tsc'));
+const omitConfig = process.env.npm_config_omit || '';
+const devDependenciesOmitted =
+  process.env.NODE_ENV === 'production' || omitConfig.split(/[,\s]+/).includes('dev');
+
+if (!hasTypeScript && devDependenciesOmitted) {
+  console.log('prepare: skipping build because dev dependencies are omitted');
+  process.exit(0);
+}
+
+if (!hasTypeScript) {
+  console.error('prepare: TypeScript is required to build this package');
+  process.exit(1);
+}
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const result = spawnSync(npmCommand, ['run', 'build'], { stdio: 'inherit' });
+
+process.exit(result.status ?? 1);

--- a/src/__tests__/api-constraints.test.ts
+++ b/src/__tests__/api-constraints.test.ts
@@ -65,7 +65,7 @@ describe('HelpScoutAPIConstraints', () => {
       const context: ToolCallContext = {
         toolName: 'searchConversations',
         arguments: { query: 'urgent refund' },
-        userQuery: 'find messages about urgent refunds',  // Use words not in inbox keywords
+        userQuery: 'find messages about urgent refunds',
         previousCalls: []
       };
 
@@ -73,6 +73,21 @@ describe('HelpScoutAPIConstraints', () => {
 
       expect(result.isValid).toBe(true);
       expect(result.suggestions.some(s => s.includes('comprehensiveConversationSearch'))).toBe(true);
+    });
+
+    it('should allow global searches that contain generic support topics', () => {
+      const context: ToolCallContext = {
+        toolName: 'searchConversations',
+        arguments: { query: 'billing issues' },
+        userQuery: 'find all conversations about billing issues in support history',
+        previousCalls: []
+      };
+
+      const result = HelpScoutAPIConstraints.validateToolCall(context);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).not.toContain('User mentioned an inbox by name but no inboxId provided');
+      expect(result.requiredPrerequisites).toBeUndefined();
     });
 
     it('should validate comprehensiveConversationSearch searchTerms', () => {
@@ -110,9 +125,8 @@ describe('HelpScoutAPIConstraints', () => {
       'search in the support inbox',
       'find messages from billing mailbox',
       'check sales queue',
-      'look at technical support',
       'customer service inbox',
-      'general help desk'
+      'general help desk inbox'
     ];
 
     testCases.forEach(query => {

--- a/src/__tests__/authentication.test.ts
+++ b/src/__tests__/authentication.test.ts
@@ -134,6 +134,19 @@ describe('Authentication Configuration', () => {
       expect(config.helpscout.clientId).toBe('oauth-client-id');
       expect(config.helpscout.clientSecret).toBe('oauth-secret');
     });
+
+    it('should ignore stale bearer API key when OAuth2 credentials are also set', async () => {
+      process.env.HELPSCOUT_API_KEY = 'Bearer old-personal-token';
+      process.env.HELPSCOUT_CLIENT_ID = 'oauth-client-id';
+      process.env.HELPSCOUT_CLIENT_SECRET = 'oauth-secret';
+
+      jest.resetModules();
+      const { config, validateConfig } = await import('../utils/config.js');
+
+      expect(() => validateConfig()).not.toThrow();
+      expect(config.helpscout.clientId).toBe('oauth-client-id');
+      expect(config.helpscout.clientSecret).toBe('oauth-secret');
+    });
   });
 
   describe('Config object structure', () => {

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -65,6 +65,16 @@ describe('Cache', () => {
       cache.set(key, params, value);
       expect(cache.get(key, params)).toEqual(value);
     });
+
+    it('should not return entries written with zero TTL', () => {
+      const key = 'zero-ttl';
+      const params = {};
+      const value = { data: 'test' };
+
+      cache.set(key, params, value, { ttl: 0 });
+
+      expect(cache.get(key, params)).toBeUndefined();
+    });
   });
 
   describe('cache management', () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import { runCli } from '../cli.js';
+import { logger } from '../utils/logger.js';
+
+jest.mock('../utils/logger.js', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+describe('CLI entrypoint', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let exitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('should log startup failures and exit non-zero', async () => {
+    const start = jest.fn().mockRejectedValue(new Error('startup boom'));
+
+    await expect(runCli(start)).rejects.toThrow('process.exit called');
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('Failed to start application', {
+      error: 'startup boom',
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Application startup failed:', 'startup boom');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should resolve without exiting when startup succeeds', async () => {
+    const start = jest.fn().mockResolvedValue(undefined);
+
+    await expect(runCli(start)).resolves.toBeUndefined();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should keep the package bin pointed at the built CLI entrypoint', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+    );
+
+    expect(packageJson.bin['help-scout-mcp-server']).toBe('dist/cli.js');
+    expect(packageJson.scripts.prepare).toBe('node scripts/prepare.cjs');
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -30,6 +30,26 @@ describe('Config Validation', () => {
       expect(() => validateConfig()).not.toThrow();
     });
 
+    it('should pass with OAuth2 configuration when stale bearer API key remains set', async () => {
+      process.env.HELPSCOUT_API_KEY = 'Bearer old-personal-token';
+      process.env.HELPSCOUT_CLIENT_ID = 'valid-client-id';
+      process.env.HELPSCOUT_CLIENT_SECRET = 'valid-client-secret';
+      process.env.HELPSCOUT_BASE_URL = 'https://api.helpscout.net/v2/';
+
+      jest.resetModules();
+      const { validateConfig } = await import('../utils/config.js');
+      expect(() => validateConfig()).not.toThrow();
+    });
+
+    it('should reject stale bearer API key when no OAuth2 credentials are configured', async () => {
+      process.env.HELPSCOUT_API_KEY = 'Bearer old-personal-token';
+      process.env.HELPSCOUT_APP_SECRET = 'client-secret';
+
+      jest.resetModules();
+      const { validateConfig } = await import('../utils/config.js');
+      expect(() => validateConfig()).toThrow(/Personal Access Tokens are no longer supported/);
+    });
+
     it('should pass with legacy OAuth2 naming (HELPSCOUT_API_KEY/APP_SECRET)', async () => {
       process.env.HELPSCOUT_API_KEY = 'client-id';
       process.env.HELPSCOUT_APP_SECRET = 'client-secret';
@@ -110,6 +130,17 @@ describe('Config Validation', () => {
       expect(config.connectionPool.maxFreeSockets).toBe(10);
       expect(config.connectionPool.timeout).toBe(30000);
       expect(config.connectionPool.keepAliveMsecs).toBe(1000);
+    });
+
+    it('should fall back to info for invalid logging levels', async () => {
+      process.env.HELPSCOUT_CLIENT_ID = 'client-id';
+      process.env.HELPSCOUT_CLIENT_SECRET = 'client-secret';
+      process.env.LOG_LEVEL = 'infos';
+
+      jest.resetModules();
+      const { config, validateConfig } = await import('../utils/config.js');
+      expect(() => validateConfig()).not.toThrow();
+      expect(config.logging.level).toBe('info');
     });
   });
 });

--- a/src/__tests__/connection-pool.test.ts
+++ b/src/__tests__/connection-pool.test.ts
@@ -112,6 +112,48 @@ describe('HelpScout Client - Connection Pooling', () => {
       expect(() => client.clearIdleConnections()).not.toThrow();
     });
 
+    it('should preserve custom pool settings when clearing idle connections', () => {
+      const axiosClientBefore = (client as any).client;
+      const httpAgentBefore = axiosClientBefore.defaults.httpAgent;
+      const httpsAgentBefore = axiosClientBefore.defaults.httpsAgent;
+      expect(axiosClientBefore.defaults.httpAgent.options.maxSockets).toBe(10);
+      expect(axiosClientBefore.defaults.httpAgent.options.maxFreeSockets).toBe(3);
+      expect(axiosClientBefore.defaults.httpAgent.options.timeout).toBe(10000);
+      expect(axiosClientBefore.defaults.httpAgent.options.keepAliveMsecs).toBe(200);
+
+      client.clearIdleConnections();
+
+      const axiosClientAfter = (client as any).client;
+      expect(axiosClientAfter.defaults.httpAgent).toBe(httpAgentBefore);
+      expect(axiosClientAfter.defaults.httpsAgent).toBe(httpsAgentBefore);
+      expect(axiosClientAfter.defaults.httpAgent.options.maxSockets).toBe(10);
+      expect(axiosClientAfter.defaults.httpAgent.options.maxFreeSockets).toBe(3);
+      expect(axiosClientAfter.defaults.httpAgent.options.timeout).toBe(10000);
+      expect(axiosClientAfter.defaults.httpAgent.options.keepAliveMsecs).toBe(200);
+      expect(axiosClientAfter.defaults.httpsAgent.options.maxSockets).toBe(10);
+      expect(axiosClientAfter.defaults.httpsAgent.options.maxFreeSockets).toBe(3);
+      expect(axiosClientAfter.defaults.httpsAgent.options.timeout).toBe(10000);
+      expect(axiosClientAfter.defaults.httpsAgent.options.keepAliveMsecs).toBe(200);
+    });
+
+    it('should destroy free sockets without destroying active sockets', () => {
+      const axiosClient = (client as any).client;
+      const freeSocket = { destroy: jest.fn() };
+      const activeSocket = { destroy: jest.fn() };
+
+      axiosClient.defaults.httpsAgent.freeSockets = { 'api.helpscout.net:443:': [freeSocket] };
+      axiosClient.defaults.httpsAgent.sockets = { 'api.helpscout.net:443:': [activeSocket] };
+
+      client.clearIdleConnections();
+
+      expect(freeSocket.destroy).toHaveBeenCalledTimes(1);
+      expect(activeSocket.destroy).not.toHaveBeenCalled();
+      expect(axiosClient.defaults.httpsAgent.freeSockets).toEqual({});
+      expect(axiosClient.defaults.httpsAgent.sockets).toEqual({
+        'api.helpscout.net:443:': [activeSocket],
+      });
+    });
+
     it('should log pool status', () => {
       const { logger } = require('../utils/logger.js');
       
@@ -181,6 +223,64 @@ describe('HelpScout Client - Connection Pooling', () => {
       
       const stats = client.getPoolStats();
       expect(stats).toBeDefined();
+    });
+
+    it('should authenticate against the configured base URL', async () => {
+      jest.resetModules();
+      jest.doMock('../utils/config.js', () => ({
+        config: {
+          helpscout: {
+            apiKey: '',
+            clientId: 'custom-client-id',
+            clientSecret: 'custom-client-secret',
+            baseUrl: 'https://helpscout-proxy.test/v2/',
+          },
+          cache: { ttlSeconds: 300, maxSize: 10000 },
+          logging: { level: 'error' },
+          security: { redactMessageContent: false },
+          connectionPool: {
+            maxSockets: 5,
+            maxFreeSockets: 2,
+            timeout: 30000,
+            keepAlive: true,
+            keepAliveMsecs: 1000,
+          },
+        },
+        validateConfig: jest.fn(),
+      }));
+      jest.doMock('../utils/logger.js', () => ({
+        logger: {
+          info: jest.fn(),
+          error: jest.fn(),
+          debug: jest.fn(),
+          warn: jest.fn(),
+        },
+      }));
+
+      const { HelpScoutClient: IsolatedHelpScoutClient } = await import('../utils/helpscout-client.js');
+      const isolatedClient = new IsolatedHelpScoutClient();
+
+      const authScope = nock('https://helpscout-proxy.test')
+        .post('/v2/oauth2/token')
+        .reply(200, {
+          access_token: 'proxy-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        });
+
+      const apiScope = nock('https://helpscout-proxy.test')
+        .get('/v2/mailboxes')
+        .query({ page: 1, size: 1 })
+        .matchHeader('authorization', 'Bearer proxy-access-token')
+        .reply(200, { _embedded: { mailboxes: [] } });
+
+      await isolatedClient.get('/mailboxes', { page: 1, size: 1 });
+      await isolatedClient.closePool();
+
+      expect(authScope.isDone()).toBe(true);
+      expect(apiScope.isDone()).toBe(true);
+      jest.dontMock('../utils/config.js');
+      jest.dontMock('../utils/logger.js');
     });
   });
 

--- a/src/__tests__/helpscout-client.test.ts
+++ b/src/__tests__/helpscout-client.test.ts
@@ -112,6 +112,38 @@ describe('HelpScoutClient', () => {
       // It should make a POST request to /oauth2/token with client credentials
       // and receive an access_token and expires_in response
     });
+
+    it('should retry transient OAuth2 token failures before API requests', async () => {
+      process.env.HELPSCOUT_CLIENT_ID = 'test-client-id';
+      process.env.HELPSCOUT_CLIENT_SECRET = 'test-client-secret';
+      process.env.HELPSCOUT_BASE_URL = `${baseURL}/`;
+
+      const authScope = nock('https://api.helpscout.net')
+        .post('/v2/oauth2/token')
+        .reply(500, { message: 'temporary auth failure' })
+        .post('/v2/oauth2/token')
+        .reply(200, {
+          access_token: 'retried-token',
+          expires_in: 7200,
+        });
+
+      const apiScope = nock(baseURL)
+        .get('/mailboxes')
+        .query({ page: 1, size: 1 })
+        .matchHeader('authorization', 'Bearer retried-token')
+        .reply(200, { _embedded: { mailboxes: [] } });
+
+      const client = new HelpScoutClient();
+      jest.spyOn(client as any, 'sleep').mockResolvedValue(undefined);
+
+      await expect(client.get('/mailboxes', { page: 1, size: 1 })).resolves.toEqual({
+        _embedded: { mailboxes: [] },
+      });
+
+      expect(authScope.isDone()).toBe(true);
+      expect(apiScope.isDone()).toBe(true);
+      await client.closePool();
+    });
   });
 
   describe('error handling', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -438,6 +438,9 @@ describe('HelpScoutMCPServer - THE ACTUAL APPLICATION', () => {
 
       const handler = readResourceCall[1];
       const result = await handler({ params: { uri: 'helpscout://threads' } });
+
+      expect(result.contents[0].uri).toBe('helpscout://threads');
+      expect(result.contents[0].mimeType).toBe('application/json');
       const payload = JSON.parse(result.contents[0].text);
 
       expect(payload.error.code).toBe('RESOURCE_ERROR');

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -218,13 +218,13 @@ describe('HelpScoutMCPServer - THE ACTUAL APPLICATION', () => {
 
       const failedServer = await HelpScoutMCPServer.create();
 
-      await expect(failedServer.start()).rejects.toThrow('process.exit() was called');
+      await expect(failedServer.start()).rejects.toThrow('Failed to connect to Help Scout API');
 
       expect(logger.error).toHaveBeenCalledWith('Failed to start server',
         expect.objectContaining({ error: 'Failed to connect to Help Scout API' })
       );
-      expect(mockConsoleError).toHaveBeenCalledWith('MCP Server startup failed:', 'Failed to connect to Help Scout API');
-      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).not.toHaveBeenCalledWith('MCP Server startup failed:', expect.any(String));
+      expect(mockExit).not.toHaveBeenCalled();
     });
 
     it('should handle configuration validation failure', async () => {
@@ -234,13 +234,13 @@ describe('HelpScoutMCPServer - THE ACTUAL APPLICATION', () => {
       const configError = new Error('Invalid configuration');
       validateConfig.mockImplementation(() => { throw configError; });
 
-      await expect(server.start()).rejects.toThrow('process.exit() was called');
+      await expect(server.start()).rejects.toThrow('Invalid configuration');
       
       expect(logger.error).toHaveBeenCalledWith('Failed to start server', 
         expect.objectContaining({ error: 'Invalid configuration' })
       );
-      expect(mockConsoleError).toHaveBeenCalledWith('MCP Server startup failed:', 'Invalid configuration');
-      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).not.toHaveBeenCalledWith('MCP Server startup failed:', expect.any(String));
+      expect(mockExit).not.toHaveBeenCalled();
     });
 
     it('should stop gracefully', async () => {
@@ -389,8 +389,17 @@ describe('HelpScoutMCPServer - THE ACTUAL APPLICATION', () => {
 
       await handler(request);
 
-      expect(toolHandler.setUserContext).toHaveBeenCalledWith('find urgent tickets in the support inbox');
-      expect(toolHandler.callTool).toHaveBeenCalledWith(request);
+      expect(toolHandler.setUserContext).not.toHaveBeenCalled();
+      expect(toolHandler.callTool).toHaveBeenCalledWith({
+        ...request,
+        params: {
+          ...request.params,
+          arguments: {
+            query: 'urgent',
+            __userQuery: 'find urgent tickets in the support inbox',
+          },
+        },
+      });
     });
 
     it('should handle resource reads with proper logging', async () => {
@@ -415,6 +424,25 @@ describe('HelpScoutMCPServer - THE ACTUAL APPLICATION', () => {
       expect(logger.debug).toHaveBeenCalledWith('Reading resource', { 
         uri: 'helpscout://inboxes' 
       });
+    });
+
+    it('should return structured resource errors for failed reads', async () => {
+      const { resourceHandler } = require('../resources/index.js');
+
+      resourceHandler.handleResource.mockRejectedValue(new Error('conversationId is required'));
+
+      const readResourceCall = mockServer.setRequestHandler.mock.calls.find(
+        call => call[0].method === 'resources/read'
+      );
+      expect(readResourceCall).toBeDefined();
+
+      const handler = readResourceCall[1];
+      const result = await handler({ params: { uri: 'helpscout://threads' } });
+      const payload = JSON.parse(result.contents[0].text);
+
+      expect(payload.error.code).toBe('RESOURCE_ERROR');
+      expect(payload.error.message).toContain('conversationId is required');
+      expect(payload.error.resourceUri).toBe('helpscout://threads');
     });
 
     it('should handle prompt requests with proper logging', async () => {

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -120,9 +120,6 @@ describe('Complete User Workflows - Integration Tests', () => {
 
       // Execute the complete workflow
       
-      // User input: "find urgent tickets in the support inbox"
-      toolHandler.setUserContext('find urgent tickets in the support inbox');
-
       // Step 1: Search for "support" inbox
       const inboxSearchRequest: CallToolRequest = {
         method: 'tools/call',
@@ -147,6 +144,7 @@ describe('Complete User Workflows - Integration Tests', () => {
           name: 'searchConversations',
           arguments: {
             query: 'urgent',
+            __userQuery: 'find urgent tickets in the support inbox',
             inboxId: supportInboxId,
             status: 'active'
           }
@@ -333,8 +331,6 @@ describe('Complete User Workflows - Integration Tests', () => {
     it('should guide users through correct workflow when they skip steps', async () => {
       // SCENARIO: User tries to search without getting inbox ID first
       
-      toolHandler.setUserContext('search conversations in the billing inbox for overdue payments');
-
       // User incorrectly tries to search without inbox ID
       const incorrectSearchRequest: CallToolRequest = {
         method: 'tools/call',
@@ -342,6 +338,7 @@ describe('Complete User Workflows - Integration Tests', () => {
           name: 'searchConversations',
           arguments: {
             query: 'overdue',
+            __userQuery: 'search conversations in the billing inbox for overdue payments',
             // Missing inboxId - user mentioned "billing inbox" but didn't search for it first
           }
         }

--- a/src/__tests__/prompts.test.ts
+++ b/src/__tests__/prompts.test.ts
@@ -161,6 +161,7 @@ describe('PromptHandler', () => {
         
         const promptText = result.messages[0].content.text;
         expect(promptText).toContain('getServerTime');
+        expect(promptText).toContain('current MCP host time');
         expect(promptText).toContain('searchConversations');
         expect(promptText).toContain('7 days ago');
       });
@@ -269,6 +270,7 @@ describe('PromptHandler', () => {
         expect(promptText).toContain('priority');
         expect(promptText).toContain('high-priority');
         expect(promptText).toContain('getServerTime');
+        expect(promptText).toContain('current MCP host time');
         expect(promptText).toContain('searchConversations');
       });
 
@@ -346,6 +348,7 @@ describe('PromptHandler', () => {
         expect(promptText).toContain('24 hours');
         expect(promptText).toContain('"inboxId": "inbox-123"');
         expect(promptText).toContain('getServerTime');
+        expect(promptText).toContain('current MCP host time');
         expect(promptText).toContain('searchConversations');
       });
 

--- a/src/__tests__/resources.test.ts
+++ b/src/__tests__/resources.test.ts
@@ -91,6 +91,7 @@ describe('ResourceHandler', () => {
       });
 
       it('should handle pagination parameters', async () => {
+        const requestedUri = 'helpscout://inboxes?page=2&size=10';
         const mockResponse = {
           _embedded: { mailboxes: [] },
           page: { size: 10, totalElements: 0 }
@@ -101,8 +102,8 @@ describe('ResourceHandler', () => {
           .query({ page: 2, size: 10 })
           .reply(200, mockResponse);
 
-        const resource = await resourceHandler.handleResource('helpscout://inboxes?page=2&size=10');
-        expect(resource).toBeDefined();
+        const resource = await resourceHandler.handleResource(requestedUri);
+        expect(resource.uri).toBe(requestedUri);
       });
 
       it('should reject invalid size parameters above Help Scout limits', async () => {
@@ -172,10 +173,11 @@ describe('ResourceHandler', () => {
           'helpscout://conversations?status=active&mailbox=123'
         );
         expect(resource).toBeDefined();
-        expect(resource.uri).toBe('helpscout://conversations');
+        expect(resource.uri).toBe('helpscout://conversations?status=active&mailbox=123');
       });
 
       it('should handle pagination parameters', async () => {
+        const requestedUri = 'helpscout://conversations?page=2&size=25';
         const mockResponse = {
           _embedded: { conversations: [] },
           page: { size: 25, totalElements: 0, number: 2 },
@@ -187,10 +189,9 @@ describe('ResourceHandler', () => {
           .query({ page: 2, size: 25 })
           .reply(200, mockResponse);
 
-        const resource = await resourceHandler.handleResource(
-          'helpscout://conversations?page=2&size=25'
-        );
+        const resource = await resourceHandler.handleResource(requestedUri);
         
+        expect(resource.uri).toBe(requestedUri);
         const data = JSON.parse(resource.text as string);
         expect(data.pagination.number).toBe(2);
         expect(data.pagination.size).toBe(25);
@@ -272,6 +273,7 @@ describe('ResourceHandler', () => {
       });
 
       it('should handle pagination parameters for threads', async () => {
+        const requestedUri = 'helpscout://threads?conversationId=123&page=2&size=25';
         const mockResponse = {
           _embedded: {
             threads: []
@@ -285,10 +287,9 @@ describe('ResourceHandler', () => {
           .query({ page: 2, size: 25 })
           .reply(200, mockResponse);
 
-        const resource = await resourceHandler.handleResource(
-          'helpscout://threads?conversationId=123&page=2&size=25'
-        );
+        const resource = await resourceHandler.handleResource(requestedUri);
         
+        expect(resource.uri).toBe(requestedUri);
         const data = JSON.parse(resource.text as string);
         expect(data.pagination.number).toBe(2);
         expect(data.pagination.size).toBe(25);
@@ -405,7 +406,7 @@ describe('ResourceHandler', () => {
     });
 
     describe('helpscout://clock', () => {
-      it('should return server time', async () => {
+      it('should return MCP host time', async () => {
         const resource = await resourceHandler.handleResource('helpscout://clock');
 
         expect(resource.uri).toBe('helpscout://clock');
@@ -414,17 +415,21 @@ describe('ResourceHandler', () => {
         const data = JSON.parse(resource.text as string);
         expect(data).toHaveProperty('isoTime');
         expect(data).toHaveProperty('unixTime');
+        expect(data).toHaveProperty('source', 'mcp_host_clock');
+        expect(data.note).toContain('local MCP host process clock');
         expect(typeof data.isoTime).toBe('string');
         expect(typeof data.unixTime).toBe('number');
       });
 
-      it('should ignore pagination parameters that do not apply to clock', async () => {
-        const resource = await resourceHandler.handleResource('helpscout://clock?page=abc&size=too-large');
+      it('should preserve clock request URI while ignoring parameters that do not apply', async () => {
+        const requestedUri = 'helpscout://clock?page=abc&size=too-large';
+        const resource = await resourceHandler.handleResource(requestedUri);
 
-        expect(resource.uri).toBe('helpscout://clock');
+        expect(resource.uri).toBe(requestedUri);
         const data = JSON.parse(resource.text as string);
         expect(data).toHaveProperty('isoTime');
         expect(data).toHaveProperty('unixTime');
+        expect(data).toHaveProperty('source', 'mcp_host_clock');
       });
     });
 

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,4 +1,5 @@
 import { 
+  AdvancedConversationSearchInputSchema,
   GetOrganizationConversationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetThreadsInputSchema,
@@ -137,6 +138,7 @@ describe('Schema Validation', () => {
       expect(parsed.query).toBe('(body:"test")');
       expect(parsed.status).toBeUndefined();
       expect(parsed.limit).toBe(50);
+      expect(parsed.page).toBe(1);
     });
 
     it('should validate status enum', () => {
@@ -162,6 +164,28 @@ describe('Schema Validation', () => {
           limit: 25.7
         });
       }).toThrow();
+    });
+  });
+
+  describe('v2 page-based pagination schemas', () => {
+    it('should accept numeric page inputs for v2 paginated tools', () => {
+      expect(SearchInboxesInputSchema.parse({ query: '', page: 2 }).page).toBe(2);
+      expect(SearchConversationsInputSchema.parse({ page: 3 }).page).toBe(3);
+      expect(GetThreadsInputSchema.parse({ conversationId: '123', page: 4 }).page).toBe(4);
+      expect(AdvancedConversationSearchInputSchema.parse({ tags: ['billing'], page: 5 }).page).toBe(5);
+      expect(StructuredConversationFilterInputSchema.parse({ assignedTo: -1, page: 6 }).page).toBe(6);
+    });
+
+    it('should reject fractional page inputs for v2 paginated tools', () => {
+      const cases = [
+        () => SearchInboxesInputSchema.parse({ query: '', page: 1.5 }),
+        () => SearchConversationsInputSchema.parse({ page: 1.5 }),
+        () => GetThreadsInputSchema.parse({ conversationId: '123', page: 1.5 }),
+        () => AdvancedConversationSearchInputSchema.parse({ tags: ['billing'], page: 1.5 }),
+        () => StructuredConversationFilterInputSchema.parse({ assignedTo: -1, page: 1.5 }),
+      ];
+
+      cases.forEach(parse => expect(parse).toThrow());
     });
   });
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -70,10 +70,32 @@ describe('ToolHandler', () => {
         expect(tool.inputSchema).toHaveProperty('properties');
       });
     });
+
+    it('should expose page-based pagination for v2 paginated tools', async () => {
+      const tools = await toolHandler.listTools();
+      const byName = Object.fromEntries(tools.map(tool => [tool.name, tool]));
+      const pageBasedTools = [
+        'searchInboxes',
+        'searchConversations',
+        'getThreads',
+        'advancedConversationSearch',
+        'structuredConversationFilter',
+      ];
+
+      for (const toolName of pageBasedTools) {
+        const properties = byName[toolName].inputSchema.properties as Record<string, unknown>;
+        expect(properties.page).toEqual(expect.objectContaining({
+          type: 'number',
+          minimum: 1,
+          default: 1,
+        }));
+        expect(properties.cursor).toBeUndefined();
+      }
+    });
   });
 
   describe('getServerTime', () => {
-    it('should return server time without Help Scout API call', async () => {
+    it('should return MCP host time without Help Scout API call', async () => {
       const request: CallToolRequest = {
         method: 'tools/call',
         params: {
@@ -91,6 +113,8 @@ describe('ToolHandler', () => {
       const response = JSON.parse(textContent.text);
       expect(response).toHaveProperty('isoTime');
       expect(response).toHaveProperty('unixTime');
+      expect(response).toHaveProperty('source', 'mcp_host_clock');
+      expect(response.note).toContain('local MCP host process clock');
       expect(typeof response.isoTime).toBe('string');
       expect(typeof response.unixTime).toBe('number');
     });
@@ -183,6 +207,156 @@ describe('ToolHandler', () => {
       const response = JSON.parse(textContent.text);
       expect(response.results).toHaveLength(1);
       expect(response.results[0].name).toBe('Support Inbox');
+    });
+  });
+
+  describe('page-based v2 pagination', () => {
+    it('should pass the requested page through searchInboxes and return nextPage metadata', async () => {
+      nock(baseURL)
+        .get('/mailboxes')
+        .query({ page: 2, size: 50 })
+        .reply(200, {
+          _embedded: {
+            mailboxes: [
+              { id: 10, name: 'Support', email: 'support@example.com', createdAt: '2023-01-01T00:00:00Z', updatedAt: '2023-01-02T00:00:00Z' },
+            ]
+          },
+          page: { size: 50, totalElements: 101, totalPages: 3, number: 2 }
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'searchInboxes',
+          arguments: { query: '', page: 2 },
+        },
+      });
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+
+      expect(response.results).toHaveLength(1);
+      expect(response.pagination).toEqual({ size: 50, totalElements: 101, totalPages: 3, number: 2 });
+      expect(response.nextPage).toBe(3);
+      expect(response.nextCursor).toBeUndefined();
+    });
+
+    it('should pass the requested page through searchConversations single-status search', async () => {
+      nock(baseURL)
+        .get('/conversations')
+        .query(params => params.page === '3' && params.status === 'active')
+        .reply(200, {
+          _embedded: {
+            conversations: [
+              { id: 123, subject: 'Paged', status: 'active', createdAt: '2023-01-01T00:00:00Z', customer: { id: 1 } },
+            ],
+          },
+          page: { size: 50, totalElements: 201, totalPages: 5, number: 3 }
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'searchConversations',
+          arguments: { status: 'active', page: 3 },
+        },
+      });
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+
+      expect(response.results).toHaveLength(1);
+      expect(response.pagination).toEqual({ size: 50, totalElements: 201, totalPages: 5, number: 3 });
+      expect(response.nextPage).toBe(4);
+      expect(response.nextCursor).toBeUndefined();
+    });
+
+    it('should pass the requested page through getThreads and omit v2 cursors', async () => {
+      nock(baseURL)
+        .get('/conversations/123/threads')
+        .query({ page: 2, size: 200 })
+        .reply(200, {
+          _embedded: {
+            threads: [
+              { id: 99, type: 'customer', body: 'page two', createdAt: '2023-01-01T00:00:00Z' },
+            ],
+          },
+          _links: { next: { href: '/conversations/123/threads?page=3' } },
+          page: { size: 200, totalElements: 401, totalPages: 3, number: 2 }
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getThreads',
+          arguments: { conversationId: '123', page: 2 },
+        },
+      });
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+
+      expect(response.threads).toHaveLength(1);
+      expect(response.pagination).toEqual({ size: 200, totalElements: 401, totalPages: 3, number: 2 });
+      expect(response.nextPage).toBe(3);
+      expect(response.nextCursor).toBeUndefined();
+    });
+
+    it('should pass page through advancedConversationSearch and omit v2 cursors', async () => {
+      nock(baseURL)
+        .get('/conversations')
+        .query(params => params.page === '2' && typeof params.query === 'string' && params.query.includes('billing'))
+        .reply(200, {
+          _embedded: {
+            conversations: [
+              { id: 456, subject: 'Billing', status: 'active', createdAt: '2023-01-01T00:00:00Z', customer: { id: 1 } },
+            ],
+          },
+          _links: { next: { href: '/conversations?page=3' } },
+          page: { size: 50, totalElements: 120, totalPages: 3, number: 2 }
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'advancedConversationSearch',
+          arguments: { tags: ['billing'], page: 2 },
+        },
+      });
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+
+      expect(response.results).toHaveLength(1);
+      expect(response.pagination).toEqual({ size: 50, totalElements: 120, totalPages: 3, number: 2 });
+      expect(response.nextPage).toBe(3);
+      expect(response.nextCursor).toBeUndefined();
+    });
+
+    it('should pass page through structuredConversationFilter and omit v2 cursors', async () => {
+      nock(baseURL)
+        .get('/conversations')
+        .query(params => params.page === '2' && Number(params.assigned_to) === 123)
+        .reply(200, {
+          _embedded: {
+            conversations: [
+              { id: 789, subject: 'Assigned', status: 'active', createdAt: '2023-01-01T00:00:00Z', customer: { id: 1 } },
+            ],
+          },
+          _links: { next: { href: '/conversations?page=3' } },
+          page: { size: 50, totalElements: 90, totalPages: 2, number: 2 }
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'structuredConversationFilter',
+          arguments: { assignedTo: 123, page: 2 },
+        },
+      });
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+
+      expect(response.results).toHaveLength(1);
+      expect(response.pagination).toEqual({ size: 50, totalElements: 90, totalPages: 2, number: 2 });
+      expect(response.nextPage).toBeNull();
+      expect(response.nextCursor).toBeUndefined();
     });
   });
 
@@ -283,15 +457,13 @@ describe('ToolHandler', () => {
 
   describe('API Constraints Validation - Branch Coverage', () => {
     it('should handle validation failures with required prerequisites', async () => {
-      // Set user context that mentions an inbox
-      toolHandler.setUserContext('search the support inbox for urgent tickets');
-      
       const request: CallToolRequest = {
         method: 'tools/call',
         params: {
           name: 'searchConversations',
           arguments: {
             query: 'urgent',
+            __userQuery: 'search the support inbox for urgent tickets',
             // No inboxId provided despite mentioning "support inbox"
           }
         }
@@ -328,12 +500,14 @@ describe('ToolHandler', () => {
         }
       });
 
-      toolHandler.setUserContext('search the support inbox for urgent tickets');
       const result = await toolHandler.callTool({
         method: 'tools/call',
         params: {
           name: 'searchConversations',
-          arguments: { query: 'urgent' }
+          arguments: {
+            query: 'urgent',
+            __userQuery: 'search the support inbox for urgent tickets',
+          }
         }
       });
 
@@ -475,14 +649,13 @@ describe('ToolHandler', () => {
     });
 
     it('should handle comprehensive search with no inbox ID when required', async () => {
-      toolHandler.setUserContext('search conversations in the support mailbox');
-
       const request: CallToolRequest = {
         method: 'tools/call',
         params: {
           name: 'comprehensiveConversationSearch',
           arguments: {
-            searchTerms: ['urgent']
+            searchTerms: ['urgent'],
+            __userQuery: 'search conversations in the support mailbox',
             // Missing inboxId despite mentioning "support mailbox"
           }
         }
@@ -498,6 +671,52 @@ describe('ToolHandler', () => {
       // In test environment, any of these outcomes is acceptable
       expect(response.error || response.details?.requiredPrerequisites || result.isError || response.totalConversationsFound !== undefined).toBeTruthy();
     }, 30000); // Extended timeout for retry logic
+
+    it('should not reuse user query context across tool calls', async () => {
+      const blockedResult = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'searchConversations',
+          arguments: {
+            query: 'urgent',
+            __userQuery: 'search the support inbox for urgent tickets',
+          },
+        },
+      });
+      const blockedResponse = JSON.parse((blockedResult.content[0] as { type: 'text'; text: string }).text);
+      expect(blockedResponse.error).toBe('API Constraint Validation Failed');
+
+      nock(baseURL)
+        .get('/conversations')
+        .query(true)
+        .reply(200, {
+          _embedded: {
+            conversations: [
+              {
+                id: 123,
+                subject: 'Urgent billing issue',
+                status: 'active',
+                createdAt: '2023-01-01T00:00:00Z',
+                customer: { id: 1 },
+              },
+            ],
+          },
+          page: { size: 50, totalElements: 1, totalPages: 1, number: 1 },
+        });
+
+      const nextResult = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'searchConversations',
+          arguments: { query: 'urgent', status: 'active' },
+        },
+      });
+      const nextResponse = JSON.parse((nextResult.content[0] as { type: 'text'; text: string }).text);
+
+      expect(nextResponse.error).toBeUndefined();
+      expect(nextResponse.results).toHaveLength(1);
+      expect(nextResponse.results[0].subject).toBe('Urgent billing issue');
+    });
   });
 
   describe('getConversationSummary', () => {
@@ -915,14 +1134,13 @@ describe('ToolHandler', () => {
     }, 30000); // Extended timeout for retry logic
 
     it('should handle invalid inboxId format validation', async () => {
-      toolHandler.setUserContext('search the support inbox');
-      
       const request: CallToolRequest = {
         method: 'tools/call',
         params: {
           name: 'searchConversations',
           arguments: {
             query: 'test',
+            __userQuery: 'search the support inbox',
             inboxId: 'invalid-format'  // Should be numeric
           }
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,19 @@
 import { main } from './index.js';
 import { logger } from './utils/logger.js';
 
-main().catch((error) => {
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  logger.error('Failed to start application', { error: errorMessage });
-  console.error('Application startup failed:', errorMessage);
-  process.exit(1);
-});
+export async function runCli(start = main): Promise<void> {
+  try {
+    await start();
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error('Failed to start application', { error: errorMessage });
+    console.error('Application startup failed:', errorMessage);
+    process.exit(1);
+  }
+}
+
+const invokedPath = (process.argv[1] || '').replace(/\\/g, '/');
+
+if (invokedPath.endsWith('/dist/cli.js') || invokedPath.endsWith('/src/cli.ts')) {
+  void runCli();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { resourceHandler } from './resources/index.js';
 import { toolHandler } from './tools/index.js';
 import { promptHandler } from './prompts/index.js';
 import type { Inbox } from './schema/types.js';
+import { createMcpResourceError } from './utils/mcp-errors.js';
 
 function getArgumentKeys(args: unknown): string[] {
   return args && typeof args === 'object' ? Object.keys(args as Record<string, unknown>) : [];
@@ -158,10 +159,21 @@ Note: Inbox auto-discovery failed (${safeError}). Use listAllInboxes tool to see
 
     this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       logger.debug('Reading resource', { uri: request.params.uri });
-      const resource = await resourceHandler.handleResource(request.params.uri);
-      return {
-        contents: [resource],
-      };
+      try {
+        const resource = await resourceHandler.handleResource(request.params.uri);
+        return {
+          contents: [resource],
+        };
+      } catch (error) {
+        return {
+          contents: [
+            createMcpResourceError(error, {
+              resourceUri: request.params.uri,
+              requestId: Math.random().toString(36).substring(7),
+            }),
+          ],
+        };
+      }
     });
 
     // Tools
@@ -183,10 +195,22 @@ Note: Inbox auto-discovery failed (${safeError}). Use listAllInboxes tool to see
         argumentKeys: getArgumentKeys(request.params.arguments),
       });
       const meta = request.params._meta as { userQuery?: unknown } | undefined;
-      if (typeof meta?.userQuery === 'string' && meta.userQuery.trim()) {
-        toolHandler.setUserContext(meta.userQuery);
-      }
-      return await toolHandler.callTool(request);
+      const userQuery = typeof meta?.userQuery === 'string' && meta.userQuery.trim()
+        ? meta.userQuery
+        : undefined;
+      const requestForTool = userQuery
+        ? {
+          ...request,
+          params: {
+            ...request.params,
+            arguments: {
+              ...(request.params.arguments || {}),
+              __userQuery: userQuery,
+            },
+          },
+        }
+        : request;
+      return await toolHandler.callTool(requestForTool);
     });
 
     // Prompts
@@ -248,8 +272,7 @@ Note: Inbox auto-discovery failed (${safeError}). Use listAllInboxes tool to see
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error('Failed to start server', { error: errorMessage });
-      console.error('MCP Server startup failed:', errorMessage);
-      process.exit(1);
+      throw error;
     }
   }
 

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -244,9 +244,9 @@ When analyzing across multiple inboxes:
 
     const prompt = `To search for conversations from the last 7 days, follow these steps:
 
-1. First, get the current server time:
+1. First, get the current MCP host time:
    \`\`\`
-   Use the "getServerTime" tool to get the current timestamp
+   Use the "getServerTime" tool to get the current MCP host timestamp
    \`\`\`
 
 2. Calculate the date 7 days ago from the current time.
@@ -301,7 +301,7 @@ This will return conversations created in the last 7 days, sorted by creation da
 
     const prompt = `To find conversations with urgent or priority tags, follow these steps:
 
-1. Get current server time using the "getServerTime" tool.
+1. Get current MCP host time using the "getServerTime" tool.
 
 2. ${inboxId ? '' : 'CRITICAL: If the user mentioned a specific inbox by name (e.g., "support inbox"), use inbox IDs from the server instructions. If the list may be stale, call "listAllInboxes" to refresh available inbox IDs.\n\n3. '}Search for conversations with urgent-related tags using the "searchConversations" tool.${timeFilter}
 
@@ -373,7 +373,7 @@ Note: The exact tag names may vary by organization. Common urgent tag variations
 
     const prompt = `To show activity in inbox "${inboxId}" over the last ${hours} hours, follow these steps:
 
-1. Get current server time using the "getServerTime" tool.
+1. Get current MCP host time using the "getServerTime" tool.
 
 2. Calculate the timestamp ${hours} hours ago from the current time.
    - Subtract ${hours} hours from the current timestamp

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -42,19 +42,19 @@ export class ResourceHandler {
 
     switch (path) {
       case 'inboxes':
-        return this.getInboxesResource(searchParams);
+        return this.getInboxesResource(uri, searchParams);
       case 'conversations':
-        return this.getConversationsResource(searchParams);
+        return this.getConversationsResource(uri, searchParams);
       case 'threads':
-        return this.getThreadsResource(searchParams);
+        return this.getThreadsResource(uri, searchParams);
       case 'clock':
-        return this.getClockResource();
+        return this.getClockResource(uri);
       default:
         throw new Error(`Unknown resource path: ${path}`);
     }
   }
 
-  private async getInboxesResource(params: Record<string, string>): Promise<TextResourceContents> {
+  private async getInboxesResource(uri: string, params: Record<string, string>): Promise<TextResourceContents> {
     try {
       const response = await helpScoutClient.get<PaginatedResponse<Inbox>>('/mailboxes', {
         page: parseResourceIntegerParam(params, 'page', 1, 1, 10000),
@@ -64,7 +64,7 @@ export class ResourceHandler {
       const inboxes = response._embedded?.mailboxes || [];
 
       return {
-        uri: 'helpscout://inboxes',
+        uri,
         mimeType: 'application/json',
         text: JSON.stringify({
           inboxes,
@@ -78,7 +78,7 @@ export class ResourceHandler {
     }
   }
 
-  private async getConversationsResource(params: Record<string, string>): Promise<TextResourceContents> {
+  private async getConversationsResource(uri: string, params: Record<string, string>): Promise<TextResourceContents> {
     try {
       const queryParams: Record<string, unknown> = {
         page: parseResourceIntegerParam(params, 'page', 1, 1, 10000),
@@ -95,7 +95,7 @@ export class ResourceHandler {
       const conversations = response._embedded?.conversations || [];
 
       return {
-        uri: 'helpscout://conversations',
+        uri,
         mimeType: 'application/json',
         text: JSON.stringify({
           conversations,
@@ -109,7 +109,7 @@ export class ResourceHandler {
     }
   }
 
-  private async getThreadsResource(params: Record<string, string>): Promise<TextResourceContents> {
+  private async getThreadsResource(uri: string, params: Record<string, string>): Promise<TextResourceContents> {
     const conversationId = params.conversationId;
     if (!conversationId) {
       throw new Error('conversationId parameter is required for threads resource');
@@ -132,7 +132,7 @@ export class ResourceHandler {
       }));
 
       return {
-        uri: `helpscout://threads?conversationId=${conversationId}`,
+        uri,
         mimeType: 'application/json',
         text: JSON.stringify({
           conversationId,
@@ -150,15 +150,17 @@ export class ResourceHandler {
     }
   }
 
-  private getClockResource(): TextResourceContents {
+  private getClockResource(uri: string): TextResourceContents {
     const now = new Date();
     const serverTime: ServerTime = {
       isoTime: now.toISOString(),
       unixTime: Math.floor(now.getTime() / 1000),
+      source: 'mcp_host_clock',
+      note: 'Timestamp from the local MCP host process clock, not the Help Scout API.',
     };
 
     return {
-      uri: 'helpscout://clock',
+      uri,
       mimeType: 'application/json',
       text: JSON.stringify(serverTime, null, 2),
     };
@@ -186,8 +188,8 @@ export class ResourceHandler {
       },
       {
         uri: 'helpscout://clock',
-        name: 'Server Time',
-        description: 'Current server timestamp for time-relative queries',
+        name: 'MCP Host Clock',
+        description: 'Current local MCP host timestamp for time-relative queries',
         mimeType: 'application/json',
       },
     ];

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -83,7 +83,7 @@ export const ThreadSchema = z.object({
 export const SearchInboxesInputSchema = z.object({
   query: z.string(),
   limit: z.number().int().min(1).max(100).default(50),
-  cursor: z.string().optional(),
+  page: z.number().int().min(1).default(1),
 });
 
 export const SearchConversationsInputSchema = z.object({
@@ -94,7 +94,7 @@ export const SearchConversationsInputSchema = z.object({
   createdAfter: z.string().optional(),
   createdBefore: z.string().optional(),
   limit: z.number().int().min(1).max(100).default(50),
-  cursor: z.string().optional(),
+  page: z.number().int().min(1).default(1),
   sort: z.enum(['createdAt', 'modifiedAt', 'number']).default('createdAt'),
   order: z.enum(['asc', 'desc']).default('desc'),
   fields: z.array(z.string()).optional(),
@@ -103,7 +103,7 @@ export const SearchConversationsInputSchema = z.object({
 export const GetThreadsInputSchema = z.object({
   conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric'),
   limit: z.number().int().min(1).max(200).default(200),
-  cursor: z.string().optional(),
+  page: z.number().int().min(1).default(1),
 });
 
 export const GetConversationSummaryInputSchema = z.object({
@@ -121,6 +121,7 @@ export const AdvancedConversationSearchInputSchema = z.object({
   createdAfter: z.string().optional(),
   createdBefore: z.string().optional(),
   limit: z.number().int().min(1).max(100).default(50),
+  page: z.number().int().min(1).default(1),
 });
 
 export const MultiStatusConversationSearchInputSchema = z.object({
@@ -148,7 +149,7 @@ export const StructuredConversationFilterInputSchema = z.object({
   sortBy: z.enum(['createdAt', 'modifiedAt', 'number', 'waitingSince', 'customerName', 'customerEmail', 'mailboxId', 'status', 'subject']).default('createdAt'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
   limit: z.number().int().min(1).max(100).default(50),
-  cursor: z.string().optional(),
+  page: z.number().int().min(1).default(1),
 }).refine(
   (data) => !!(data.assignedTo !== undefined || data.folderId !== undefined || data.customerIds !== undefined || data.conversationNumber !== undefined || (data.sortBy && ['waitingSince', 'customerName', 'customerEmail'].includes(data.sortBy))),
   { message: 'Must use at least one unique field: assignedTo, folderId, customerIds, conversationNumber, or unique sorting. For content search, use comprehensiveConversationSearch.' }
@@ -277,6 +278,8 @@ export const ListAllInboxesInputSchema = z.object({
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
   unixTime: z.number(),
+  source: z.literal('mcp_host_clock'),
+  note: z.string(),
 });
 
 export const ErrorSchema = z.object({

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -70,9 +70,13 @@ const TOOL_CONSTANTS = {
   } as const
 } as const;
 
+function getNextPage(page?: { number?: number; totalPages?: number }): number | null {
+  if (!page || page.number === undefined || page.totalPages === undefined) return null;
+  return page.number < page.totalPages ? page.number + 1 : null;
+}
+
 export class ToolHandler {
   private callHistory: string[] = [];
-  private currentUserQuery?: string;
 
   constructor() {
     // Direct imports, no DI needed
@@ -127,10 +131,10 @@ export class ToolHandler {
   }
 
   /**
-   * Set the current user query for context-aware validation
+   * Deprecated compatibility no-op. Pass __userQuery in tool arguments instead.
    */
-  setUserContext(userQuery: string): void {
-    this.currentUserQuery = userQuery;
+  setUserContext(_userQuery: string): void {
+    // Request-scoped context is carried by __userQuery to avoid shared mutable state.
   }
 
   private getToolCallUserQuery(args: Record<string, unknown>): string | undefined {
@@ -157,9 +161,11 @@ export class ToolHandler {
               maximum: TOOL_CONSTANTS.MAX_PAGE_SIZE,
               default: TOOL_CONSTANTS.DEFAULT_PAGE_SIZE,
             },
-            cursor: {
-              type: 'string',
-              description: 'Pagination cursor for next page',
+            page: {
+              type: 'number',
+              minimum: 1,
+              default: 1,
+              description: 'Page number',
             },
           },
           required: ['query'],
@@ -205,9 +211,11 @@ export class ToolHandler {
               maximum: TOOL_CONSTANTS.MAX_PAGE_SIZE,
               default: TOOL_CONSTANTS.DEFAULT_PAGE_SIZE,
             },
-            cursor: {
-              type: 'string',
-              description: 'Pagination cursor for next page',
+            page: {
+              type: 'number',
+              minimum: 1,
+              default: 1,
+              description: 'Page number',
             },
             sort: {
               type: 'string',
@@ -260,9 +268,11 @@ export class ToolHandler {
               maximum: TOOL_CONSTANTS.MAX_THREAD_SIZE,
               default: TOOL_CONSTANTS.DEFAULT_THREAD_SIZE,
             },
-            cursor: {
-              type: 'string',
-              description: 'Pagination cursor for next page',
+            page: {
+              type: 'number',
+              minimum: 1,
+              default: 1,
+              description: 'Page number',
             },
           },
           required: ['conversationId'],
@@ -270,7 +280,7 @@ export class ToolHandler {
       },
       {
         name: 'getServerTime',
-        description: 'Get current server timestamp. Use before date-relative searches to calculate time ranges.',
+        description: 'Get the current MCP host timestamp. Use before date-relative searches to calculate time ranges.',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -346,6 +356,12 @@ export class ToolHandler {
               minimum: 1,
               maximum: TOOL_CONSTANTS.MAX_PAGE_SIZE,
               default: TOOL_CONSTANTS.DEFAULT_PAGE_SIZE,
+            },
+            page: {
+              type: 'number',
+              minimum: 1,
+              default: 1,
+              description: 'Page number',
             },
           },
         },
@@ -425,7 +441,7 @@ export class ToolHandler {
             sortBy: { type: 'string', enum: ['createdAt', 'modifiedAt', 'number', 'waitingSince', 'customerName', 'customerEmail', 'mailboxId', 'status', 'subject'], default: 'createdAt', description: 'waitingSince/customerName/customerEmail are unique to this tool' },
             sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' },
             limit: { type: 'number', minimum: 1, maximum: 100, default: 50 },
-            cursor: { type: 'string' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
           },
         },
       },
@@ -553,11 +569,11 @@ export class ToolHandler {
     logger.info('Tool call started', {
       requestId,
       toolName: request.params.name,
-      argumentKeys: Object.keys(request.params.arguments || {}),
+      argumentKeys: Object.keys(request.params.arguments || {}).filter(key => key !== '__userQuery'),
     });
 
     const args = request.params.arguments || {};
-    const userQuery = this.getToolCallUserQuery(args) ?? this.currentUserQuery;
+    const userQuery = this.getToolCallUserQuery(args);
 
     // REVERSE LOGIC VALIDATION: Check API constraints before making the call
     const validationContext: ToolCallContext = {
@@ -712,7 +728,7 @@ export class ToolHandler {
   private async searchInboxes(args: unknown): Promise<CallToolResult> {
     const input = SearchInboxesInputSchema.parse(args);
     const response = await helpScoutClient.get<PaginatedResponse<Inbox>>('/mailboxes', {
-      page: 1,
+      page: input.page,
       size: input.limit,
     });
 
@@ -735,7 +751,9 @@ export class ToolHandler {
             })),
             query: input.query,
             totalFound: filteredInboxes.length,
-            totalAvailable: inboxes.length,
+            totalAvailable: response.page?.totalElements ?? inboxes.length,
+            pagination: response.page,
+            nextPage: getNextPage(response.page),
             usage: filteredInboxes.length > 0 ? 
               'NEXT STEP: Use the "id" field from these results in your conversation search tools (comprehensiveConversationSearch or searchConversations)' : 
               'No inboxes matched your query. Try a different search term or use empty string "" to list all inboxes.',
@@ -752,7 +770,7 @@ export class ToolHandler {
     const input = SearchConversationsInputSchema.parse(args);
 
     const baseParams: Record<string, unknown> = {
-      page: 1,
+      page: input.page,
       size: input.limit,
       sortField: input.sort,
       sortOrder: input.order,
@@ -948,6 +966,7 @@ export class ToolHandler {
     const results = {
       results: conversations,
       pagination,
+      nextPage: input.status ? getNextPage(originalPagination as { number?: number; totalPages?: number } | undefined) : null,
       searchInfo: {
         query: input.query,
         statusesSearched: searchedStatuses,
@@ -1040,7 +1059,7 @@ export class ToolHandler {
     const response = await helpScoutClient.get<PaginatedResponse<Thread>>(
       `/conversations/${input.conversationId}/threads`,
       {
-        page: 1,
+        page: input.page,
         size: input.limit,
       }
     );
@@ -1061,7 +1080,7 @@ export class ToolHandler {
             conversationId: input.conversationId,
             threads: processedThreads,
             pagination: response.page,
-            nextCursor: response._links?.next?.href,
+            nextPage: getNextPage(response.page),
           }, null, 2),
         },
       ],
@@ -1073,6 +1092,8 @@ export class ToolHandler {
     const serverTime: ServerTime = {
       isoTime: now.toISOString(),
       unixTime: Math.floor(now.getTime() / 1000),
+      source: 'mcp_host_clock',
+      note: 'Timestamp from the local MCP host process clock, not the Help Scout API.',
     };
 
     return {
@@ -1160,7 +1181,7 @@ export class ToolHandler {
 
     // Set up query parameters
     const queryParams: Record<string, unknown> = {
-      page: 1,
+      page: input.page,
       size: input.limit || 50,
       sortField: 'createdAt',
       sortOrder: 'desc',
@@ -1216,7 +1237,7 @@ export class ToolHandler {
               tags: input.tags,
             },
             pagination: paginationInfo,
-            nextCursor: response._links?.next?.href,
+            nextPage: getNextPage(response.page),
             clientSideFiltering: clientSideFiltered ? `createdBefore filter removed ${originalCount - conversations.length} of ${originalCount} results` : undefined,
             note: !effectiveInboxId ? 'Searching ALL inboxes. Set HELPSCOUT_DEFAULT_INBOX_ID for better LLM context.' : undefined,
           }, null, 2),
@@ -1547,7 +1568,7 @@ export class ToolHandler {
     const input = StructuredConversationFilterInputSchema.parse(args);
 
     const queryParams: Record<string, unknown> = {
-      page: 1,
+      page: input.page,
       size: input.limit,
       sortField: input.sortBy,
       sortOrder: input.sortOrder,
@@ -1615,7 +1636,7 @@ export class ToolHandler {
           },
           inboxScope: this.formatInboxScope(effectiveInboxId, input.inboxId),
           pagination: paginationInfo,
-          nextCursor: response._links?.next?.href,
+          nextPage: getNextPage(response.page),
           clientSideFiltering: clientSideFiltered ? `createdBefore filter removed ${originalCount - conversations.length} of ${originalCount} results` : undefined,
           note: 'Structural filtering applied. For content-based search or rep activity, use comprehensiveConversationSearch.',
         }, null, 2),
@@ -1730,6 +1751,7 @@ export class ToolHandler {
           results: slimResults,
           returnedCount: customers.length,
           pagination: response.page,
+          nextPage: getNextPage(response.page),
           usage: 'Use customer.id with getCustomer for full profile (includes emails, phones, address, etc.), or with structuredConversationFilter(customerIds) for their conversations.',
         }, null, 2),
       }],
@@ -1920,8 +1942,7 @@ export class ToolHandler {
           results: organizations.map(org => this.formatOrganization(org)),
           returnedCount: organizations.length,
           pagination: response.page,
-          nextCursor: response._links?.next?.href,
-          nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
+          nextPage: getNextPage(response.page),
           usage: 'Use organization.id with getOrganization for details, getOrganizationMembers for customers, or getOrganizationConversations for support history.',
         }, null, 2),
       }],
@@ -1948,8 +1969,7 @@ export class ToolHandler {
           members: customers.map(c => this.formatCustomer(c)),
           returnedCount: customers.length,
           pagination: response.page,
-          nextCursor: response._links?.next?.href,
-          nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
+          nextPage: getNextPage(response.page),
           usage: 'Use customer.id with getCustomer for full profile or structuredConversationFilter(customerIds) for their conversations.',
         }, null, 2),
       }],
@@ -1986,8 +2006,7 @@ export class ToolHandler {
           })),
           returnedCount: conversations.length,
           pagination: response.page,
-          nextCursor: response._links?.next?.href,
-          nextPage: response._links?.next?.href ? (response.page?.number ?? 0) + 1 : undefined,
+          nextPage: getNextPage(response.page),
           usage: 'Use conversation.id with getThreads to read full message history, or getConversationSummary for a quick overview.',
         }, null, 2),
       }],

--- a/src/utils/api-constraints.ts
+++ b/src/utils/api-constraints.ts
@@ -56,7 +56,7 @@ export class HelpScoutAPIConstraints {
     const suggestions: string[] = [];
     const requiredPrerequisites: string[] = [];
     
-    // CONSTRAINT 1: Inbox name mentioned but no inboxId provided
+    // CONSTRAINT 1: Specific inbox reference but no inboxId provided
     const inboxMentioned = this.detectInboxMention(userQuery);
     const hasInboxId = args.inboxId && typeof args.inboxId === 'string';
     const hasListedInboxes = previousCalls.includes('listAllInboxes') || previousCalls.includes('searchInboxes');
@@ -65,7 +65,7 @@ export class HelpScoutAPIConstraints {
       errors.push('User mentioned an inbox by name but no inboxId provided');
       if (!hasListedInboxes) {
         requiredPrerequisites.push('listAllInboxes');
-        suggestions.push('REQUIRED: Use inbox IDs from server instructions or call listAllInboxes when user mentions inbox names like "support", "sales", "billing", etc.');
+        suggestions.push('REQUIRED: Use inbox IDs from server instructions or call listAllInboxes when user mentions a specific inbox, mailbox, or queue.');
       } else {
         suggestions.push('Use the inbox ID from the listAllInboxes results');
       }
@@ -184,11 +184,6 @@ export class HelpScoutAPIConstraints {
    * Detect if user query mentions an inbox by name
    */
   private static detectInboxMention(userQuery: string): boolean {
-    const inboxKeywords = [
-      'inbox', 'mailbox', 'support', 'sales', 'billing', 'technical', 'general',
-      'customer service', 'help desk', 'contact', 'feedback', 'info', 'admin'
-    ];
-    
     const lowerQuery = userQuery.toLowerCase();
     
     // Look for patterns like "support inbox", "in the sales mailbox", "billing queue"
@@ -197,14 +192,8 @@ export class HelpScoutAPIConstraints {
       /\b([\w\s]+)\s+(?:inbox|mailbox|queue)/,
       /\b(?:inbox|mailbox)\s+([\w\s]+)/
     ];
-    
-    // Check for explicit inbox keywords
-    const hasInboxKeyword = inboxKeywords.some(keyword => lowerQuery.includes(keyword));
-    
-    // Check for inbox mention patterns
-    const hasInboxPattern = patterns.some(pattern => pattern.test(lowerQuery));
-    
-    return hasInboxKeyword || hasInboxPattern;
+
+    return patterns.some(pattern => pattern.test(lowerQuery));
   }
   
   /**

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -40,7 +40,13 @@ export class Cache {
 
   set<T>(prefix: string, data: unknown, value: T, options?: CacheOptions): void {
     const key = this.generateKey(prefix, data);
-    const ttl = options?.ttl ? options.ttl * 1000 : this.defaultTtl;
+    if (options?.ttl !== undefined && options.ttl <= 0) {
+      this.cache.delete(key);
+      logger.debug('Cache skipped', { key, prefix, ttl: options.ttl });
+      return;
+    }
+
+    const ttl = options?.ttl !== undefined ? options.ttl * 1000 : this.defaultTtl;
     
     this.cache.set(key, value, { ttl });
     logger.debug('Cache set', { key, prefix, ttl: ttl / 1000 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -42,6 +42,12 @@ function parseIntegerEnv(name: string, defaultValue: number, min = 0): number {
   return Number.isInteger(parsed) && parsed >= min ? parsed : defaultValue;
 }
 
+function parseLogLevel(defaultValue = 'info'): string {
+  const rawValue = process.env.LOG_LEVEL?.trim();
+  const levels = ['error', 'warn', 'info', 'debug'];
+  return rawValue && levels.includes(rawValue) ? rawValue : defaultValue;
+}
+
 export const config: Config = {
   helpscout: {
     // OAuth2 authentication (Client Credentials flow)
@@ -56,7 +62,7 @@ export const config: Config = {
     maxSize: parseIntegerEnv('MAX_CACHE_SIZE', 10000, 1),
   },
   logging: {
-    level: process.env.LOG_LEVEL || 'info',
+    level: parseLogLevel(),
   },
   security: {
     // Default: show content. Set REDACT_MESSAGE_CONTENT=true to hide message bodies.
@@ -72,8 +78,14 @@ export const config: Config = {
 };
 
 export function validateConfig(): void {
-  // Check if user is trying to use deprecated Personal Access Token
-  if (process.env.HELPSCOUT_API_KEY?.startsWith('Bearer ')) {
+  const hasOAuth2 = Boolean(
+    config.helpscout.clientId &&
+    config.helpscout.clientSecret &&
+    !config.helpscout.clientId.startsWith('Bearer ')
+  );
+
+  // Check if user is trying to use deprecated Personal Access Token as the only credential.
+  if (process.env.HELPSCOUT_API_KEY?.startsWith('Bearer ') && !hasOAuth2) {
     throw new Error(
       'Personal Access Tokens are no longer supported.\n\n' +
       'Help Scout API now requires OAuth2 Client Credentials.\n' +
@@ -86,8 +98,6 @@ export function validateConfig(): void {
       'Get OAuth2 credentials: Help Scout → My Apps → Create Private App'
     );
   }
-
-  const hasOAuth2 = (config.helpscout.clientId && config.helpscout.clientSecret);
 
   if (!hasOAuth2) {
     throw new Error(

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -68,6 +68,7 @@ export class HelpScoutClient {
   private authenticationPromise: Promise<void> | null = null;
   private httpAgent: HttpAgent;
   private httpsAgent: HttpsAgent;
+  private readonly poolConfig: ConnectionPoolConfig;
   private defaultRetryConfig: RetryConfig = {
     retries: 3,
     retryDelay: 1000, // 1 second
@@ -83,23 +84,23 @@ export class HelpScoutClient {
 
   constructor(poolConfig: Partial<ConnectionPoolConfig> = {}) {
     // Merge default pool config with any custom settings
-    const finalPoolConfig = { ...DEFAULT_POOL_CONFIG, ...poolConfig };
+    this.poolConfig = { ...DEFAULT_POOL_CONFIG, ...poolConfig };
     
     // Create HTTP agents with connection pooling
     this.httpAgent = new HttpAgent({
-      keepAlive: finalPoolConfig.keepAlive,
-      keepAliveMsecs: finalPoolConfig.keepAliveMsecs,
-      maxSockets: finalPoolConfig.maxSockets,
-      maxFreeSockets: finalPoolConfig.maxFreeSockets,
-      timeout: finalPoolConfig.timeout,
+      keepAlive: this.poolConfig.keepAlive,
+      keepAliveMsecs: this.poolConfig.keepAliveMsecs,
+      maxSockets: this.poolConfig.maxSockets,
+      maxFreeSockets: this.poolConfig.maxFreeSockets,
+      timeout: this.poolConfig.timeout,
     });
 
     this.httpsAgent = new HttpsAgent({
-      keepAlive: finalPoolConfig.keepAlive,
-      keepAliveMsecs: finalPoolConfig.keepAliveMsecs,
-      maxSockets: finalPoolConfig.maxSockets,
-      maxFreeSockets: finalPoolConfig.maxFreeSockets,
-      timeout: finalPoolConfig.timeout,
+      keepAlive: this.poolConfig.keepAlive,
+      keepAliveMsecs: this.poolConfig.keepAliveMsecs,
+      maxSockets: this.poolConfig.maxSockets,
+      maxFreeSockets: this.poolConfig.maxFreeSockets,
+      timeout: this.poolConfig.timeout,
     });
 
     // Create Axios instance with connection pooling agents
@@ -116,10 +117,10 @@ export class HelpScoutClient {
     this.setupInterceptors();
     
     logger.info('HTTP connection pool initialized', {
-      maxSockets: finalPoolConfig.maxSockets,
-      maxFreeSockets: finalPoolConfig.maxFreeSockets,
-      keepAlive: finalPoolConfig.keepAlive,
-      timeout: finalPoolConfig.timeout,
+      maxSockets: this.poolConfig.maxSockets,
+      maxFreeSockets: this.poolConfig.maxFreeSockets,
+      keepAlive: this.poolConfig.keepAlive,
+      timeout: this.poolConfig.timeout,
     });
   }
 
@@ -266,8 +267,14 @@ export class HelpScoutClient {
   private async authenticate(): Promise<void> {
     try {
       // OAuth2 Client Credentials flow (only supported method)
-      const clientId = config.helpscout.clientId;
-      const clientSecret = config.helpscout.clientSecret;
+      const currentApiKey = process.env.HELPSCOUT_API_KEY || '';
+      const clientId = process.env.HELPSCOUT_APP_ID ||
+        process.env.HELPSCOUT_CLIENT_ID ||
+        (currentApiKey.startsWith('Bearer ') ? '' : currentApiKey) ||
+        config.helpscout.clientId;
+      const clientSecret = process.env.HELPSCOUT_APP_SECRET ||
+        process.env.HELPSCOUT_CLIENT_SECRET ||
+        config.helpscout.clientSecret;
 
       if (!clientId || !clientSecret) {
         throw new Error(
@@ -276,11 +283,22 @@ export class HelpScoutClient {
         );
       }
 
-      const response = await axios.post('https://api.helpscout.net/v2/oauth2/token', {
+      const configuredBaseUrl = this.client.defaults.baseURL || config.helpscout.baseUrl;
+      const baseUrl = configuredBaseUrl.endsWith('/')
+        ? configuredBaseUrl
+        : `${configuredBaseUrl}/`;
+      const tokenUrl = new URL('oauth2/token', baseUrl).toString();
+
+      const response = await this.executeWithRetry(() => axios.post(tokenUrl, {
         grant_type: 'client_credentials',
         client_id: clientId,
         client_secret: clientSecret,
-      });
+      }, {
+        timeout: 30000,
+        httpAgent: this.httpAgent,
+        httpsAgent: this.httpsAgent,
+        validateStatus: (status) => status >= 200 && status < 300,
+      }));
 
       this.accessToken = response.data.access_token;
       this.tokenExpiresAt = Date.now() + (response.data.expires_in * 1000) - 60000; // 1 minute buffer
@@ -499,35 +517,34 @@ export class HelpScoutClient {
     logger.info('All HTTP connections closed');
   }
 
+  private closeIdleSockets(agent: HttpAgent | HttpsAgent): number {
+    let closed = 0;
+    const freeSockets = agent.freeSockets as Record<string, Array<{ destroy: () => void }>>;
+
+    for (const [socketKey, sockets] of Object.entries(freeSockets)) {
+      for (const socket of sockets || []) {
+        socket.destroy();
+        closed++;
+      }
+      delete freeSockets[socketKey];
+    }
+
+    return closed;
+  }
+
   /**
    * Clear idle connections to free up resources
    */
   clearIdleConnections(): void {
     const stats = this.getPoolStats();
-    
-    // Force destroy all agent connections by recreating them
-    this.httpAgent.destroy();
-    this.httpsAgent.destroy();
-    
-    // Recreate agents with same configuration
-    const poolConfig = {
-      keepAlive: true,
-      keepAliveMsecs: 1000,
-      maxSockets: 50,
-      maxFreeSockets: 10,
-      timeout: 30000,
-    };
-    
-    this.httpAgent = new HttpAgent(poolConfig);
-    this.httpsAgent = new HttpsAgent(poolConfig);
-
-    // Update Axios instance to use the new agents
-    this.client.defaults.httpAgent = this.httpAgent;
-    this.client.defaults.httpsAgent = this.httpsAgent;
+    const clearedHttp = this.closeIdleSockets(this.httpAgent);
+    const clearedHttps = this.closeIdleSockets(this.httpsAgent);
 
     logger.debug('Cleared idle connections', {
-      clearedHttp: stats.http.freeSockets,
-      clearedHttps: stats.https.freeSockets,
+      clearedHttp,
+      clearedHttps,
+      activeHttp: stats.http.sockets,
+      activeHttps: stats.https.sockets,
     });
   }
 

--- a/src/utils/mcp-errors.ts
+++ b/src/utils/mcp-errors.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResult, TextResourceContents } from '@modelcontextprotocol/sdk/types.js';
 import { ApiError, ErrorSchema } from '../schema/types.js';
 import { logger } from './logger.js';
 
@@ -130,10 +130,7 @@ export function createMcpResourceError(
     resourceUri: string;
     requestId?: string;
   }
-): {
-  type: 'text';
-  text: string;
-} {
+): TextResourceContents {
   const { resourceUri, requestId } = context;
 
   // Handle our structured API errors
@@ -147,7 +144,8 @@ export function createMcpResourceError(
     });
 
     return {
-      type: 'text',
+      uri: resourceUri,
+      mimeType: 'application/json',
       text: JSON.stringify(
         {
           error: {
@@ -175,7 +173,8 @@ export function createMcpResourceError(
   });
 
   return {
-    type: 'text',
+    uri: resourceUri,
+    mimeType: 'application/json',
     text: JSON.stringify(
       {
         error: {


### PR DESCRIPTION
## Summary
- Replaces cursor inputs with page-number pagination for v2 Help Scout tools and returns `nextPage` where applicable, while preserving v3 customer email cursor behavior.
- Hardens OAuth configuration/retry behavior, connection cleanup, resource errors and URI identity, cache TTL handling, request-scoped user-query validation, CLI startup, and package install behavior.
- Updates docs and regression coverage for MCP host clock semantics and pagination contracts.

## Testing
- `npm test -- --runInBand src/__tests__/resources.test.ts src/__tests__/tools.test.ts src/__tests__/prompts.test.ts`
- `npm test -- --runInBand`
- `npm run type-check`
- `npm run lint`
- `npm audit --audit-level=moderate`
- `npm run build`
- `npm run mcpb:pack`
- `npm run test:docker:ci`
- `npm run test:forensic`
- `npm run dogfood:full`
- `npm run test:docker`

Closes NAS-988
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->