### PR TITLE
feat(NAS-724): add property metadata tools

### DIFF
--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -164,6 +164,18 @@
       "description": "List conversations associated with an organization"
     },
     {
+      "name": "listCustomerProperties",
+      "description": "List customer property definitions with slugs, types, and dropdown options"
+    },
+    {
+      "name": "listOrganizationProperties",
+      "description": "List organization property definitions with slugs, types, and dropdown options"
+    },
+    {
+      "name": "getOrganizationProperty",
+      "description": "Get an organization property definition by slug"
+    },
+    {
       "name": "listTags",
       "description": "List Help Scout tags with IDs, exact names, and ticket counts"
     },

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 25 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(25);
+    it('should have all 28 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(28);
 
       const expectedTools = [
         'searchInboxes',
@@ -85,6 +85,9 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'listOrganizations',
         'getOrganizationMembers',
         'getOrganizationConversations',
+        'listCustomerProperties',
+        'listOrganizationProperties',
+        'getOrganizationProperty',
         'listTags',
         'getTag',
         'listUsers',

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -37,7 +37,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(25);
+      expect(tools).toHaveLength(28);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -56,6 +56,9 @@ describe('ToolHandler', () => {
         'listOrganizations',
         'getOrganizationMembers',
         'getOrganizationConversations',
+        'listCustomerProperties',
+        'listOrganizationProperties',
+        'getOrganizationProperty',
         'listTags',
         'getTag',
         'listUsers',
@@ -223,6 +226,98 @@ describe('ToolHandler', () => {
   });
 
   describe('operator metadata tools', () => {
+    it('should list customer property definitions', async () => {
+      nock(baseURL)
+        .get('/customer-properties')
+        .reply(200, {
+          _embedded: {
+            'customer-properties': [
+              { type: 'text', slug: 'car', name: 'Car' },
+              {
+                type: 'dropdown',
+                slug: 'plan',
+                name: 'Plan',
+                options: [
+                  { id: '556cca5f-1afc-48ef-8323-b88b55808404', label: 'Standard' },
+                  { id: '1313b25a-1150-49a4-8514-5b31f37e427f', label: 'Plus' },
+                ],
+              },
+            ],
+          },
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listCustomerProperties',
+          arguments: {},
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.customerProperties).toHaveLength(2);
+      expect(response.customerProperties[1]).toEqual(expect.objectContaining({ slug: 'plan', type: 'dropdown' }));
+      expect(response.customerProperties[1].options[0]).toEqual(expect.objectContaining({ label: 'Standard' }));
+      expect(response.usage).toContain('customer');
+    });
+
+    it('should list and get organization property definitions', async () => {
+      nock(baseURL)
+        .get('/organizations/properties')
+        .reply(200, {
+          _embedded: {
+            'organization-properties': [
+              { type: 'text', slug: 'customer-tier', name: 'Customer Tier' },
+              {
+                type: 'dropdown',
+                slug: 'industry',
+                name: 'Industry',
+                options: [
+                  { label: 'Technology' },
+                  { label: 'Healthcare' },
+                ],
+              },
+            ],
+          },
+        });
+      nock(baseURL)
+        .get('/organizations/properties/industry')
+        .reply(200, {
+          type: 'dropdown',
+          slug: 'industry',
+          name: 'Industry',
+          options: [
+            { label: 'Technology' },
+            { label: 'Healthcare' },
+          ],
+        });
+
+      const list = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'listOrganizationProperties',
+          arguments: {},
+        },
+      });
+      const get = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getOrganizationProperty',
+          arguments: { slug: 'industry' },
+        },
+      });
+
+      const listResponse = JSON.parse((list.content[0] as { type: 'text'; text: string }).text);
+      const getResponse = JSON.parse((get.content[0] as { type: 'text'; text: string }).text);
+      expect(list.isError).toBeUndefined();
+      expect(get.isError).toBeUndefined();
+      expect(listResponse.organizationProperties).toHaveLength(2);
+      expect(listResponse.organizationProperties[1]).toEqual(expect.objectContaining({ slug: 'industry', type: 'dropdown' }));
+      expect(getResponse.organizationProperty).toEqual(expect.objectContaining({ slug: 'industry', name: 'Industry' }));
+      expect(getResponse.organizationProperty.options[0]).toEqual(expect.objectContaining({ label: 'Technology' }));
+    });
+
     it('should list tags with optional name filtering', async () => {
       nock(baseURL)
         .get('/tags')

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -218,6 +218,16 @@ export const OrganizationSchema = z.object({
   updatedAt: z.string().optional(),
 });
 
+export const PropertyDefinitionSchema = z.object({
+  type: z.enum(['text', 'number', 'url', 'date', 'dropdown']),
+  slug: z.string(),
+  name: z.string(),
+  options: z.array(z.object({
+    id: z.string().optional(),
+    label: z.string(),
+  })).optional(),
+});
+
 export const TagSchema = z.object({
   id: z.number(),
   slug: z.string().optional(),
@@ -329,6 +339,14 @@ export const GetOrganizationConversationsInputSchema = z.object({
   page: z.number().int().min(1).default(1),
 });
 
+export const ListCustomerPropertiesInputSchema = z.object({});
+
+export const ListOrganizationPropertiesInputSchema = z.object({});
+
+export const GetOrganizationPropertyInputSchema = z.object({
+  slug: z.string().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/, 'Property slug must be alphanumeric and may include hyphens or underscores'),
+});
+
 export const GetCustomerContactsInputSchema = z.object({
   customerId: z.string().regex(/^\d+$/, 'Customer ID must be numeric').describe('Customer ID'),
 });
@@ -398,6 +416,7 @@ export type Thread = z.infer<typeof ThreadSchema>;
 export type Customer = z.infer<typeof CustomerSchema>;
 export type CustomerAddress = z.infer<typeof CustomerAddressSchema>;
 export type Organization = z.infer<typeof OrganizationSchema>;
+export type PropertyDefinition = z.infer<typeof PropertyDefinitionSchema>;
 export type Tag = z.infer<typeof TagSchema>;
 export type User = z.infer<typeof UserSchema>;
 export type Team = z.infer<typeof TeamSchema>;
@@ -416,6 +435,9 @@ export type GetOrganizationInput = z.infer<typeof GetOrganizationInputSchema>;
 export type ListOrganizationsInput = z.infer<typeof ListOrganizationsInputSchema>;
 export type GetOrganizationMembersInput = z.infer<typeof GetOrganizationMembersInputSchema>;
 export type GetOrganizationConversationsInput = z.infer<typeof GetOrganizationConversationsInputSchema>;
+export type ListCustomerPropertiesInput = z.infer<typeof ListCustomerPropertiesInputSchema>;
+export type ListOrganizationPropertiesInput = z.infer<typeof ListOrganizationPropertiesInputSchema>;
+export type GetOrganizationPropertyInput = z.infer<typeof GetOrganizationPropertyInputSchema>;
 export type GetCustomerContactsInput = z.infer<typeof GetCustomerContactsInputSchema>;
 export type ListAllInboxesInput = z.infer<typeof ListAllInboxesInputSchema>;
 export type ListTagsInput = z.infer<typeof ListTagsInputSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import {
   Customer,
   CustomerAddress,
   Organization,
+  PropertyDefinition,
   Tag,
   User,
   Team,
@@ -35,6 +36,9 @@ import {
   ListOrganizationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetOrganizationConversationsInputSchema,
+  ListCustomerPropertiesInputSchema,
+  ListOrganizationPropertiesInputSchema,
+  GetOrganizationPropertyInputSchema,
   ListTagsInputSchema,
   GetTagInputSchema,
   ListUsersInputSchema,
@@ -573,6 +577,33 @@ export class ToolHandler {
         },
       },
       {
+        name: 'listCustomerProperties',
+        description: 'List customer property definitions. Use to interpret custom property values embedded on customer records.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'listOrganizationProperties',
+        description: 'List organization property definitions. Use to interpret custom company property values embedded on organizations.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'getOrganizationProperty',
+        description: 'Get one organization property definition by slug. Use after listOrganizationProperties when exact option labels are needed.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            slug: { type: 'string', description: 'Organization property slug from listOrganizationProperties' },
+          },
+          required: ['slug'],
+        },
+      },
+      {
         name: 'listTags',
         description: 'List Help Scout tags used across inboxes. Use to discover tag IDs and exact names before filtering conversations or reports.',
         inputSchema: {
@@ -772,6 +803,15 @@ export class ToolHandler {
           break;
         case 'getOrganizationConversations':
           result = await this.getOrganizationConversations(request.params.arguments || {});
+          break;
+        case 'listCustomerProperties':
+          result = await this.listCustomerProperties(request.params.arguments || {});
+          break;
+        case 'listOrganizationProperties':
+          result = await this.listOrganizationProperties(request.params.arguments || {});
+          break;
+        case 'getOrganizationProperty':
+          result = await this.getOrganizationProperty(request.params.arguments || {});
           break;
         case 'listTags':
           result = await this.listTags(request.params.arguments || {});
@@ -1303,6 +1343,65 @@ export class ToolHandler {
           usage: filteredTags.length > 0
             ? 'Use tag.id for report filters that require IDs, or tag.name with conversation tag filters.'
             : 'No tags matched. Omit name to list tags alphabetically across all inboxes.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listCustomerProperties(args: unknown): Promise<CallToolResult> {
+    ListCustomerPropertiesInputSchema.parse(args);
+    const response = await helpScoutClient.get<{
+      _embedded?: { 'customer-properties'?: PropertyDefinition[] };
+    }>('/customer-properties');
+    const properties = response._embedded?.['customer-properties'] || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          customerProperties: properties,
+          totalProperties: properties.length,
+          usage: properties.length > 0
+            ? 'Use property.slug to interpret values embedded on customer records.'
+            : 'No customer property definitions returned for this account.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async listOrganizationProperties(args: unknown): Promise<CallToolResult> {
+    ListOrganizationPropertiesInputSchema.parse(args);
+    const response = await helpScoutClient.get<{
+      _embedded?: { 'organization-properties'?: PropertyDefinition[] };
+    }>('/organizations/properties');
+    const properties = response._embedded?.['organization-properties'] || [];
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          organizationProperties: properties,
+          totalProperties: properties.length,
+          usage: properties.length > 0
+            ? 'Use property.slug with getOrganizationProperty, and to interpret values embedded on organization records.'
+            : 'No organization property definitions returned for this account.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getOrganizationProperty(args: unknown): Promise<CallToolResult> {
+    const input = GetOrganizationPropertyInputSchema.parse(args);
+    const property = await helpScoutClient.get<PropertyDefinition>(`/organizations/properties/${input.slug}`);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          organizationProperty: property,
+          usage: property.type === 'dropdown'
+            ? 'Use option labels exactly as returned when interpreting or setting organization property values.'
+            : 'Use property.slug to interpret values embedded on organization records.',
         }, null, 2),
       }],
     };

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -52,6 +52,9 @@ const EXPECTED_TOOLS = [
   'listOrganizations',
   'getOrganizationMembers',
   'getOrganizationConversations',
+  'listCustomerProperties',
+  'listOrganizationProperties',
+  'getOrganizationProperty',
   'listTags',
   'getTag',
   'listUsers',
@@ -81,6 +84,7 @@ interface DogfoodContext {
   tagId?: string;
   userId?: string;
   teamId?: string;
+  organizationPropertySlug?: string;
   createdAfter?: string;
   createdBefore?: string;
   nextCustomerCursor?: string;
@@ -339,6 +343,36 @@ function buildScenarios(): Scenario[] {
       expectError: true,
       validate: (data) => {
         requireCondition(data !== undefined, 'Expected validation response');
+      },
+    },
+    {
+      tool: 'listCustomerProperties',
+      name: 'customer property definition discovery',
+      args: {},
+      validate: (data) => {
+        requireArray(data, ['customerProperties', 'properties', 'results'], 'customerProperties');
+      },
+    },
+    {
+      tool: 'listOrganizationProperties',
+      name: 'organization property definition discovery',
+      args: {},
+      validate: (data) => {
+        requireArray(data, ['organizationProperties', 'properties', 'results'], 'organizationProperties');
+      },
+      after: (data, _result, ctx) => {
+        const properties = getArray(data, ['organizationProperties', 'properties', 'results']) as JsonObject[];
+        if (properties[0]?.slug) ctx.organizationPropertySlug = String(properties[0].slug);
+      },
+    },
+    {
+      tool: 'getOrganizationProperty',
+      name: 'discovered organization property details',
+      skipIf: (ctx) => ctx.organizationPropertySlug ? undefined : 'No organization property available from listOrganizationProperties',
+      args: (ctx) => ({ slug: ctx.organizationPropertySlug ?? 'missing' }),
+      validate: (data) => {
+        const property = getObject(data, 'organizationProperty');
+        requireCondition(property?.slug, 'Missing organization property');
       },
     },
     {

--- a/tests/test-all-tools-edge-cases.ts
+++ b/tests/test-all-tools-edge-cases.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --loader ts-node/esm
 /**
- * Comprehensive authenticated edge-case test for all 25 MCP tools.
+ * Comprehensive authenticated edge-case test for all 28 MCP tools.
  *
  * Run: node --loader ts-node/esm tests/test-all-tools-edge-cases.ts
  *
@@ -91,7 +91,7 @@ const expectGraceful = (data: any) => ({
 // ---------------------------------------------------------------------------
 
 async function main() {
-  console.error('\n=== Comprehensive Edge-Case Test Suite (25 Tools) ===\n');
+  console.error('\n=== Comprehensive Edge-Case Test Suite (28 Tools) ===\n');
   console.error('  Golden data: Customer ' + GOLDEN.customerId + ', Org ' + GOLDEN.orgId + '\n');
 
   // =========================================================================
@@ -117,6 +117,24 @@ async function main() {
     ok: d?.results?.some((r: any) => r.name?.includes('Client')),
     detail: d?.results?.[0]?.name,
   }));
+
+  await test('happy', 'listCustomerProperties', 'listCustomerProperties', {}, (d) => ({
+    ok: Array.isArray(d?.customerProperties),
+    detail: `${d?.customerProperties?.length || 0} customer properties`,
+  }));
+
+  const orgPropertiesResult = await test('happy', 'listOrganizationProperties', 'listOrganizationProperties', {}, (d) => ({
+    ok: Array.isArray(d?.organizationProperties),
+    detail: `${d?.organizationProperties?.length || 0} organization properties`,
+  }));
+
+  const orgPropertySlug = orgPropertiesResult?.organizationProperties?.[0]?.slug;
+  if (orgPropertySlug) {
+    await test('happy', `getOrganizationProperty (${orgPropertySlug})`, 'getOrganizationProperty', { slug: orgPropertySlug }, (d) => ({
+      ok: !!d?.organizationProperty?.slug,
+      detail: d?.organizationProperty?.name,
+    }));
+  }
 
   const tagsResult = await test('happy', 'listTags (page 1)', 'listTags', { page: 1 }, (d) => ({
     ok: Array.isArray(d?.tags),

--- a/tests/test-docker.cjs
+++ b/tests/test-docker.cjs
@@ -221,7 +221,7 @@ class DockerLiveTester {
     });
     this.assertNoError(tools, 'tools/list');
     const toolNames = tools.result.tools.map(tool => tool.name);
-    for (const required of ['getServerTime', 'listAllInboxes', 'searchInboxes', 'listTags', 'listUsers', 'listInboxFolders']) {
+    for (const required of ['getServerTime', 'listAllInboxes', 'searchInboxes', 'listTags', 'listUsers', 'listInboxFolders', 'listCustomerProperties', 'listOrganizationProperties']) {
       if (!toolNames.includes(required)) {
         throw new Error(`Missing expected tool ${required}`);
       }


### PR DESCRIPTION
## Summary
- Add customer property definition discovery so customer custom fields can be interpreted from returned records.
- Add organization property listing and single-property lookup by slug.
- Update MCPB declarations plus unit, manifest, Docker, dogfood, and authenticated edge-case coverage for the new tools.

## Testing
- npm run type-check
- npm run lint
- npm test -- --runInBand
- npm run build
- npm run mcpb:build
- npm run mcpb:pack
- npm run test:docker:ci
- Local diff review check: 0 open findings
- npm run dogfood:full: blocked locally because this worktree has no Help Scout env vars; the same dogfood path runs in PR CI with repository secrets

Closes NAS-724
Closes NAS-1281
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->