### PR TITLE
feat(NAS-714): add operator metadata tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,26 @@ jobs:
         HELPSCOUT_CLIENT_SECRET: ${{ secrets.HELPSCOUT_APP_SECRET }}
       run: npm test -- --runInBand
 
+    - name: Run full dogfood
+      if: matrix.node-version == '20.x'
+      env:
+        HELPSCOUT_APP_ID: ${{ secrets.HELPSCOUT_APP_ID }}
+        HELPSCOUT_APP_SECRET: ${{ secrets.HELPSCOUT_APP_SECRET }}
+        HELPSCOUT_CLIENT_ID: ${{ secrets.HELPSCOUT_APP_ID }}
+        HELPSCOUT_CLIENT_SECRET: ${{ secrets.HELPSCOUT_APP_SECRET }}
+        HELPSCOUT_DEFAULT_INBOX_ID: '359402'
+      run: npm run dogfood:full
+
+    - name: Run authenticated edge-case test
+      if: matrix.node-version == '20.x'
+      env:
+        HELPSCOUT_APP_ID: ${{ secrets.HELPSCOUT_APP_ID }}
+        HELPSCOUT_APP_SECRET: ${{ secrets.HELPSCOUT_APP_SECRET }}
+        HELPSCOUT_CLIENT_ID: ${{ secrets.HELPSCOUT_APP_ID }}
+        HELPSCOUT_CLIENT_SECRET: ${{ secrets.HELPSCOUT_APP_SECRET }}
+        HELPSCOUT_DEFAULT_INBOX_ID: '359402'
+      run: npm run test:forensic
+
     - name: Docker smoke test
       run: npm run test:docker:ci
 

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -162,6 +162,38 @@
     {
       "name": "getOrganizationConversations",
       "description": "List conversations associated with an organization"
+    },
+    {
+      "name": "listTags",
+      "description": "List Help Scout tags with IDs, exact names, and ticket counts"
+    },
+    {
+      "name": "getTag",
+      "description": "Get a Help Scout tag by ID"
+    },
+    {
+      "name": "listUsers",
+      "description": "List Help Scout users with optional exact email or inbox filtering"
+    },
+    {
+      "name": "getUser",
+      "description": "Get a Help Scout user by ID or the authenticated resource owner"
+    },
+    {
+      "name": "listTeams",
+      "description": "List Help Scout teams with IDs for member lookup and reporting"
+    },
+    {
+      "name": "getTeamMembers",
+      "description": "List users who belong to a Help Scout team"
+    },
+    {
+      "name": "listInboxCustomFields",
+      "description": "List custom field definitions and option IDs for an inbox"
+    },
+    {
+      "name": "listInboxFolders",
+      "description": "List folders and counts for a Help Scout inbox"
     }
   ],
   "prompts": [

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 17 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(17);
+    it('should have all 25 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(25);
 
       const expectedTools = [
         'searchInboxes',
@@ -84,7 +84,15 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'getOrganization',
         'listOrganizations',
         'getOrganizationMembers',
-        'getOrganizationConversations'
+        'getOrganizationConversations',
+        'listTags',
+        'getTag',
+        'listUsers',
+        'getUser',
+        'listTeams',
+        'getTeamMembers',
+        'listInboxCustomFields',
+        'listInboxFolders'
       ];
 
       const toolNames = manifest.tools.map((tool: any) => tool.name);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -37,7 +37,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(17);
+      expect(tools).toHaveLength(25);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -56,6 +56,14 @@ describe('ToolHandler', () => {
         'listOrganizations',
         'getOrganizationMembers',
         'getOrganizationConversations',
+        'listTags',
+        'getTag',
+        'listUsers',
+        'getUser',
+        'listTeams',
+        'getTeamMembers',
+        'listInboxCustomFields',
+        'listInboxFolders',
       ]);
     });
 
