### PR TITLE
feat(NAS-720,NAS-725): add conversation source and attachment tools

### DIFF
--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -16,16 +16,15 @@ Current:
 - `structuredConversationFilter`
 - `getConversationSummary`
 - `getThreads`
+- `getOriginalSource`
+- `getAttachment`
 - `searchInboxes`
 - `listAllInboxes`
 
 Next:
 
-- Fix status filter consistency, especially `status=all` and spam handling.
-- Add original source retrieval for cases where rendered thread content is not
-  enough.
-- Add attachment retrieval with metadata-first defaults and explicit content
-  fetches.
+- Add narrower thread/attachment fixture coverage as the dogfood account gets
+  richer test data.
 
 ## 2. Customer And Account Context
 

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -216,6 +216,14 @@
       "description": "Get one saved reply for a Help Scout inbox"
     },
     {
+      "name": "getOriginalSource",
+      "description": "Get original source JSON for a Help Scout conversation thread"
+    },
+    {
+      "name": "getAttachment",
+      "description": "Get base64-encoded Help Scout attachment data"
+    },
+    {
       "name": "listWorkflows",
       "description": "List Help Scout workflows"
     },

--- a/mcp.json
+++ b/mcp.json
@@ -40,6 +40,8 @@
     "listInboxFolders",
     "listSavedReplies",
     "getSavedReply",
