### PR TITLE
docs(NAS-1280): define MCP tool contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Alternative names `HELPSCOUT_CLIENT_ID` / `HELPSCOUT_CLIENT_SECRET` and legacy `
 
 ## Tools
 
+For the MCP compatibility contract and roadmap, see:
+
+- [MCP tool contract](guides/architecture/mcp-tool-contract.md)
+- [MCP vs CLI boundary](guides/architecture/mcp-vs-cli.md)
+- [MCP tool surface roadmap](guides/roadmap/mcp-tool-surface.md)
+
 ### Which tool should I use?
 
 | Task | Tool | Example |

--- a/guides/architecture/mcp-tool-contract.md
+++ b/guides/architecture/mcp-tool-contract.md
@@ -1,0 +1,140 @@
+# MCP Tool Contract
+
+This server targets the latest stable Model Context Protocol specification:
+`2025-11-25`.
+
+The official MCP documentation labels `2025-11-25` as the latest stable
+specification. Draft documentation may describe proposed newer protocol shapes,
+including the `2026-07-28` draft stream, but those draft behaviors are not a
+required compatibility target until they are published as stable.
+
+Source references:
+
+- https://modelcontextprotocol.io/specification/2025-11-25
+- https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+- https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+
+## Compatibility Baseline
+
+- The stdio server remains the primary transport.
+- Help Scout credentials are read from environment variables for stdio clients.
+- HTTP transport and OAuth authorization are separate future work.
+- Existing clients that parse `content[].text` must keep working.
+- Tool results that expose structured JSON should return both:
+  - `structuredContent` with the JSON object
+  - a serialized JSON `TextContent` block for backward compatibility
+- `outputSchema` should be added only when the result shape is stable enough to
+  validate without breaking normal Help Scout API variation.
+- Tool input and output schemas default to JSON Schema 2020-12 unless an
+  explicit `$schema` is required.
+
+## Tool Metadata
+
+Each MCP tool should have:
+
+- A stable machine name using the existing camelCase naming style.
+- A human-readable `title` for MCP hosts that render display names.
+- A direct, user-intent description, not an internal endpoint description.
+- A valid `inputSchema`. Tools with no arguments should explicitly accept an
+  empty object.
+- `annotations.readOnlyHint: true` for read-only Help Scout tools where the SDK
+  supports it.
+- `outputSchema` once the returned structure is intentionally stable.
+
+Icons are optional display metadata. Add them only when supported by the server
+SDK and packaged clients can consume them consistently.
+
+## Result Shape
+
+All read tools should converge on a predictable result envelope:
+
+```json
+{
+  "data": {},
+  "meta": {
+    "source": "helpscout",
+    "fetchedAt": "2026-06-13T00:00:00.000Z"
+  }
+}
+```
+
+List and search tools should use a collection envelope:
+
+```json
+{
+  "items": [],
+  "page": {
+    "cursor": null,
+    "page": 1,
+    "size": 50,
+    "hasMore": false
+  },
+  "filters": {},
+  "meta": {
+    "source": "helpscout",
+    "fetchedAt": "2026-06-13T00:00:00.000Z"
+  }
+}
+```
+
+The envelope should not hide useful Help Scout fields. Preserve raw identifiers,
+links, timestamps, and relevant embedded objects unless redaction is enabled.
+
+## Error Policy
+
+Use MCP tool results for errors the model can act on:
+
+- Validation errors
+- Missing required arguments
+- Unknown Help Scout IDs
+- Help Scout API errors that return a useful status or message
+- Partial failures where some requested subresources failed
+
+Use protocol-level errors for server or transport failures:
+
+- Invalid MCP messages
+- Startup failure
+- Broken transport
+- Unexpected process errors before the tool handler can respond
+
+Tool errors should be structured and readable, with `isError` set when the MCP
+SDK supports it. Error payloads should include the failing Help Scout status,
+operation, and model-correctable guidance when available.
+
+## Tool Naming
+
+Use names that match support workflows:
+
+- `listX` for browseable metadata and collections.
+- `getX` for direct ID or slug lookups.
+- `searchX` for user-entered query or filter workflows.
+- `summarizeX` only when the server creates a derived support summary.
+
+Avoid exposing raw Help Scout endpoint names when a workflow name is clearer.
+Avoid adding write verbs until write/automation tools have a separate permission
+and consent model.
+
+## Boundaries
+
+Tools are model-controlled and should stay focused on Help Scout data access.
+Use the other MCP feature surfaces deliberately:
+
+- Resources: stable, fetchable context objects such as documentation pages or
+  cached large attachments.
+- Prompts: repeatable support workflows that combine multiple tools.
+- MCP Apps: interactive views layered on top of existing tool data.
+- Sampling and elicitation: out of scope until there is a concrete workflow that
+  requires host-mediated model calls or user input.
+
+## Rollout Order
+
+1. Add `title`, read-only annotations, and explicit empty input schemas across
+   existing tools.
+2. Add `structuredContent` while keeping serialized JSON text.
+3. Add `outputSchema` for the highest-value stable tools first:
+   `getServerTime`, inbox metadata tools, property metadata tools, tag/user/team
+   metadata tools, customer and organization lookups.
+4. Add broader output schemas for conversation search and thread tools after the
+   response envelope is stable.
+5. Extend the dogfood harness to validate tool metadata, structured content, and
+   schema conformance.

--- a/guides/architecture/mcp-vs-cli.md
+++ b/guides/architecture/mcp-vs-cli.md
@@ -1,0 +1,81 @@
+# MCP vs CLI Boundary
+
+The MCP server and local CLI scripts serve different audiences. Keeping that
+boundary clear prevents duplicate product surfaces and makes tests easier to
+trust.
+
+## MCP Surface
+
+MCP tools are for AI hosts and support workflows. They should be typed,
+discoverable, read-only by default, and safe for model-controlled invocation.
+
+Use MCP tools for:
+
+- Searching conversations, customers, organizations, inboxes, and metadata.
+- Fetching full support context for a known Help Scout object.
+- Returning structured result data that hosts can validate and compose.
+- Exposing support workflows through prompts.
+- Supplying interactive MCP Apps views from existing tool data.
+
+MCP tools should not:
+
+- Depend on local repo files.
+- Run package, build, Docker, or deployment commands.
+- Mutate Help Scout data without a separate write-tool permission model.
+- Expose secrets, credential diagnostics, or CI implementation details.
+- Replace operator scripts that are meant for repository maintenance.
+
+## CLI And Script Surface
+
+CLI commands and package scripts are for operators maintaining this package.
+They can assume a local checkout and are allowed to inspect build artifacts,
+environment configuration, and packaging state.
+
+Use CLI scripts for:
+
+- Build, lint, type-check, unit tests, and package validation.
+- Full dogfood runs against the configured Help Scout test account.
+- MCP client contract tests that spawn the built stdio server.
+- Docker smoke tests and local package assembly.
+- Seeding or verifying test data.
+- Environment diagnostics that confirm required variables are present without
+  printing secret values.
+- Release packaging steps, when release work is explicitly requested.
+
+CLI scripts should not become the product API. If a workflow is useful to an AI
+host during support work, expose it as an MCP tool and make the CLI test it
+through MCP.
+
+## Shared Quality Gates
+
+Every feature PR should prove both surfaces at the right level:
+
+- Unit tests for local business logic and API transformations.
+- MCP dogfood for real host behavior over stdio.
+- Edge-case tests for authenticated Help Scout API behavior.
+- MCPB build and validation when tool metadata or packaging changes.
+- Docker smoke tests when packaging, entrypoint, or runtime assumptions change.
+
+Before merge, CI should run the authenticated dogfood lane with repository
+secrets. After merge, the main branch CI run should be checked before starting a
+dependent PR.
+
+## Testing Account Policy
+
+The connected Help Scout account is the complete test lane for dogfood. Test
+fixtures should be deterministic enough for broad tool coverage, but the server
+must tolerate normal Help Scout account variation:
+
+- Optional fields may be absent.
+- Empty collections are valid for some accounts.
+- Pagination may return fewer objects than requested.
+- Deleted or inaccessible IDs should return model-correctable tool errors.
+
+Test scripts may require known fixture IDs through environment variables. MCP
+tools should not assume those fixture IDs in production behavior.
+
+## No Docker Publishing In Feature PRs
+
+Feature PR quality gates may build and smoke-test Docker images locally or in
+CI. They should not push Docker images or create release tags. Docker publishing
+belongs to explicit release work.

--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -1,0 +1,153 @@
+# MCP Tool Surface Roadmap
+
+This roadmap sorts future Help Scout MCP work by likely support-team usage. It
+is a product map, not a release plan.
+
+## 1. Core Support Loop
+
+These are the highest-usage tools because they map directly to daily support
+questions.
+
+Current:
+
+- `searchConversations`
+- `advancedConversationSearch`
+- `comprehensiveConversationSearch`
+- `structuredConversationFilter`
+- `getConversationSummary`
+- `getThreads`
+- `searchInboxes`
+- `listAllInboxes`
+
+Next:
+
+- Fix status filter consistency, especially `status=all` and spam handling.
+- Add original source retrieval for cases where rendered thread content is not
+  enough.
+- Add attachment retrieval with metadata-first defaults and explicit content
+  fetches.
+
+## 2. Customer And Account Context
+
+These tools answer who the customer is, what account they belong to, and what
+history matters before a reply.
+
+Current:
+
+- `listCustomers`
+- `getCustomer`
+- `searchCustomersByEmail`
+- `getCustomerContacts`
+- `listOrganizations`
+- `getOrganization`
+- `getOrganizationMembers`
+- `getOrganizationConversations`
+- `listCustomerProperties`
+- `listOrganizationProperties`
+- `getOrganizationProperty`
+
+Next:
+
+- Normalize structured output envelopes for customer and organization tools.
+- Add output schemas for stable profile, contact, property, and organization
+  response shapes.
+- Expand dogfood coverage for property-heavy accounts.
+
+## 3. Operator Metadata
+
+Metadata tools help AI hosts interpret how a Help Scout account is configured.
+They also reduce hallucinated IDs in later feature work.
+
+Current:
+
+- `listTags`
+- `getTag`
+- `listUsers`
+- `getUser`
+- `listTeams`
+- `getTeamMembers`
+- `listInboxCustomFields`
+- `listInboxFolders`
+
+Next:
+
+- Add saved replies.
+- Add workflows.
+- Add stronger metadata result schemas.
+- Keep metadata tools read-only and browseable.
+
+## 4. Support Quality And Reporting
+
+These tools are less frequent than the core support loop, but important for
+managers and recurring analysis.
+
+Next:
+
+- Satisfaction ratings.
+- Reporting API coverage.
+- Time-windowed trend queries that return compact, chartable data.
+- Guardrails to avoid large, slow account-wide report pulls by default.
+
+## 5. Docs API
+
+Docs API support should be its own namespace or clearly named tool family. It
+may require different Help Scout permissions and different user expectations
+than mailbox tools.
+
+Next:
+
+- Docs collection and article search.
+- Article retrieval.
+- Lightweight article metadata for citation and freshness checks.
+
+## 6. Admin And Integration Metadata
+
+Admin and integration tools are useful but lower-frequency. They should remain
+read-only until a separate write boundary exists.
+
+Next:
+
+- Webhook listing and inspection.
+- Integration health metadata if available through supported APIs.
+
+## 7. MCP Apps Views
+
+Interactive views should compose existing tool data rather than introduce a
+second data path.
+
+Candidate views:
+
+- Inbox command center.
+- Customer health dashboard.
+- Conversation review workspace.
+- Account context panel.
+
+The first MCP Apps work should prove that a view can reuse stable tool envelopes
+and dogfood fixtures without special casing the test account.
+
+## 8. Remote MCP And OAuth
+
+Remote MCP, OAuth, and Cloudflare deployment are platform work. They should not
+reshape the core stdio tool contract unless the stable MCP spec requires it.
+
+Next:
+
+- Remote MCP OAuth research.
+- Cloudflare Workers MCP deployment design.
+- Clear separation between stdio environment credentials and HTTP authorization.
+
+## 9. Write And Automation Tools
+
+Write tools are intentionally deferred. They require a stricter permission and
+confirmation model than read tools.
+
+Possible future families:
+
+- Draft reply creation.
+- Tagging or assignment.
+- Workflow execution.
+- Conversation status updates.
+
+Do not mix write tools into the read-only surface without explicit naming,
+metadata, user confirmation guidance, and test coverage for denied or partial
+actions.

--- a/scripts/check-conversations.ts
+++ b/scripts/check-conversations.ts
@@ -29,14 +29,16 @@ function loadEnv(): Record<string, string> {
 
 async function main() {
   const env = loadEnv();
+  const clientId = env.HELPSCOUT_APP_ID || env.HELPSCOUT_CLIENT_ID;
+  const clientSecret = env.HELPSCOUT_APP_SECRET || env.HELPSCOUT_CLIENT_SECRET;
 
   // Get token
   const tokenRes = await axios.post(
     'https://api.helpscout.net/v2/oauth2/token',
     new URLSearchParams({
       grant_type: 'client_credentials',
-      client_id: env.HELPSCOUT_CLIENT_ID,
-      client_secret: env.HELPSCOUT_CLIENT_SECRET,
+      client_id: clientId,
+      client_secret: clientSecret,
     })
   );
 

--- a/scripts/debug-api.ts
+++ b/scripts/debug-api.ts
@@ -29,14 +29,16 @@ function loadEnv(): Record<string, string> {
 
 async function main() {
   const env = loadEnv();
+  const clientId = env.HELPSCOUT_APP_ID || env.HELPSCOUT_CLIENT_ID;
+  const clientSecret = env.HELPSCOUT_APP_SECRET || env.HELPSCOUT_CLIENT_SECRET;
 
   // Get token
   const tokenRes = await axios.post(
     'https://api.helpscout.net/v2/oauth2/token',
     new URLSearchParams({
       grant_type: 'client_credentials',
-      client_id: env.HELPSCOUT_CLIENT_ID,
-      client_secret: env.HELPSCOUT_CLIENT_SECRET,
+      client_id: clientId,
+      client_secret: clientSecret,
     })
   );
 

--- a/scripts/generate-synthetic-data.ts
+++ b/scripts/generate-synthetic-data.ts
@@ -403,8 +403,8 @@ async function main() {
   console.log('═══════════════════════════════════════════════════════════\n');
 
   const env = loadEnv();
-  const clientId = env.HELPSCOUT_CLIENT_ID;
-  const clientSecret = env.HELPSCOUT_CLIENT_SECRET;
+  const clientId = env.HELPSCOUT_APP_ID || env.HELPSCOUT_CLIENT_ID;
+  const clientSecret = env.HELPSCOUT_APP_SECRET || env.HELPSCOUT_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
     console.error('❌ Missing credentials in .env');

--- a/scripts/import-conversations.ts
+++ b/scripts/import-conversations.ts
@@ -472,8 +472,8 @@ async function main() {
 
   // Load credentials
   const env = loadEnv();
-  const clientId = env.HELPSCOUT_CLIENT_ID;
-  const clientSecret = env.HELPSCOUT_CLIENT_SECRET;
+  const clientId = env.HELPSCOUT_APP_ID || env.HELPSCOUT_CLIENT_ID;
+  const clientSecret = env.HELPSCOUT_APP_SECRET || env.HELPSCOUT_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
     console.error('❌ Missing credentials in .env');

--- a/scripts/live-api-test.ts
+++ b/scripts/live-api-test.ts
@@ -3,7 +3,8 @@
  * Live API Test Script for Help Scout MCP Server
  *
  * Tests the current MCP tool surface against the live Help Scout API to verify functionality.
- * Requires valid HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET in .env
+ * Requires valid HELPSCOUT_APP_ID and HELPSCOUT_APP_SECRET in .env.
+ * HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET are also supported.
  *
  * Usage:
  *   npx tsx scripts/live-api-test.ts
@@ -54,11 +55,11 @@ class HelpScoutClient {
   private baseUrl = 'https://api.helpscout.net/v2';
 
   async authenticate(): Promise<void> {
-    const clientId = process.env.HELPSCOUT_CLIENT_ID;
-    const clientSecret = process.env.HELPSCOUT_CLIENT_SECRET;
+    const clientId = process.env.HELPSCOUT_APP_ID || process.env.HELPSCOUT_CLIENT_ID;
+    const clientSecret = process.env.HELPSCOUT_APP_SECRET || process.env.HELPSCOUT_CLIENT_SECRET;
 
     if (!clientId || !clientSecret) {
-      throw new Error('Missing HELPSCOUT_CLIENT_ID or HELPSCOUT_CLIENT_SECRET');
+      throw new Error('Missing HELPSCOUT_APP_ID/HELPSCOUT_APP_SECRET or HELPSCOUT_CLIENT_ID/HELPSCOUT_CLIENT_SECRET');
     }
 
     const response = await fetch('https://api.helpscout.net/v2/oauth2/token', {

--- a/scripts/verify-credentials.ts
+++ b/scripts/verify-credentials.ts
@@ -105,12 +105,13 @@ async function main() {
 
   const env = loadEnv();
 
-  const clientId = env.HELPSCOUT_CLIENT_ID;
-  const clientSecret = env.HELPSCOUT_CLIENT_SECRET;
+  const clientId = env.HELPSCOUT_APP_ID || env.HELPSCOUT_CLIENT_ID;
+  const clientSecret = env.HELPSCOUT_APP_SECRET || env.HELPSCOUT_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
     console.error('❌ Missing credentials in .env file');
-    console.error('   Required: HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET');
+    console.error('   Required: HELPSCOUT_APP_ID and HELPSCOUT_APP_SECRET');
+    console.error('   Also supported: HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET');
     process.exit(1);
   }
 
@@ -176,8 +177,9 @@ async function main() {
 
       if (error.response?.status === 401) {
         console.error('\n   Authentication failed. Check your credentials:');
-        console.error('   - Verify HELPSCOUT_CLIENT_ID is correct (App ID from Help Scout)');
-        console.error('   - Verify HELPSCOUT_CLIENT_SECRET is correct (App Secret from Help Scout)');
+        console.error('   - Verify HELPSCOUT_APP_ID is correct (App ID from Help Scout)');
+        console.error('   - Verify HELPSCOUT_APP_SECRET is correct (App Secret from Help Scout)');
+        console.error('   - HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET are also supported');
         console.error('   - Ensure the OAuth app is associated with an active user');
       } else if (error.response?.status === 429) {
         console.error('\n   Rate limited. Wait a moment and try again.');

--- a/src/__tests__/helpscout-client.test.ts
+++ b/src/__tests__/helpscout-client.test.ts
@@ -29,8 +29,8 @@ jest.mock('../utils/config.js', () => ({
   config: {
     helpscout: {
       get apiKey() { return process.env.HELPSCOUT_API_KEY || ''; },
-      get clientId() { return process.env.HELPSCOUT_CLIENT_ID || process.env.HELPSCOUT_API_KEY || ''; },
-      get clientSecret() { return process.env.HELPSCOUT_CLIENT_SECRET || process.env.HELPSCOUT_APP_SECRET || ''; },
+      get clientId() { return process.env.HELPSCOUT_APP_ID || process.env.HELPSCOUT_CLIENT_ID || process.env.HELPSCOUT_API_KEY || ''; },
+      get clientSecret() { return process.env.HELPSCOUT_APP_SECRET || process.env.HELPSCOUT_CLIENT_SECRET || ''; },
       get baseUrl() { return process.env.HELPSCOUT_BASE_URL || 'https://api.helpscout.net/v2/'; },
     },
     cache: {
@@ -59,6 +59,7 @@ describe('HelpScoutClient', () => {
     
     // Clear any environment variables from previous tests
     delete process.env.HELPSCOUT_API_KEY;
+    delete process.env.HELPSCOUT_APP_ID;
     delete process.env.HELPSCOUT_CLIENT_ID;
     delete process.env.HELPSCOUT_CLIENT_SECRET;
     delete process.env.HELPSCOUT_APP_SECRET;
@@ -70,12 +71,19 @@ describe('HelpScoutClient', () => {
     if (pending.length > 0) {
       console.log('Pending nock interceptors:', pending);
     }
+    jest.restoreAllMocks();
     nock.recorder.clear();
     nock.cleanAll();
     nock.restore();
   });
 
   describe('authentication', () => {
+    it('rejects non-HTTPS base URLs before direct client use can authenticate', () => {
+      process.env.HELPSCOUT_BASE_URL = 'http://api.helpscout.net/v2/';
+
+      expect(() => new HelpScoutClient()).toThrow('HELPSCOUT_BASE_URL must use HTTPS');
+    });
+
     it.skip('should authenticate with OAuth2 Client Credentials', async () => {
       // SKIP: Nock has timing issues with axios OAuth2 POST requests in this test environment.
       // OAuth2 authentication is properly tested in integration tests with proper mocking.
@@ -227,6 +235,63 @@ describe('HelpScoutClient', () => {
         message: 'Help Scout API rate limit exceeded. Please wait 1 seconds before retrying.'
       });
     }, 15000); // Increase timeout to account for retries
+
+    it('honors long Retry-After delta seconds instead of capping at retry backoff max', async () => {
+      const client = new HelpScoutClient();
+      const retryError = {
+        response: {
+          status: 429,
+          headers: { 'retry-after': '60' },
+        },
+        config: {
+          metadata: { requestId: 'retry-after-delta' },
+        },
+        message: 'Rate limited',
+      };
+      const operation = jest.fn<() => Promise<any>>()
+        .mockRejectedValueOnce(retryError)
+        .mockResolvedValueOnce({ data: { ok: true } });
+      const sleep = jest.spyOn(client as any, 'sleep').mockResolvedValue(undefined);
+
+      await expect((client as any).executeWithRetry(operation, {
+        retries: 1,
+        retryDelay: 1,
+        maxRetryDelay: 10,
+        retryCondition: () => true,
+      })).resolves.toMatchObject({ data: { ok: true } });
+
+      expect(sleep).toHaveBeenCalledWith(60000);
+    });
+
+    it('honors HTTP-date Retry-After headers', async () => {
+      const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const client = new HelpScoutClient();
+      const retryAt = new Date(now + 45000).toUTCString();
+      const retryError = {
+        response: {
+          status: 429,
+          headers: { 'retry-after': retryAt },
+        },
+        config: {
+          metadata: { requestId: 'retry-after-date' },
+        },
+        message: 'Rate limited',
+      };
+      const operation = jest.fn<() => Promise<any>>()
+        .mockRejectedValueOnce(retryError)
+        .mockResolvedValueOnce({ data: { ok: true } });
+      const sleep = jest.spyOn(client as any, 'sleep').mockResolvedValue(undefined);
+
+      await expect((client as any).executeWithRetry(operation, {
+        retries: 1,
+        retryDelay: 1,
+        maxRetryDelay: 10,
+        retryCondition: () => true,
+      })).resolves.toMatchObject({ data: { ok: true } });
+
+      expect(sleep).toHaveBeenCalledWith(45000);
+    });
 
     it('should handle 400 bad request errors', async () => {
       const client = new HelpScoutClient();

--- a/src/__tests__/package-scripts.test.ts
+++ b/src/__tests__/package-scripts.test.ts
@@ -4,6 +4,26 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 
 describe('package scripts', () => {
+  it('keeps operational scripts aligned with documented Help Scout credential names', () => {
+    const credentialScripts = [
+      'scripts/check-conversations.ts',
+      'scripts/debug-api.ts',
+      'scripts/generate-synthetic-data.ts',
+      'scripts/import-conversations.ts',
+      'scripts/live-api-test.ts',
+      'scripts/verify-credentials.ts',
+    ];
+
+    for (const scriptPath of credentialScripts) {
+      const content = fs.readFileSync(path.join(process.cwd(), scriptPath), 'utf8');
+
+      expect(content).toContain('HELPSCOUT_APP_ID');
+      expect(content).toContain('HELPSCOUT_APP_SECRET');
+      expect(content).toContain('HELPSCOUT_CLIENT_ID');
+      expect(content).toContain('HELPSCOUT_CLIENT_SECRET');
+    }
+  });
+
   it('guards sync:plugin when the target checkout has local files', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'helpscout-sync-plugin-'));
     const pluginDir = path.join(tempRoot, 'helpscout-navigator');

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -83,6 +83,8 @@ export class HelpScoutClient {
   };
 
   constructor(poolConfig: Partial<ConnectionPoolConfig> = {}) {
+    this.validateHttpsBaseUrl(config.helpscout.baseUrl);
+
     // Merge default pool config with any custom settings
     this.poolConfig = { ...DEFAULT_POOL_CONFIG, ...poolConfig };
     
@@ -128,6 +130,42 @@ export class HelpScoutClient {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
+  private validateHttpsBaseUrl(baseUrl: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(baseUrl);
+    } catch {
+      throw new Error(`Invalid Help Scout base URL: ${baseUrl}`);
+    }
+
+    if (parsed.protocol !== 'https:') {
+      throw new Error('HELPSCOUT_BASE_URL must use HTTPS to protect OAuth2 credentials');
+    }
+  }
+
+  private parseRetryAfterMs(value: unknown, fallbackMs = 60000): number {
+    const rawValue = Array.isArray(value) ? value[0] : value;
+
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue >= 0) {
+      return rawValue * 1000;
+    }
+
+    if (typeof rawValue === 'string') {
+      const trimmed = rawValue.trim();
+      const seconds = Number(trimmed);
+      if (Number.isFinite(seconds) && seconds >= 0) {
+        return seconds * 1000;
+      }
+
+      const retryAt = Date.parse(trimmed);
+      if (Number.isFinite(retryAt)) {
+        return Math.max(retryAt - Date.now(), 0);
+      }
+    }
+
+    return fallbackMs;
+  }
+
   private calculateRetryDelay(attempt: number, baseDelay: number, maxDelay: number): number {
     // Exponential backoff with jitter
     const exponentialDelay = baseDelay * Math.pow(2, attempt);
@@ -159,8 +197,7 @@ export class HelpScoutClient {
         
         // Handle rate limits specially
         if (lastError.response?.status === 429) {
-          const retryAfter = parseInt(lastError.response.headers['retry-after'] || '60', 10) * 1000;
-          const delay = Math.min(retryAfter, retryConfig.maxRetryDelay);
+          const delay = this.parseRetryAfterMs(lastError.response.headers['retry-after']);
           
           logger.warn('Rate limit hit, waiting before retry', {
             attempt: attempt + 1,
@@ -279,7 +316,7 @@ export class HelpScoutClient {
       if (!clientId || !clientSecret) {
         throw new Error(
           'OAuth2 authentication required. Help Scout API only supports OAuth2 Client Credentials flow.\n' +
-          'Set HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET (or use legacy HELPSCOUT_API_KEY and HELPSCOUT_APP_SECRET)'
+          'Set HELPSCOUT_APP_ID and HELPSCOUT_APP_SECRET. HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET are also supported.'
         );
       }
 
@@ -330,7 +367,7 @@ export class HelpScoutClient {
         message: 'Help Scout authentication failed. Please check your API credentials.',
         details: {
           requestId,
-          suggestion: 'Verify HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET are valid',
+          suggestion: 'Verify HELPSCOUT_APP_ID and HELPSCOUT_APP_SECRET are valid. HELPSCOUT_CLIENT_ID and HELPSCOUT_CLIENT_SECRET are also supported.',
         },
       };
     }
@@ -358,7 +395,7 @@ export class HelpScoutClient {
     }
 
     if (error.response?.status === 429) {
-      const retryAfter = parseInt(error.response.headers['retry-after'] || '60', 10);
+      const retryAfter = Math.ceil(this.parseRetryAfterMs(error.response.headers['retry-after']) / 1000);
       return {
         code: 'RATE_LIMIT',
         message: `Help Scout API rate limit exceeded. Please wait ${retryAfter} seconds before retrying.`,

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -1094,8 +1094,8 @@ function printSummary(): void {
 
 async function main(): Promise<void> {
   const missingCredentials = [
-    ['HELPSCOUT_CLIENT_ID or HELPSCOUT_APP_ID', process.env.HELPSCOUT_CLIENT_ID ?? process.env.HELPSCOUT_APP_ID],
-    ['HELPSCOUT_CLIENT_SECRET or HELPSCOUT_APP_SECRET', process.env.HELPSCOUT_CLIENT_SECRET ?? process.env.HELPSCOUT_APP_SECRET],
+    ['HELPSCOUT_APP_ID or HELPSCOUT_CLIENT_ID', process.env.HELPSCOUT_APP_ID ?? process.env.HELPSCOUT_CLIENT_ID],
+    ['HELPSCOUT_APP_SECRET or HELPSCOUT_CLIENT_SECRET', process.env.HELPSCOUT_APP_SECRET ?? process.env.HELPSCOUT_CLIENT_SECRET],
   ].filter(([, value]) => !value);
 
   if (missingCredentials.length > 0) {

--- a/tests/seed-integration-data.ts
+++ b/tests/seed-integration-data.ts
@@ -81,7 +81,8 @@ const CLIENT_SECRET =
 const BASE_URL = process.env.HELPSCOUT_BASE_URL || 'https://api.helpscout.net/v2/';
 
 if (!CLIENT_ID || !CLIENT_SECRET) {
-  console.error('Missing HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET in .env');
+  console.error('Missing HELPSCOUT_APP_ID / HELPSCOUT_APP_SECRET in .env');
+  console.error('HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET are also supported.');
   process.exit(1);
 }
 

--- a/tests/seed-org-customers.ts
+++ b/tests/seed-org-customers.ts
@@ -23,7 +23,8 @@ const CLIENT_SECRET =
 const BASE_URL = process.env.HELPSCOUT_BASE_URL || 'https://api.helpscout.net/v2/';
 
 if (!CLIENT_ID || !CLIENT_SECRET) {
-  console.error('Missing HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET in .env');
+  console.error('Missing HELPSCOUT_APP_ID / HELPSCOUT_APP_SECRET in .env');
+  console.error('HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET are also supported.');
   process.exit(1);
 }
 
@@ -71,11 +72,11 @@ async function api(): Promise<AxiosInstance> {
   });
 }
 
-function extractIdFromHeaders(headers: Record<string, string>): number | null {
+function extractIdFromHeaders(headers: Record<string, unknown>): number | null {
   const resourceId = headers['resource-id'];
-  if (resourceId && /^\d+$/.test(resourceId)) return Number(resourceId);
+  if (typeof resourceId === 'string' && /^\d+$/.test(resourceId)) return Number(resourceId);
   const location = headers['location'];
-  if (location) {
+  if (typeof location === 'string') {
     const match = location.match(/\/(\d+)(?:\?|$)/);
     if (match) return Number(match[1]);
   }

--- a/tests/seed-test-data.ts
+++ b/tests/seed-test-data.ts
@@ -29,7 +29,8 @@ const CLIENT_SECRET =
 const BASE_URL = process.env.HELPSCOUT_BASE_URL || 'https://api.helpscout.net/v2/';
 
 if (!CLIENT_ID || !CLIENT_SECRET) {
-  console.error('Missing HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET in .env');
+  console.error('Missing HELPSCOUT_APP_ID / HELPSCOUT_APP_SECRET in .env');
+  console.error('HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET are also supported.');
   process.exit(1);
 }
 
@@ -74,14 +75,14 @@ function heading(msg: string) {
 }
 
 /** Extract resource ID from Help Scout 201 response headers. */
-function extractIdFromHeaders(headers: Record<string, string>): number | null {
+function extractIdFromHeaders(headers: Record<string, unknown>): number | null {
   // resource-id header is the most reliable
   const resourceId = headers['resource-id'];
-  if (resourceId && /^\d+$/.test(resourceId)) return Number(resourceId);
+  if (typeof resourceId === 'string' && /^\d+$/.test(resourceId)) return Number(resourceId);
 
   // Fallback: parse the Location URL (may have query params)
   const location = headers['location'];
-  if (location) {
+  if (typeof location === 'string') {
     const match = location.match(/\/(\d+)(?:\?|$)/);
     if (match) return Number(match[1]);
   }


### PR DESCRIPTION
## Summary
- Define the stable MCP 2025-11-25 tool contract, result-shape direction, and rollout order.
- Document the MCP vs CLI boundary and the feature roadmap sorted by likely Help Scout usage.
- Align operational scripts and runtime guidance with documented Help Scout credential names while keeping legacy aliases.
- Harden direct HelpScoutClient use by enforcing HTTPS base URLs and honoring server-provided Retry-After windows.

## Testing
- npm run type-check
- npm run lint
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck --types node scripts/check-conversations.ts scripts/debug-api.ts scripts/generate-synthetic-data.ts scripts/import-conversations.ts scripts/live-api-test.ts scripts/verify-credentials.ts tests/mcp-client-dogfood.ts tests/seed-integration-data.ts tests/seed-org-customers.ts tests/seed-test-data.ts
- npm run mcpb:build
- npm run mcpb:pack
- npm test -- --runInBand --silent
- npm run test:docker:ci
- Local review check: open findings 0

Authenticated dogfood is expected to run in PR CI using the configured HELPSCOUT_APP_ID and HELPSCOUT_APP_SECRET repository secrets. Local authenticated dogfood was not run because those env vars were not available in this worktree shell.

Closes NAS-1280