@@ -80,6 +88,10 @@ describe('ToolHandler', () => {
         'getThreads',
         'advancedConversationSearch',
         'structuredConversationFilter',
+        'listTags',
+        'listUsers',
+        'listTeams',
+        'getTeamMembers',
       ];
 
       for (const toolName of pageBasedTools) {
@@ -207,6 +219,216 @@ describe('ToolHandler', () => {
       const response = JSON.parse(textContent.text);
       expect(response.results).toHaveLength(1);
       expect(response.results[0].name).toBe('Support Inbox');
+    });
+  });
+
+  describe('operator metadata tools', () => {
+    it('should list tags with optional name filtering', async () => {
+      nock(baseURL)
+        .get('/tags')
+        .query({ page: 1 })
+        .reply(200, {
+          _embedded: {
+            tags: [
+              { id: 10, slug: 'billing', name: 'Billing', color: 'green', createdAt: '2023-01-01T00:00:00Z', ticketCount: 4 },
+              { id: 11, slug: 'shipping', name: 'Shipping', color: 'blue', createdAt: '2023-01-01T00:00:00Z', ticketCount: 1 },
+            ],
+          },
+          page: { number: 1, size: 50, totalElements: 2, totalPages: 1 },
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listTags',
+          arguments: { name: 'bill' },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.tags).toHaveLength(1);
+      expect(response.tags[0]).toEqual(expect.objectContaining({ id: 10, name: 'Billing', slug: 'billing' }));
+      expect(response.usage).toContain('tag');
+      expect(response.nextPage).toBeNull();
+    });
+
+    it('should get a tag by ID', async () => {
+      nock(baseURL)
+        .get('/tags/10')
+        .reply(200, {
+          id: 10,
+          slug: 'billing',
+          name: 'Billing',
+          color: 'green',
+          createdAt: '2023-01-01T00:00:00Z',
+          updatedAt: '2023-01-02T00:00:00Z',
+          ticketCount: 4,
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getTag',
+          arguments: { tagId: '10' },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.tag).toEqual(expect.objectContaining({ id: 10, name: 'Billing' }));
+    });
+
+    it('should list users with email and inbox filters', async () => {
+      nock(baseURL)
+        .get('/users')
+        .query({ page: 2, email: 'agent@example.com', mailbox: 359402 })
+        .reply(200, {
+          _embedded: {
+            users: [
+              { id: 4, firstName: 'Ada', lastName: 'Agent', email: 'agent@example.com', role: 'user', type: 'user', mention: 'ada', initials: 'AA' },
+            ],
+          },
+          page: { number: 2, size: 50, totalElements: 51, totalPages: 2 },
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listUsers',
+          arguments: { email: 'agent@example.com', inboxId: '359402', page: 2 },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.users).toHaveLength(1);
+      expect(response.users[0]).toEqual(expect.objectContaining({ id: 4, email: 'agent@example.com', mention: 'ada' }));
+      expect(response.nextPage).toBeNull();
+    });
+
+    it('should get a user by ID and support the authenticated user shortcut', async () => {
+      nock(baseURL)
+        .get('/users/4')
+        .reply(200, { id: 4, firstName: 'Ada', lastName: 'Agent', email: 'agent@example.com', role: 'user', type: 'user' });
+      nock(baseURL)
+        .get('/users/me')
+        .reply(200, { id: 5, firstName: 'Resource', lastName: 'Owner', email: 'owner@example.com', role: 'owner', type: 'user', companyId: 1 });
+
+      const byId = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getUser',
+          arguments: { userId: '4' },
+        },
+      });
+      const current = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getUser',
+          arguments: { userId: 'me' },
+        },
+      });
+
+      expect(JSON.parse((byId.content[0] as { type: 'text'; text: string }).text).user.id).toBe(4);
+      expect(JSON.parse((current.content[0] as { type: 'text'; text: string }).text).user).toEqual(expect.objectContaining({
+        id: 5,
+        companyId: 1,
+      }));
+    });
+
+    it('should list teams and team members', async () => {
+      nock(baseURL)
+        .get('/teams')
+        .query({ page: 1 })
+        .reply(200, {
+          _embedded: {
+            teams: [
+              { id: 99, name: 'Support', mention: 'support', initials: 'S', createdAt: '2023-01-01T00:00:00Z' },
+            ],
+          },
+          page: { number: 1, size: 50, totalElements: 1, totalPages: 1 },
+        });
+      nock(baseURL)
+        .get('/teams/99/members')
+        .query({ page: 1 })
+        .reply(200, {
+          _embedded: {
+            users: [
+              { id: 4, firstName: 'Ada', lastName: 'Agent', email: 'agent@example.com', role: 'user', type: 'user' },
+            ],
+          },
+          page: { number: 1, size: 50, totalElements: 1, totalPages: 1 },
+        });
+
+      const teams = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listTeams',
+          arguments: {},
+        },
+      });
+      const members = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getTeamMembers',
+          arguments: { teamId: '99' },
+        },
+      });
+
+      expect(JSON.parse((teams.content[0] as { type: 'text'; text: string }).text).teams[0]).toEqual(expect.objectContaining({ id: 99, name: 'Support' }));
+      expect(JSON.parse((members.content[0] as { type: 'text'; text: string }).text).members[0]).toEqual(expect.objectContaining({ id: 4, email: 'agent@example.com' }));
+    });
+
+    it('should list inbox custom fields and folders', async () => {
+      nock(baseURL)
+        .get('/mailboxes/359402/fields')
+        .reply(200, {
+          _embedded: {
+            fields: [
+              {
+                id: 104,
+                required: false,
+                order: 1,
+                type: 'dropdown',
+                name: 'Plan',
+                options: [{ id: 168, order: 1, label: 'Pro' }],
+              },
+            ],
+          },
+          page: { number: 1, size: 50, totalElements: 1, totalPages: 1 },
+        });
+      nock(baseURL)
+        .get('/mailboxes/359402/folders')
+        .reply(200, {
+          _embedded: {
+            folders: [
+              { id: 1234, name: 'Mine', type: 'mytickets', userId: 4, totalCount: 2, activeCount: 1, updatedAt: '2023-01-01T00:00:00Z' },
+            ],
+          },
+          page: { number: 1, size: 50, totalElements: 1, totalPages: 1 },
+        });
+
+      const fields = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listInboxCustomFields',
+          arguments: { inboxId: '359402' },
+        },
+      });
+      const folders = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listInboxFolders',
+          arguments: { inboxId: '359402' },
+        },
+      });
+
+      const fieldsResponse = JSON.parse((fields.content[0] as { type: 'text'; text: string }).text);
+      const foldersResponse = JSON.parse((folders.content[0] as { type: 'text'; text: string }).text);
+      expect(fieldsResponse.fields[0]).toEqual(expect.objectContaining({ id: 104, name: 'Plan', type: 'dropdown' }));
+      expect(fieldsResponse.fields[0].options[0]).toEqual(expect.objectContaining({ id: 168, label: 'Pro' }));
+      expect(foldersResponse.folders[0]).toEqual(expect.objectContaining({ id: 1234, name: 'Mine', activeCount: 1 }));
     });
   });
 

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -218,6 +218,69 @@ export const OrganizationSchema = z.object({
   updatedAt: z.string().optional(),
 });
 