+    "getOriginalSource",
+    "getAttachment",
     "listWorkflows",
     "listWebhooks",
     "getWebhook"

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 33 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(33);
+    it('should have all 35 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(35);
 
       const expectedTools = [
         'searchInboxes',
@@ -98,6 +98,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'listInboxFolders',
         'listSavedReplies',
         'getSavedReply',
+        'getOriginalSource',
+        'getAttachment',
         'listWorkflows',
         'listWebhooks',
         'getWebhook'

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,5 +1,8 @@
 import nock from 'nock';
 import { ToolHandler } from '../tools/index.js';
+import { cache } from '../utils/cache.js';
+import { config } from '../utils/config.js';
+import { REDACTED_MESSAGE_BODY } from '../utils/constants.js';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
 describe('ToolHandler', () => {
@@ -13,6 +16,7 @@ describe('ToolHandler', () => {
     process.env.HELPSCOUT_BASE_URL = `${baseURL}/`;
     
     nock.cleanAll();
+    cache.clear();
     
     // Mock OAuth2 authentication endpoint
     nock(baseURL)
@@ -633,6 +637,36 @@ describe('ToolHandler', () => {
       expect(response.originalSource).toEqual({ original: 'From: customer@example.com\nSubject: Raw source' });
     });
 
+    it('should redact a thread original source when message redaction is enabled', async () => {
+      const originalRedactMessageContent = config.security.redactMessageContent;
+      config.security.redactMessageContent = true;
+
+      try {
+        const scope = nock(baseURL)
+          .get('/conversations/123/threads/456/original-source')
+          .reply(200, {
+            original: 'From: customer@example.com\nSubject: Raw source',
+          });
+
+        const result = await toolHandler.callTool({
+          method: 'tools/call',
+          params: {
+            name: 'getOriginalSource',
+            arguments: { conversationId: '123', threadId: '456' },
+          },
+        });
+
+        const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+        expect(result.isError).toBeUndefined();
+        expect(response.conversationId).toBe('123');
+        expect(response.threadId).toBe('456');
+        expect(response.originalSource).toBe(REDACTED_MESSAGE_BODY);
+        expect(scope.isDone()).toBe(false);
+      } finally {
+        config.security.redactMessageContent = originalRedactMessageContent;
+      }
+    });
+
     it('should get attachment data', async () => {
       nock(baseURL)
         .get('/conversations/123/attachments/789/data')
@@ -657,6 +691,39 @@ describe('ToolHandler', () => {
         encoding: 'base64',
         source: 'Help Scout attachment data endpoint',
       }));
+    });
+
+    it('should not cache attachment data responses', async () => {
+      const scope = nock(baseURL)
+        .get('/conversations/123/attachments/789/data')
+        .reply(200, {
+          data: 'Zmlyc3Q=',
+        })
+        .get('/conversations/123/attachments/789/data')
+        .reply(200, {
+          data: 'c2Vjb25k',
+        });
+
+      const first = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getAttachment',
+          arguments: { conversationId: '123', attachmentId: '789' },
+        },
+      });
+      const second = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getAttachment',
+          arguments: { conversationId: '123', attachmentId: '789' },
+        },
+      });
+
+      const firstResponse = JSON.parse((first.content[0] as { type: 'text'; text: string }).text);
+      const secondResponse = JSON.parse((second.content[0] as { type: 'text'; text: string }).text);
+      expect(firstResponse.attachment).toEqual({ data: 'Zmlyc3Q=' });
+      expect(secondResponse.attachment).toEqual({ data: 'c2Vjb25k' });
+      expect(scope.isDone()).toBe(true);
     });
 
     it('should list workflows', async () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -37,7 +37,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(33);
+      expect(tools).toHaveLength(35);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -69,6 +69,8 @@ describe('ToolHandler', () => {
         'listInboxFolders',
         'listSavedReplies',
         'getSavedReply',
+        'getOriginalSource',
+        'getAttachment',
         'listWorkflows',
         'listWebhooks',
         'getWebhook',
@@ -607,6 +609,54 @@ describe('ToolHandler', () => {
       expect(listResponse.savedReplies[0]).toEqual(expect.objectContaining({ id: 1001, name: 'Refund policy' }));
       expect(listResponse.nextPage).toBeNull();
       expect(getResponse.savedReply).toEqual(expect.objectContaining({ id: 1001, text: 'Refunds take 5-7 business days.' }));
+    });
+
+    it('should get a thread original source', async () => {
+      nock(baseURL)
+        .get('/conversations/123/threads/456/original-source')
+        .reply(200, {
+          original: 'From: customer@example.com\nSubject: Raw source',
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getOriginalSource',
+          arguments: { conversationId: '123', threadId: '456' },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.conversationId).toBe('123');
+      expect(response.threadId).toBe('456');
+      expect(response.originalSource).toEqual({ original: 'From: customer@example.com\nSubject: Raw source' });
+    });
+
+    it('should get attachment data', async () => {
+      nock(baseURL)
+        .get('/conversations/123/attachments/789/data')
+        .reply(200, {
+          data: 'ZmlsZQ==',
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getAttachment',
+          arguments: { conversationId: '123', attachmentId: '789' },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.conversationId).toBe('123');
+      expect(response.attachmentId).toBe('789');
+      expect(response.attachment).toEqual({ data: 'ZmlsZQ==' });
+      expect(response.contentHandling).toEqual(expect.objectContaining({
+        encoding: 'base64',
+        source: 'Help Scout attachment data endpoint',
+      }));
     });
 
     it('should list workflows', async () => {

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -442,6 +442,16 @@ export const GetSavedReplyInputSchema = z.object({
   replyId: z.string().regex(/^\d+$/, 'Saved reply ID must be numeric').describe('Saved reply ID'),
 });
 
+export const GetOriginalSourceInputSchema = z.object({
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric').describe('Conversation ID'),
+  threadId: z.string().regex(/^\d+$/, 'Thread ID must be numeric').describe('Thread ID'),
+});
+
+export const GetAttachmentInputSchema = z.object({
+  conversationId: z.string().regex(/^\d+$/, 'Conversation ID must be numeric').describe('Conversation ID'),
+  attachmentId: z.string().regex(/^\d+$/, 'Attachment ID must be numeric').describe('Attachment ID'),
+});
+
 export const ListWorkflowsInputSchema = z.object({
   page: z.number().int().min(1).default(1),
 });
@@ -513,6 +523,8 @@ export type ListInboxCustomFieldsInput = z.infer<typeof ListInboxCustomFieldsInp
 export type ListInboxFoldersInput = z.infer<typeof ListInboxFoldersInputSchema>;
 export type ListSavedRepliesInput = z.infer<typeof ListSavedRepliesInputSchema>;
 export type GetSavedReplyInput = z.infer<typeof GetSavedReplyInputSchema>;
+export type GetOriginalSourceInput = z.infer<typeof GetOriginalSourceInputSchema>;
+export type GetAttachmentInput = z.infer<typeof GetAttachmentInputSchema>;
 export type ListWorkflowsInput = z.infer<typeof ListWorkflowsInputSchema>;
 export type ListWebhooksInput = z.infer<typeof ListWebhooksInputSchema>;
 export type GetWebhookInput = z.infer<typeof GetWebhookInputSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -52,6 +52,8 @@ import {
   ListInboxFoldersInputSchema,
   ListSavedRepliesInputSchema,
   GetSavedReplyInputSchema,
+  GetOriginalSourceInputSchema,
+  GetAttachmentInputSchema,
   ListWorkflowsInputSchema,
   ListWebhooksInputSchema,
   GetWebhookInputSchema,
@@ -740,6 +742,30 @@ export class ToolHandler {
         },
       },
       {
+        name: 'getOriginalSource',
+        description: 'Get the original source JSON for a Help Scout conversation thread.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            conversationId: { type: 'string', description: 'Conversation ID from searchConversations or getConversationSummary' },
+            threadId: { type: 'string', description: 'Thread ID from getThreads' },
+          },
+          required: ['conversationId', 'threadId'],
+        },
+      },
+      {
+        name: 'getAttachment',
+        description: 'Get base64-encoded Help Scout attachment data by conversation and attachment ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            conversationId: { type: 'string', description: 'Conversation ID from searchConversations or getConversationSummary' },
+            attachmentId: { type: 'string', description: 'Attachment ID from getThreads attachment links' },
+          },
+          required: ['conversationId', 'attachmentId'],
+        },
+      },
+      {
         name: 'listWorkflows',
         description: 'List Help Scout workflows. Use to inspect account workflow configuration and discover workflow IDs.',
         inputSchema: {
@@ -920,6 +946,12 @@ export class ToolHandler {
           break;
         case 'getSavedReply':
           result = await this.getSavedReply(request.params.arguments || {});
+          break;
+        case 'getOriginalSource':
+          result = await this.getOriginalSource(request.params.arguments || {});
+          break;
+        case 'getAttachment':
+          result = await this.getAttachment(request.params.arguments || {});
           break;
         case 'listWorkflows':
           result = await this.listWorkflows(request.params.arguments || {});
@@ -1604,6 +1636,48 @@ export class ToolHandler {
           replyId: input.replyId,
           savedReply,
           usage: 'Use saved reply content as reference context only; this tool does not send or draft replies.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getOriginalSource(args: unknown): Promise<CallToolResult> {
+    const input = GetOriginalSourceInputSchema.parse(args);
+    const originalSource = await helpScoutClient.get<Record<string, unknown>>(
+      `/conversations/${input.conversationId}/threads/${input.threadId}/original-source`
+    );
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          conversationId: input.conversationId,
+          threadId: input.threadId,
+          originalSource,
+          usage: 'Use original source for read-only inspection of raw thread content when rendered thread fields are insufficient.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getAttachment(args: unknown): Promise<CallToolResult> {
+    const input = GetAttachmentInputSchema.parse(args);
+    const attachment = await helpScoutClient.get<Record<string, unknown>>(
+      `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`
+    );
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          conversationId: input.conversationId,
+          attachmentId: input.attachmentId,
+          attachment,
+          contentHandling: {
+            encoding: 'base64',
+            source: 'Help Scout attachment data endpoint',
+          },
+          usage: 'Decode attachment.data only when the caller explicitly needs the file content; avoid logging decoded attachment bytes.',
         }, null, 2),
       }],
     };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1643,6 +1643,20 @@ export class ToolHandler {
 
   private async getOriginalSource(args: unknown): Promise<CallToolResult> {
     const input = GetOriginalSourceInputSchema.parse(args);
+    if (config.security.redactMessageContent) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            conversationId: input.conversationId,
+            threadId: input.threadId,
+            originalSource: REDACTED_MESSAGE_BODY,
+            usage: 'Original source content is hidden because REDACT_MESSAGE_CONTENT is enabled.',
+          }, null, 2),
+        }],
+      };
+    }
+
     const originalSource = await helpScoutClient.get<Record<string, unknown>>(
       `/conversations/${input.conversationId}/threads/${input.threadId}/original-source`
     );
