### PR TITLE
fix(NAS-479): guard empty tool response content

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -400,6 +400,27 @@ describe('ToolHandler', () => {
       const textContent = result.content[0] as { type: 'text'; text: string };
       expect(textContent.text).toContain('Unknown tool');
     });
+
+    it('should return a structured error when a tool returns no text content', async () => {
+      jest.spyOn(toolHandler as any, 'searchInboxes').mockResolvedValue({ content: [] });
+
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'searchInboxes',
+          arguments: { query: 'support' },
+        },
+      };
+
+      const result = await toolHandler.callTool(request);
+      expect(result.isError).toBe(true);
+      expect(result.content[0]).toHaveProperty('type', 'text');
+
+      const textContent = result.content[0] as { type: 'text'; text: string };
+      const response = JSON.parse(textContent.text);
+      expect(response.error.code).toBe('TOOL_ERROR');
+      expect(response.error.message).toContain('missing text content');
+    });
   });
 
   describe('searchConversations', () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -678,11 +678,23 @@ export class ToolHandler {
       const duration = Date.now() - startTime;
       // Add to call history for future validation
       this.callHistory.push(request.params.name);
+
+      const firstContent = result.content?.[0];
+      if (!firstContent || firstContent.type !== 'text' || typeof firstContent.text !== 'string') {
+        return createMcpToolError(
+          new Error('Tool returned an invalid MCP response: missing text content'),
+          {
+            toolName: request.params.name,
+            requestId,
+            duration,
+          }
+        );
+      }
       
       // Enhance result with API constraint guidance (best-effort: never turn a success into a failure)
       let guidanceProvided = false;
       try {
-        const originalContent = JSON.parse((result.content[0] as any).text);
+        const originalContent = JSON.parse(firstContent.text);
         const guidance = HelpScoutAPIConstraints.generateToolGuidance(
           request.params.name,
           originalContent,


### PR DESCRIPTION
## Summary
- Return a structured MCP tool error when a tool handler produces an empty or non-text content payload.
- Reuse the validated text content for API guidance injection instead of indexing into `result.content[0]` directly.
- Add a regression test for empty content arrays.

## Testing
- `npm test -- --runInBand src/__tests__/tools.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm audit --audit-level=moderate`
- `npm run build`
- `npm test -- --runInBand`
- `npm run mcpb:pack`
- `npm run test:docker:ci`
- `npm run test:forensic`
- `npm run dogfood:full`
- `npm run test:docker`

Closes NAS-479
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->