### PR TITLE
feat(NAS-718): add satisfaction rating tool

### DIFF
--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -81,9 +81,13 @@ Next:
 These tools are less frequent than the core support loop, but important for
 managers and recurring analysis.
 
+Current:
+
+- `getSatisfactionRating`
+
 Next:
 
-- Satisfaction ratings.
+- Rating fixture coverage when the dogfood account has known rating data.
 - Reporting API coverage.
 - Time-windowed trend queries that return compact, chartable data.
 - Guardrails to avoid large, slow account-wide report pulls by default.

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -234,6 +234,10 @@
     {
       "name": "getWebhook",
       "description": "Get a Help Scout webhook by ID"
+    },
+    {
+      "name": "getSatisfactionRating",
+      "description": "Get a Help Scout satisfaction rating by ID"
     }
   ],
   "prompts": [

--- a/mcp.json
+++ b/mcp.json
@@ -44,7 +44,8 @@
     "getAttachment",
     "listWorkflows",
     "listWebhooks",
-    "getWebhook"
+    "getWebhook",
+    "getSatisfactionRating"
   ],
   "prompts": [
     "search-last-7-days",

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 35 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(35);
+    it('should have all 36 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(36);
 
       const expectedTools = [
         'searchInboxes',
@@ -102,7 +102,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'getAttachment',
         'listWorkflows',
         'listWebhooks',
-        'getWebhook'
+        'getWebhook',
+        'getSatisfactionRating'
       ];
 
       const toolNames = manifest.tools.map((tool: any) => tool.name);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -41,7 +41,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(35);
+      expect(tools).toHaveLength(36);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -78,6 +78,7 @@ describe('ToolHandler', () => {
         'listWorkflows',
         'listWebhooks',
         'getWebhook',
+        'getSatisfactionRating',
       ]);
     });
 
@@ -812,6 +813,72 @@ describe('ToolHandler', () => {
       expect(get.isError).toBeUndefined();
       expect(listResponse.webhooks[0]).toEqual(expect.objectContaining({ id: 91, state: 'enabled' }));
       expect(getResponse.webhook).toEqual(expect.objectContaining({ id: 91, url: 'https://example.com/webhook' }));
+    });
+
+    it('should get a satisfaction rating by ID', async () => {
+      nock(baseURL)
+        .get('/ratings/9001')
+        .reply(200, {
+          id: 9001,
+          threadId: 456,
+          conversationId: 123,
+          conversationNumber: 321,
+          mailboxId: 359402,
+          rating: 'great',
+          comments: 'Well done!',
+          createdAt: '2024-01-02T03:04:05Z',
+          user: {
+            id: 42,
+            email: 'agent@example.com',
+            firstName: 'Ava',
+            lastName: 'Agent',
+          },
+          customer: {
+            id: 77,
+            email: 'customer@example.com',
+            firstName: 'Chris',
+            lastName: 'Customer',
+          },
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getSatisfactionRating',
+          arguments: { ratingId: '9001' },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.ratingId).toBe('9001');
+      expect(response.rating).toEqual(expect.objectContaining({
+        id: 9001,
+        rating: 'great',
+        comments: 'Well done!',
+        conversationId: 123,
+      }));
+      expect(response.usage).toContain('read-only quality context');
+    });
+
+    it('should validate satisfaction rating IDs before calling Help Scout', async () => {
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getSatisfactionRating',
+          arguments: { ratingId: 'abc' },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.error.code).toBe('INVALID_INPUT');
+      expect(response.error.validationIssues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          field: 'ratingId',
+          message: 'Rating ID must be numeric',
+        }),
+      ]));
     });
   });
 

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -329,6 +329,31 @@ export const WebhookSchema = z.object({
   updatedAt: z.string().optional(),
 }).passthrough();
 