@@ -1663,7 +1677,9 @@ export class ToolHandler {
   private async getAttachment(args: unknown): Promise<CallToolResult> {
     const input = GetAttachmentInputSchema.parse(args);
     const attachment = await helpScoutClient.get<Record<string, unknown>>(
-      `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`
+      `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`,
+      undefined,
+      { ttl: 0 }
     );
 
     return {

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -32,6 +32,10 @@ const GOLDEN = {
   inboxName: process.env.MCP_DOGFOOD_INBOX_NAME ?? 'Client Support',
   tag: process.env.MCP_DOGFOOD_TAG ?? 'mcp-test',
   searchTerm: process.env.MCP_DOGFOOD_SEARCH_TERM ?? 'test',
+  originalSourceConversationId: process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID,
+  originalSourceThreadId: process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID,
+  attachmentConversationId: process.env.MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID,
+  attachmentId: process.env.MCP_DOGFOOD_ATTACHMENT_ID,
 };
 
 const EXPECTED_TOOLS = [
@@ -65,6 +69,8 @@ const EXPECTED_TOOLS = [
   'listInboxFolders',
   'listSavedReplies',
   'getSavedReply',
+  'getOriginalSource',
+  'getAttachment',
   'listWorkflows',
   'listWebhooks',
   'getWebhook',
@@ -85,6 +91,10 @@ interface DogfoodContext {
   organizationId: string;
   conversationId?: string;
   conversationNumber?: number;
+  originalSourceConversationId?: string;
+  originalSourceThreadId?: string;
+  attachmentConversationId?: string;
+  attachmentId?: string;
   assigneeId?: number;
   tagId?: string;
   userId?: string;
@@ -155,6 +165,10 @@ class McpDogfoodSession {
       customerId: GOLDEN.customerId,
       customerEmail: GOLDEN.customerEmail,
       organizationId: GOLDEN.organizationId,
+      originalSourceConversationId: GOLDEN.originalSourceConversationId,
+      originalSourceThreadId: GOLDEN.originalSourceThreadId,
+      attachmentConversationId: GOLDEN.attachmentConversationId,
+      attachmentId: GOLDEN.attachmentId,
     };
   }
 
@@ -798,6 +812,19 @@ function buildScenarios(): Scenario[] {
       validate: (data) => {
         requireArray(data, ['threads'], 'threads');
       },
+      after: (data, _result, ctx) => {
+        const threads = getArray(data, ['threads']) as JsonObject[];
+        if (ctx.attachmentId) return;
+        for (const thread of threads) {
+          const attachments = Array.isArray(thread.attachments) ? thread.attachments as JsonObject[] : [];
+          const attachment = attachments.find((item) => item.id);
+          if (attachment?.id) {
+            ctx.attachmentConversationId = ctx.conversationId;
+            ctx.attachmentId = String(attachment.id);
+            break;
+          }
+        }
+      },
     },
     {
       tool: 'getThreads',
@@ -815,6 +842,36 @@ function buildScenarios(): Scenario[] {
       expectError: true,
       validate: (data) => {
         requireCondition(data !== undefined, 'Expected validation response');
+      },
+    },
+    {
+      tool: 'getOriginalSource',
+      name: 'discovered thread original source',
+      skipIf: (ctx) => ctx.originalSourceConversationId && ctx.originalSourceThreadId
+        ? undefined
+        : 'No original-source fixture available',
+      args: (ctx) => ({
+        conversationId: ctx.originalSourceConversationId ?? '1',
+        threadId: ctx.originalSourceThreadId ?? '1',
+      }),
+      validate: (data) => {
+        const originalSource = getObject(data, 'originalSource');
+        requireCondition(originalSource && 'original' in originalSource, 'Missing original source payload');
+      },
+    },
+    {
+      tool: 'getAttachment',
+      name: 'discovered attachment data',
+      skipIf: (ctx) => ctx.attachmentConversationId && ctx.attachmentId
+        ? undefined
+        : 'No attachment fixture available from getThreads',
+      args: (ctx) => ({
+        conversationId: ctx.attachmentConversationId ?? '1',
+        attachmentId: ctx.attachmentId ?? '1',
+      }),
+      validate: (data) => {
+        const attachment = getObject(data, 'attachment');
+        requireCondition(typeof attachment?.data === 'string', 'Missing base64 attachment data');
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add direct Help Scout API tools for thread original-source and attachment data retrieval.
- Update schemas, MCPB manifest, local tool inventory, dogfood coverage, and the API surface roadmap.

## Testing
- npm test -- src/__tests__/tools.test.ts --runInBand
- npm test -- src/__tests__/mcpb-validation.test.ts --runInBand
- npm run type-check
- npm run lint
- npm run build
- npm test -- --runInBand
- npm run mcpb:build
- npm run dogfood:mcp
- npm run security (completed with existing repo-wide Semgrep findings)

Closes NAS-720
Closes NAS-725
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->