+export const TagSchema = z.object({
+  id: z.number(),
+  slug: z.string().optional(),
+  name: z.string(),
+  color: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  ticketCount: z.number().optional(),
+});
+
+export const UserSchema = z.object({
+  id: z.number(),
+  firstName: z.string().nullable().optional(),
+  lastName: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+  role: z.string().optional(),
+  timezone: z.string().nullable().optional(),
+  photoUrl: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  type: z.string().optional(),
+  mention: z.string().nullable().optional(),
+  initials: z.string().nullable().optional(),
+  jobTitle: z.string().nullable().optional(),
+  phone: z.string().nullable().optional(),
+  alternateEmails: z.array(z.string()).optional(),
+  companyId: z.number().optional(),
+});
+
+export const TeamSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  timezone: z.string().nullable().optional(),
+  photoUrl: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  mention: z.string().nullable().optional(),
+  initials: z.string().nullable().optional(),
+});
+
+export const InboxCustomFieldSchema = z.object({
+  id: z.number(),
+  required: z.boolean().optional(),
+  order: z.number().optional(),
+  type: z.string(),
+  name: z.string(),
+  options: z.array(z.object({
+    id: z.number(),
+    order: z.number().optional(),
+    label: z.string(),
+  })).optional(),
+});
+
+export const InboxFolderSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  type: z.string().optional(),
+  userId: z.number().optional(),
+  totalCount: z.number().optional(),
+  activeCount: z.number().optional(),
+  updatedAt: z.string().optional(),
+});
+
 // Customer & Organization Input Schemas
 export const GetCustomerInputSchema = z.object({
   customerId: z.string().regex(/^\d+$/, 'Customer ID must be numeric').describe('Customer ID'),
@@ -274,6 +337,45 @@ export const ListAllInboxesInputSchema = z.object({
   limit: z.number().int().min(1).max(100).default(100),
 });
 
+export const ListTagsInputSchema = z.object({
+  name: z.string().optional().describe('Case-insensitive client-side filter by tag name'),
+  page: z.number().int().min(1).default(1),
+});
+
+export const GetTagInputSchema = z.object({
+  tagId: z.string().regex(/^\d+$/, 'Tag ID must be numeric').describe('Tag ID'),
+});
+
+export const ListUsersInputSchema = z.object({
+  email: z.string().optional().describe('Exact email match'),
+  inboxId: z.string().regex(/^\d+$/, 'Inbox ID must be numeric').optional().describe('Filter by inbox ID'),
+  page: z.number().int().min(1).default(1),
+});
+
+export const GetUserInputSchema = z.object({
+  userId: z.union([
+    z.literal('me'),
+    z.string().regex(/^\d+$/, 'User ID must be numeric or "me"'),
+  ]).describe('User ID or "me" for the authenticated resource owner'),
+});
+
+export const ListTeamsInputSchema = z.object({
+  page: z.number().int().min(1).default(1),
+});
+
+export const GetTeamMembersInputSchema = z.object({
+  teamId: z.string().regex(/^\d+$/, 'Team ID must be numeric').describe('Team ID'),
+  page: z.number().int().min(1).default(1),
+});
+
+export const ListInboxCustomFieldsInputSchema = z.object({
+  inboxId: z.string().regex(/^\d+$/, 'Inbox ID must be numeric').describe('Inbox ID'),
+});
+
+export const ListInboxFoldersInputSchema = z.object({
+  inboxId: z.string().regex(/^\d+$/, 'Inbox ID must be numeric').describe('Inbox ID'),
+});
+
 // Response Types
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
@@ -296,6 +398,11 @@ export type Thread = z.infer<typeof ThreadSchema>;
 export type Customer = z.infer<typeof CustomerSchema>;
 export type CustomerAddress = z.infer<typeof CustomerAddressSchema>;
 export type Organization = z.infer<typeof OrganizationSchema>;
+export type Tag = z.infer<typeof TagSchema>;
+export type User = z.infer<typeof UserSchema>;
+export type Team = z.infer<typeof TeamSchema>;
+export type InboxCustomField = z.infer<typeof InboxCustomFieldSchema>;
+export type InboxFolder = z.infer<typeof InboxFolderSchema>;
 export type SearchInboxesInput = z.infer<typeof SearchInboxesInputSchema>;
 export type SearchConversationsInput = z.infer<typeof SearchConversationsInputSchema>;
 export type GetThreadsInput = z.infer<typeof GetThreadsInputSchema>;
@@ -311,5 +418,13 @@ export type GetOrganizationMembersInput = z.infer<typeof GetOrganizationMembersI
 export type GetOrganizationConversationsInput = z.infer<typeof GetOrganizationConversationsInputSchema>;
 export type GetCustomerContactsInput = z.infer<typeof GetCustomerContactsInputSchema>;
 export type ListAllInboxesInput = z.infer<typeof ListAllInboxesInputSchema>;
+export type ListTagsInput = z.infer<typeof ListTagsInputSchema>;
+export type GetTagInput = z.infer<typeof GetTagInputSchema>;
+export type ListUsersInput = z.infer<typeof ListUsersInputSchema>;
+export type GetUserInput = z.infer<typeof GetUserInputSchema>;
+export type ListTeamsInput = z.infer<typeof ListTeamsInputSchema>;
+export type GetTeamMembersInput = z.infer<typeof GetTeamMembersInputSchema>;
+export type ListInboxCustomFieldsInput = z.infer<typeof ListInboxCustomFieldsInputSchema>;
+export type ListInboxFoldersInput = z.infer<typeof ListInboxFoldersInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,11 @@ import {
   Customer,
   CustomerAddress,
   Organization,
+  Tag,
+  User,
+  Team,
+  InboxCustomField,
+  InboxFolder,
   ServerTime,
   SearchInboxesInputSchema,
   SearchConversationsInputSchema,
@@ -30,6 +35,14 @@ import {
   ListOrganizationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetOrganizationConversationsInputSchema,
+  ListTagsInputSchema,
+  GetTagInputSchema,
+  ListUsersInputSchema,
+  GetUserInputSchema,
+  ListTeamsInputSchema,
+  GetTeamMembersInputSchema,
+  ListInboxCustomFieldsInputSchema,
+  ListInboxFoldersInputSchema,
 } from '../schema/types.js';
 
 /**
@@ -559,6 +572,95 @@ export class ToolHandler {
           required: ['organizationId'],
         },
       },
+      {
+        name: 'listTags',
+        description: 'List Help Scout tags used across inboxes. Use to discover tag IDs and exact names before filtering conversations or reports.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Optional case-insensitive client-side tag name filter' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+        },
+      },
+      {
+        name: 'getTag',
+        description: 'Get a Help Scout tag by ID. Use after listTags when an exact tag record is needed.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            tagId: { type: 'string', description: 'Tag ID from listTags' },
+          },
+          required: ['tagId'],
+        },
+      },
+      {
+        name: 'listUsers',
+        description: 'List Help Scout users with optional exact email or inbox filter. Use to discover assignee IDs, mentions, and roles.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', description: 'Exact user email filter' },
+            inboxId: { type: 'string', description: 'Inbox ID to find users with access to that inbox' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+        },
+      },
+      {
+        name: 'getUser',
+        description: 'Get a Help Scout user by ID, or pass "me" to get the authenticated resource owner.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string', description: 'User ID from listUsers, or "me" for the authenticated resource owner' },
+          },
+          required: ['userId'],
+        },
+      },
+      {
+        name: 'listTeams',
+        description: 'List Help Scout teams. Use to discover team IDs before team-member lookup or team-scoped reporting.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+        },
+      },
+      {
+        name: 'getTeamMembers',
+        description: 'List members of a Help Scout team. Use after listTeams to discover user IDs in a team.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            teamId: { type: 'string', description: 'Team ID from listTeams' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+          },
+          required: ['teamId'],
+        },
+      },
+      {
+        name: 'listInboxCustomFields',
+        description: 'List custom field definitions for an inbox, including dropdown option IDs used by conversation filters and updates.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            inboxId: { type: 'string', description: 'Inbox ID from listAllInboxes or server instructions' },
+          },
+          required: ['inboxId'],
+        },
+      },
+      {
+        name: 'listInboxFolders',
+        description: 'List Help Scout folders for an inbox. Use to discover folder IDs and counts before folder-scoped lookups.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            inboxId: { type: 'string', description: 'Inbox ID from listAllInboxes or server instructions' },
+          },
+          required: ['inboxId'],
+        },
+      },
     ];
   }
 
@@ -670,6 +772,30 @@ export class ToolHandler {
           break;
         case 'getOrganizationConversations':
           result = await this.getOrganizationConversations(request.params.arguments || {});
+          break;
+        case 'listTags':
+          result = await this.listTags(request.params.arguments || {});
+          break;
+        case 'getTag':
+          result = await this.getTag(request.params.arguments || {});
+          break;
+        case 'listUsers':
+          result = await this.listUsers(request.params.arguments || {});
+          break;
+        case 'getUser':
+          result = await this.getUser(request.params.arguments || {});
+          break;
+        case 'listTeams':
+          result = await this.listTeams(request.params.arguments || {});
+          break;
+        case 'getTeamMembers':
+          result = await this.getTeamMembers(request.params.arguments || {});
+          break;
+        case 'listInboxCustomFields':
+          result = await this.listInboxCustomFields(request.params.arguments || {});
+          break;
+        case 'listInboxFolders':
+          result = await this.listInboxFolders(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -1150,6 +1276,184 @@ export class ToolHandler {
           }, null, 2),
         },
       ],
+    };
+  }
+
+  private async listTags(args: unknown): Promise<CallToolResult> {
+    const input = ListTagsInputSchema.parse(args);
+    const response = await helpScoutClient.get<PaginatedResponse<Tag>>('/tags', {
+      page: input.page,
+    });
+
+    const tags = response._embedded?.tags || [];
+    const filteredTags = input.name
+      ? tags.filter(tag => tag.name.toLowerCase().includes(input.name!.toLowerCase()))
+      : tags;
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          tags: filteredTags,
+          nameFilter: input.name,
+          totalFound: filteredTags.length,
+          totalAvailable: response.page?.totalElements ?? tags.length,
+          pagination: response.page,
+          nextPage: getNextPage(response.page),
+          usage: filteredTags.length > 0
+            ? 'Use tag.id for report filters that require IDs, or tag.name with conversation tag filters.'
+            : 'No tags matched. Omit name to list tags alphabetically across all inboxes.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getTag(args: unknown): Promise<CallToolResult> {
+    const input = GetTagInputSchema.parse(args);
+    const tag = await helpScoutClient.get<Tag>(`/tags/${input.tagId}`);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          tag,
+          usage: 'Use tag.name with conversation tag filters; use tag.id for report endpoints that expect tag IDs.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listUsers(args: unknown): Promise<CallToolResult> {
+    const input = ListUsersInputSchema.parse(args);
+    const params: Record<string, unknown> = { page: input.page };
+    if (input.email) params.email = input.email;
+    if (input.inboxId) params.mailbox = Number(input.inboxId);
+
+    const response = await helpScoutClient.get<PaginatedResponse<User>>('/users', params);
+    const users = response._embedded?.users || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          users,
+          filters: {
+            email: input.email,
+            inboxId: input.inboxId,
+          },
+          totalUsers: users.length,
+          pagination: response.page,
+          nextPage: getNextPage(response.page),
+          usage: users.length > 0
+            ? 'Use user.id for assignee filters and user.mention when composing Help Scout note/reply text.'
+            : 'No users matched these filters. Try omitting email or inboxId.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getUser(args: unknown): Promise<CallToolResult> {
+    const input = GetUserInputSchema.parse(args);
+    const path = input.userId === 'me' ? '/users/me' : `/users/${input.userId}`;
+    const user = await helpScoutClient.get<User>(path);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          user,
+          usage: 'Use user.id for assignment, assignee filters, and user/team report filters.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listTeams(args: unknown): Promise<CallToolResult> {
+    const input = ListTeamsInputSchema.parse(args);
+    const response = await helpScoutClient.get<PaginatedResponse<Team>>('/teams', {
+      page: input.page,
+    });
+    const teams = response._embedded?.teams || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          teams,
+          totalTeams: teams.length,
+          pagination: response.page,
+          nextPage: getNextPage(response.page),
+          usage: teams.length > 0
+            ? 'Use team.id with getTeamMembers to discover team member user IDs.'
+            : 'No teams returned for this Help Scout account.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getTeamMembers(args: unknown): Promise<CallToolResult> {
+    const input = GetTeamMembersInputSchema.parse(args);
+    const response = await helpScoutClient.get<PaginatedResponse<User>>(`/teams/${input.teamId}/members`, {
+      page: input.page,
+    });
+    const members = response._embedded?.users || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          teamId: input.teamId,
+          members,
+          totalMembers: members.length,
+          pagination: response.page,
+          nextPage: getNextPage(response.page),
+          usage: members.length > 0
+            ? 'Use member.id for assignee filters or user report filters.'
+            : 'No users returned for this team.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listInboxCustomFields(args: unknown): Promise<CallToolResult> {
+    const input = ListInboxCustomFieldsInputSchema.parse(args);
+    const response = await helpScoutClient.get<PaginatedResponse<InboxCustomField>>(`/mailboxes/${input.inboxId}/fields`);
+    const fields = response._embedded?.fields || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          inboxId: input.inboxId,
+          fields,
+          totalFields: fields.length,
+          pagination: response.page,
+          usage: fields.length > 0
+            ? 'Use field.id and dropdown option IDs when filtering or interpreting custom field values.'
+            : 'No custom fields returned for this inbox.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listInboxFolders(args: unknown): Promise<CallToolResult> {
+    const input = ListInboxFoldersInputSchema.parse(args);
+    const response = await helpScoutClient.get<PaginatedResponse<InboxFolder>>(`/mailboxes/${input.inboxId}/folders`);
+    const folders = response._embedded?.folders || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          inboxId: input.inboxId,
+          folders,
+          totalFolders: folders.length,
+          pagination: response.page,
+          usage: folders.length > 0
+            ? 'Use folder.id with structuredConversationFilter for folder-scoped lookups.'
+            : 'No folders returned for this inbox.',
+        }, null, 2),
+      }],
     };
   }
 

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -52,6 +52,14 @@ const EXPECTED_TOOLS = [
   'listOrganizations',
   'getOrganizationMembers',
   'getOrganizationConversations',
+  'listTags',
+  'getTag',
+  'listUsers',
+  'getUser',
+  'listTeams',
+  'getTeamMembers',
+  'listInboxCustomFields',
+  'listInboxFolders',
 ] as const;
 
 type ToolName = typeof EXPECTED_TOOLS[number];
@@ -70,6 +78,9 @@ interface DogfoodContext {
   conversationId?: string;
   conversationNumber?: number;
   assigneeId?: number;
+  tagId?: string;
+  userId?: string;
+  teamId?: string;
   createdAfter?: string;
   createdBefore?: string;
   nextCustomerCursor?: string;
@@ -80,6 +91,7 @@ interface Scenario {
   tool: ToolName;
   args: JsonObject | ((ctx: DogfoodContext) => JsonObject);
   expectError?: boolean;
+  skipIf?: (ctx: DogfoodContext) => string | undefined;
   validate: (data: unknown, result: CallToolResult, ctx: DogfoodContext) => void;
   after?: (data: unknown, result: CallToolResult, ctx: DogfoodContext) => void;
 }
@@ -213,6 +225,13 @@ function dateDaysAhead(days: number): string {
 }
 
 async function runScenario(session: McpDogfoodSession, ctx: DogfoodContext, scenario: Scenario): Promise<void> {
+  const skipReason = scenario.skipIf?.(ctx);
+  if (skipReason) {
+    results.push({ name: scenario.name, tool: scenario.tool, status: 'PASS', durationMs: 0, detail: `SKIP: ${skipReason}` });
+    process.stderr.write(`  ${scenario.tool}: ${scenario.name}... SKIP (${skipReason})\n`);
+    return;
+  }
+
   const args = typeof scenario.args === 'function' ? scenario.args(ctx) : scenario.args;
   const label = `${scenario.tool}: ${scenario.name}`;
   process.stderr.write(`  ${label}...`);
@@ -320,6 +339,115 @@ function buildScenarios(): Scenario[] {
       expectError: true,
       validate: (data) => {
         requireCondition(data !== undefined, 'Expected validation response');
+      },
+    },
+    {
+      tool: 'listTags',
+      name: 'tag discovery',
+      args: { page: 1 },
+      validate: (data) => {
+        requireArray(data, ['tags', 'results'], 'tags');
+      },
+      after: (data, _result, ctx) => {
+        const tags = getArray(data, ['tags', 'results']) as JsonObject[];
+        const preferred = tags.find((tag) => getString(tag.name) === GOLDEN.tag) ?? tags[0];
+        if (preferred?.id) ctx.tagId = String(preferred.id);
+      },
+    },
+    {
+      tool: 'listTags',
+      name: 'tag name filter',
+      args: { name: GOLDEN.tag, page: 1 },
+      validate: (data) => {
+        requireArray(data, ['tags', 'results'], 'tags');
+      },
+    },
+    {
+      tool: 'getTag',
+      name: 'discovered tag details',
+      skipIf: (ctx) => ctx.tagId ? undefined : 'No tag available from listTags',
+      args: (ctx) => ({ tagId: ctx.tagId ?? '0' }),
+      validate: (data) => {
+        const tag = getObject(data, 'tag');
+        requireCondition(tag?.id, 'Missing tag');
+      },
+    },
+    {
+      tool: 'listUsers',
+      name: 'user discovery',
+      args: { page: 1 },
+      validate: (data) => {
+        const users = requireArray(data, ['users', 'results'], 'users') as JsonObject[];
+        requireCondition(users.length > 0, 'No users returned');
+      },
+      after: (data, _result, ctx) => {
+        const users = getArray(data, ['users', 'results']) as JsonObject[];
+        if (users[0]?.id) ctx.userId = String(users[0].id);
+      },
+    },
+    {
+      tool: 'listUsers',
+      name: 'users by inbox filter',
+      args: (ctx) => ({ inboxId: ctx.inboxId, page: 1 }),
+      validate: (data) => {
+        requireArray(data, ['users', 'results'], 'users');
+      },
+    },
+    {
+      tool: 'getUser',
+      name: 'authenticated user shortcut',
+      args: { userId: 'me' },
+      validate: (data, _result, ctx) => {
+        const user = getObject(data, 'user');
+        requireCondition(user?.id, 'Missing user');
+        ctx.userId = String(user.id);
+      },
+    },
+    {
+      tool: 'getUser',
+      name: 'discovered user details',
+      skipIf: (ctx) => ctx.userId ? undefined : 'No user available from listUsers/getUser me',
+      args: (ctx) => ({ userId: ctx.userId ?? 'me' }),
+      validate: (data) => {
+        const user = getObject(data, 'user');
+        requireCondition(user?.id, 'Missing user');
+      },
+    },
+    {
+      tool: 'listTeams',
+      name: 'team discovery',
+      args: { page: 1 },
+      validate: (data) => {
+        requireArray(data, ['teams', 'results'], 'teams');
+      },
+      after: (data, _result, ctx) => {
+        const teams = getArray(data, ['teams', 'results']) as JsonObject[];
+        if (teams[0]?.id) ctx.teamId = String(teams[0].id);
+      },
+    },
+    {
+      tool: 'getTeamMembers',
+      name: 'discovered team members',
+      skipIf: (ctx) => ctx.teamId ? undefined : 'No team available from listTeams',
+      args: (ctx) => ({ teamId: ctx.teamId ?? '0', page: 1 }),
+      validate: (data) => {
+        requireArray(data, ['members', 'users', 'results'], 'members');
+      },
+    },
+    {
+      tool: 'listInboxCustomFields',
+      name: 'inbox custom field definitions',
+      args: (ctx) => ({ inboxId: ctx.inboxId }),
+      validate: (data) => {
+        requireArray(data, ['fields', 'results'], 'fields');
+      },
+    },
+    {
+      tool: 'listInboxFolders',
+      name: 'inbox folders',
+      args: (ctx) => ({ inboxId: ctx.inboxId }),
+      validate: (data) => {
+        requireArray(data, ['folders', 'results'], 'folders');
       },
     },
     {

--- a/tests/test-all-tools-edge-cases.ts
+++ b/tests/test-all-tools-edge-cases.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --loader ts-node/esm
 /**
- * Comprehensive authenticated edge-case test for all 16 MCP tools.
+ * Comprehensive authenticated edge-case test for all 25 MCP tools.
  *
  * Run: node --loader ts-node/esm tests/test-all-tools-edge-cases.ts
  *
@@ -91,11 +91,11 @@ const expectGraceful = (data: any) => ({
 // ---------------------------------------------------------------------------
 
 async function main() {
-  console.error('\n=== Comprehensive Edge-Case Test Suite (16 Tools) ===\n');
+  console.error('\n=== Comprehensive Edge-Case Test Suite (25 Tools) ===\n');
   console.error('  Golden data: Customer ' + GOLDEN.customerId + ', Org ' + GOLDEN.orgId + '\n');
 
   // =========================================================================
-  // CATEGORY 1: Happy Path (all 16 tools with golden data)
+  // CATEGORY 1: Happy Path (all tools with golden data)
   // =========================================================================
 
   await test('happy', 'getServerTime', 'getServerTime', {}, (d) => ({
@@ -117,6 +117,61 @@ async function main() {
     ok: d?.results?.some((r: any) => r.name?.includes('Client')),
     detail: d?.results?.[0]?.name,
   }));
+
+  const tagsResult = await test('happy', 'listTags (page 1)', 'listTags', { page: 1 }, (d) => ({
+    ok: Array.isArray(d?.tags),
+    detail: `${d?.tags?.length || 0} tags`,
+  }));
+
+  const tagId = tagsResult?.tags?.[0]?.id ? String(tagsResult.tags[0].id) : null;
+  if (tagId) {
+    await test('happy', `getTag (ID: ${tagId})`, 'getTag', { tagId }, (d) => ({
+      ok: !!d?.tag?.id,
+      detail: d?.tag?.name,
+    }));
+  }
+
+  const usersResult = await test('happy', 'listUsers (page 1)', 'listUsers', { page: 1 }, (d) => ({
+    ok: Array.isArray(d?.users) && d.users.length > 0,
+    detail: `${d?.users?.length || 0} users`,
+  }));
+
+  const userId = usersResult?.users?.[0]?.id ? String(usersResult.users[0].id) : null;
+  await test('happy', 'getUser (me)', 'getUser', { userId: 'me' }, (d) => ({
+    ok: !!d?.user?.id,
+    detail: d?.user?.email,
+  }));
+  if (userId) {
+    await test('happy', `getUser (ID: ${userId})`, 'getUser', { userId }, (d) => ({
+      ok: !!d?.user?.id,
+      detail: d?.user?.email,
+    }));
+  }
+
+  const teamsResult = await test('happy', 'listTeams (page 1)', 'listTeams', { page: 1 }, (d) => ({
+    ok: Array.isArray(d?.teams),
+    detail: `${d?.teams?.length || 0} teams`,
+  }));
+
+  const teamId = teamsResult?.teams?.[0]?.id ? String(teamsResult.teams[0].id) : null;
+  if (teamId) {
+    await test('happy', `getTeamMembers (ID: ${teamId})`, 'getTeamMembers', { teamId }, (d) => ({
+      ok: Array.isArray(d?.members),
+      detail: `${d?.members?.length || 0} members`,
+    }));
+  }
+
+  await test('happy', 'listInboxCustomFields (golden inbox)', 'listInboxCustomFields',
+    { inboxId: GOLDEN.inboxId }, (d) => ({
+      ok: Array.isArray(d?.fields),
+      detail: `${d?.fields?.length || 0} fields`,
+    }));
+
+  await test('happy', 'listInboxFolders (golden inbox)', 'listInboxFolders',
+    { inboxId: GOLDEN.inboxId }, (d) => ({
+      ok: Array.isArray(d?.folders),
+      detail: `${d?.folders?.length || 0} folders`,
+    }));
 
   let conversationId: string | null = null;
   const convResult = await test('happy', 'searchConversations (default)', 'searchConversations', {}, (d) => ({

--- a/tests/test-docker.cjs
+++ b/tests/test-docker.cjs
@@ -221,7 +221,7 @@ class DockerLiveTester {
     });
     this.assertNoError(tools, 'tools/list');
     const toolNames = tools.result.tools.map(tool => tool.name);
-    for (const required of ['getServerTime', 'listAllInboxes', 'searchInboxes']) {
+    for (const required of ['getServerTime', 'listAllInboxes', 'searchInboxes', 'listTags', 'listUsers', 'listInboxFolders']) {
       if (!toolNames.includes(required)) {
         throw new Error(`Missing expected tool ${required}`);
       }


### PR DESCRIPTION
## Summary
- Add read-only Help Scout metadata tools for tags, users, teams, team members, inbox custom fields, and inbox folders.
- Update MCPB declarations, unit coverage, Docker smoke expectations, and authenticated dogfood scenarios for the expanded 25-tool surface.
- Add CI coverage for full dogfood and authenticated edge-case checks on the Node 20 PR leg using the existing Help Scout Actions secrets.

## Testing
- npm run type-check
- npm run lint
- npm test -- --runInBand
- npm run build
- npm run mcpb:pack
- npm run test:docker:ci
- Local credential-backed dogfood commands require a local .env; repo Actions secrets are present and CI now runs npm run dogfood:full and npm run test:forensic before merge.

Closes NAS-714
Closes NAS-713
Closes NAS-716
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->