+export const SatisfactionRatingSchema = z.object({
+  id: z.number(),
+  threadId: z.number().optional(),
+  conversationId: z.number().optional(),
+  conversationNumber: z.number().optional(),
+  mailboxId: z.number().optional(),
+  rating: z.enum(['great', 'not_good', 'okay', 'unknown']).or(z.string()).optional(),
+  comments: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
+  modifiedAt: z.string().optional(),
+  user: z.object({
+    id: z.number(),
+    email: z.string().nullable().optional(),
+    firstName: z.string().nullable().optional(),
+    lastName: z.string().nullable().optional(),
+  }).passthrough().optional(),
+  customer: z.object({
+    id: z.number(),
+    email: z.string().nullable().optional(),
+    firstName: z.string().nullable().optional(),
+    lastName: z.string().nullable().optional(),
+    photoUrl: z.string().nullable().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
 // Customer & Organization Input Schemas
 export const GetCustomerInputSchema = z.object({
   customerId: z.string().regex(/^\d+$/, 'Customer ID must be numeric').describe('Customer ID'),
@@ -464,6 +489,10 @@ export const GetWebhookInputSchema = z.object({
   webhookId: z.string().regex(/^\d+$/, 'Webhook ID must be numeric').describe('Webhook ID'),
 });
 
+export const GetSatisfactionRatingInputSchema = z.object({
+  ratingId: z.string().regex(/^\d+$/, 'Rating ID must be numeric').describe('Satisfaction rating ID'),
+});
+
 // Response Types
 export const ServerTimeSchema = z.object({
   isoTime: z.string(),
@@ -495,6 +524,7 @@ export type InboxFolder = z.infer<typeof InboxFolderSchema>;
 export type SavedReply = z.infer<typeof SavedReplySchema>;
 export type Workflow = z.infer<typeof WorkflowSchema>;
 export type Webhook = z.infer<typeof WebhookSchema>;
+export type SatisfactionRating = z.infer<typeof SatisfactionRatingSchema>;
 export type SearchInboxesInput = z.infer<typeof SearchInboxesInputSchema>;
 export type SearchConversationsInput = z.infer<typeof SearchConversationsInputSchema>;
 export type GetThreadsInput = z.infer<typeof GetThreadsInputSchema>;
@@ -528,5 +558,6 @@ export type GetAttachmentInput = z.infer<typeof GetAttachmentInputSchema>;
 export type ListWorkflowsInput = z.infer<typeof ListWorkflowsInputSchema>;
 export type ListWebhooksInput = z.infer<typeof ListWebhooksInputSchema>;
 export type GetWebhookInput = z.infer<typeof GetWebhookInputSchema>;
+export type GetSatisfactionRatingInput = z.infer<typeof GetSatisfactionRatingInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,6 +22,7 @@ import {
   SavedReply,
   Workflow,
   Webhook,
+  SatisfactionRating,
   ServerTime,
   SearchInboxesInputSchema,
   SearchConversationsInputSchema,
@@ -57,6 +58,7 @@ import {
   ListWorkflowsInputSchema,
   ListWebhooksInputSchema,
   GetWebhookInputSchema,
+  GetSatisfactionRatingInputSchema,
 } from '../schema/types.js';
 
 type ConversationStatus = 'active' | 'pending' | 'closed' | 'spam';
@@ -796,6 +798,17 @@ export class ToolHandler {
           required: ['webhookId'],
         },
       },
+      {
+        name: 'getSatisfactionRating',
+        description: 'Get a Help Scout satisfaction rating by ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            ratingId: { type: 'string', description: 'Satisfaction rating ID' },
+          },
+          required: ['ratingId'],
+        },
+      },
     ];
   }
 
@@ -961,6 +974,9 @@ export class ToolHandler {
           break;
         case 'getWebhook':
           result = await this.getWebhook(request.params.arguments || {});
+          break;
+        case 'getSatisfactionRating':
+          result = await this.getSatisfactionRating(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -1755,6 +1771,22 @@ export class ToolHandler {
         text: JSON.stringify({
           webhook,
           usage: 'Use webhook configuration for integration inspection only; this tool does not create or update webhooks.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getSatisfactionRating(args: unknown): Promise<CallToolResult> {
+    const input = GetSatisfactionRatingInputSchema.parse(args);
+    const rating = await helpScoutClient.get<SatisfactionRating>(`/ratings/${input.ratingId}`);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          ratingId: input.ratingId,
+          rating,
+          usage: 'Use satisfaction rating data as read-only quality context; this tool does not compute reports or trends.',
         }, null, 2),
       }],
     };

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -36,6 +36,7 @@ const GOLDEN = {
   originalSourceThreadId: process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID,
   attachmentConversationId: process.env.MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID,
   attachmentId: process.env.MCP_DOGFOOD_ATTACHMENT_ID,
+  satisfactionRatingId: process.env.MCP_DOGFOOD_SATISFACTION_RATING_ID,
 };
 
 const EXPECTED_TOOLS = [
@@ -74,6 +75,7 @@ const EXPECTED_TOOLS = [
   'listWorkflows',
   'listWebhooks',
   'getWebhook',
+  'getSatisfactionRating',
 ] as const;
 
 type ToolName = typeof EXPECTED_TOOLS[number];
@@ -101,6 +103,7 @@ interface DogfoodContext {
   teamId?: string;
   savedReplyId?: string;
   webhookId?: string;
+  satisfactionRatingId?: string;
   organizationPropertySlug?: string;
   createdAfter?: string;
   createdBefore?: string;
@@ -169,6 +172,7 @@ class McpDogfoodSession {
       originalSourceThreadId: GOLDEN.originalSourceThreadId,
       attachmentConversationId: GOLDEN.attachmentConversationId,
       attachmentId: GOLDEN.attachmentId,
+      satisfactionRatingId: GOLDEN.satisfactionRatingId,
     };
   }
 
@@ -555,6 +559,17 @@ function buildScenarios(): Scenario[] {
       validate: (data) => {
         const webhook = getObject(data, 'webhook');
         requireCondition(webhook?.id, 'Missing webhook');
+      },
+    },
+    {
+      tool: 'getSatisfactionRating',
+      name: 'fixture satisfaction rating details',
+      skipIf: (ctx) => ctx.satisfactionRatingId ? undefined : 'No satisfaction rating fixture available',
+      args: (ctx) => ({ ratingId: ctx.satisfactionRatingId ?? '0' }),
+      validate: (data) => {
+        const rating = getObject(data, 'rating');
+        requireCondition(rating?.id, 'Missing satisfaction rating');
+        requireCondition(typeof rating.rating === 'string', 'Missing rating value');
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add direct Help Scout API support for retrieving one satisfaction rating by ID.
- Update schemas, MCPB manifest, local tool inventory, dogfood coverage, and the API surface roadmap.

## Testing
- npm test -- src/__tests__/tools.test.ts --runInBand --testNamePattern "satisfaction rating"
- npm test -- src/__tests__/tools.test.ts --runInBand
- npm test -- src/__tests__/mcpb-validation.test.ts --runInBand
- npm run type-check
- npm run lint
- npm run build
- npm test -- --runInBand
- npm run mcpb:build
- npm run dogfood:mcp
- npm run security (exit 0; existing repo-wide findings remain)
- git diff --check

Closes NAS-718
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->