### PR TITLE
feat(NAS-719): add core reporting tools

### DIFF
--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -84,11 +84,17 @@ managers and recurring analysis.
 Current:
 
 - `getSatisfactionRating`
+- `getCompanyReport`
+- `getConversationsReport`
+- `getHappinessReport`
+- `getHappinessRatingsReport`
 
 Next:
 
 - Rating fixture coverage when the dogfood account has known rating data.
-- Reporting API coverage.
+- Productivity report coverage.
+- User and team report coverage.
+- Report drilldown coverage with strict pagination and bounded filters.
 - Time-windowed trend queries that return compact, chartable data.
 - Guardrails to avoid large, slow account-wide report pulls by default.
 

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -238,6 +238,22 @@
     {
       "name": "getSatisfactionRating",
       "description": "Get a Help Scout satisfaction rating by ID"
+    },
+    {
+      "name": "getCompanyReport",
+      "description": "Get the Help Scout company overall report"
+    },
+    {
+      "name": "getConversationsReport",
+      "description": "Get the Help Scout conversations overall report"
+    },
+    {
+      "name": "getHappinessReport",
+      "description": "Get the Help Scout happiness overall report"
+    },
+    {
+      "name": "getHappinessRatingsReport",
+      "description": "Get Help Scout happiness rating rows"
     }
   ],
   "prompts": [

--- a/mcp.json
+++ b/mcp.json
@@ -45,7 +45,11 @@
     "listWorkflows",
     "listWebhooks",
     "getWebhook",
-    "getSatisfactionRating"
+    "getSatisfactionRating",
+    "getCompanyReport",
+    "getConversationsReport",
+    "getHappinessReport",
+    "getHappinessRatingsReport"
   ],
   "prompts": [
     "search-last-7-days",

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 36 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(36);
+    it('should have all 40 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(40);
 
       const expectedTools = [
         'searchInboxes',
@@ -103,7 +103,11 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'listWorkflows',
         'listWebhooks',
         'getWebhook',
-        'getSatisfactionRating'
+        'getSatisfactionRating',
+        'getCompanyReport',
+        'getConversationsReport',
+        'getHappinessReport',
+        'getHappinessRatingsReport'
       ];
 
       const toolNames = manifest.tools.map((tool: any) => tool.name);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -41,7 +41,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(36);
+      expect(tools).toHaveLength(40);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -79,6 +79,10 @@ describe('ToolHandler', () => {
         'listWebhooks',
         'getWebhook',
         'getSatisfactionRating',
+        'getCompanyReport',
+        'getConversationsReport',
+        'getHappinessReport',
+        'getHappinessRatingsReport',
       ]);
     });
 
@@ -877,6 +881,176 @@ describe('ToolHandler', () => {
         expect.objectContaining({
           field: 'ratingId',
           message: 'Rating ID must be numeric',
+        }),
+      ]));
+    });
+
+    it('should get core reporting API data for a bounded time range', async () => {
+      const reportArgs = {
+        start: '2024-01-01T00:00:00Z',
+        end: '2024-01-31T23:59:59Z',
+        previousStart: '2023-12-01T00:00:00Z',
+        previousEnd: '2023-12-31T23:59:59Z',
+        mailboxes: ['359402'],
+        tags: ['123'],
+        types: ['email'],
+        folders: ['456'],
+      };
+
+      nock(baseURL)
+        .get('/reports/company')
+        .query({
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+        })
+        .reply(200, {
+          current: { customersHelped: 28, totalReplies: 62 },
+          previous: { customersHelped: 27, totalReplies: 60 },
+          deltas: { customersHelped: 3.7 },
+        });
+
+      nock(baseURL)
+        .get('/reports/conversations')
+        .query({
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+        })
+        .reply(200, {
+          current: { totalConversations: 1816, conversationsPerDay: 60 },
+          previous: { totalConversations: 2080, conversationsPerDay: 67 },
+          busiestDay: { day: 3, hour: 0, count: 411 },
+        });
+
+      nock(baseURL)
+        .get('/reports/happiness')
+        .query({
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+        })
+        .reply(200, {
+          current: { happinessScore: 5.45, greatCount: 41, ratingsCount: 110 },
+          previous: { happinessScore: -0.18, greatCount: 340, ratingsCount: 1074 },
+        });
+
+      for (const [toolName, reportType, expectedField] of [
+        ['getCompanyReport', 'company', 'customersHelped'],
+        ['getConversationsReport', 'conversations', 'totalConversations'],
+        ['getHappinessReport', 'happiness', 'happinessScore'],
+      ] as const) {
+        const result = await toolHandler.callTool({
+          method: 'tools/call',
+          params: {
+            name: toolName,
+            arguments: reportArgs,
+          },
+        });
+
+        const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+        expect(result.isError).toBeUndefined();
+        expect(response.reportType).toBe(reportType);
+        expect(response.filters).toEqual(expect.objectContaining({
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+        }));
+        expect(response.report.current[expectedField]).toBeDefined();
+      }
+    });
+
+    it('should get happiness ratings report rows with pagination and rating filter', async () => {
+      nock(baseURL)
+        .get('/reports/happiness/ratings')
+        .query({
+          start: '2024-01-01T00:00:00Z',
+          end: '2024-01-31T23:59:59Z',
+          page: 2,
+          sortField: 'rating',
+          sortOrder: 'ASC',
+          rating: 'great',
+        })
+        .reply(200, {
+          results: [{
+            number: 222043,
+            threadid: 1169815634,
+            id: 432207336,
+            type: 'email',
+            ratingId: 1,
+            ratingComments: 'Thanks!',
+            ratingCreatedAt: '2024-01-15T12:26:53Z',
+          }],
+          page: 2,
+          count: 100,
+          pages: 10,
+        });
+
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getHappinessRatingsReport',
+          arguments: {
+            start: '2024-01-01T00:00:00Z',
+            end: '2024-01-31T23:59:59Z',
+            page: 2,
+            sortField: 'rating',
+            sortOrder: 'asc',
+            rating: 'great',
+          },
+        },
+      });
+
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(result.isError).toBeUndefined();
+      expect(response.reportType).toBe('happinessRatings');
+      expect(response.filters).toEqual(expect.objectContaining({
+        page: 2,
+        sortField: 'rating',
+        sortOrder: 'ASC',
+        rating: 'great',
+      }));
+      expect(response.report.results[0]).toEqual(expect.objectContaining({
+        number: 222043,
+        ratingId: 1,
+      }));
+    });
+
+    it('should require comparison report dates to be paired', async () => {
+      const result = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getCompanyReport',
+          arguments: {
+            start: '2024-01-01T00:00:00Z',
+            end: '2024-01-31T23:59:59Z',
+            previousStart: '2023-12-01T00:00:00Z',
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(response.error.code).toBe('INVALID_INPUT');
+      expect(response.error.validationIssues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: 'previousStart and previousEnd must be provided together',
         }),
       ]));
     });

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -354,6 +354,73 @@ export const SatisfactionRatingSchema = z.object({
   }).passthrough().optional(),
 }).passthrough();
 
+export const ReportResponseSchema = z.object({
+  current: z.unknown().optional(),
+  previous: z.unknown().optional(),
+  deltas: z.unknown().optional(),
+}).passthrough();
+
+export const HappinessRatingsReportSchema = z.object({
+  facets: z.record(z.unknown()).optional(),
+  results: z.array(z.object({
+    number: z.number().optional(),
+    threadid: z.number().optional(),
+    threadCreatedAt: z.string().optional(),
+    id: z.number().optional(),
+    type: z.enum(['email', 'chat', 'phone']).or(z.string()).optional(),
+    ratingId: z.number().optional(),
+    ratingCustomerId: z.number().optional(),
+    ratingComments: z.string().nullable().optional(),
+    ratingCreatedAt: z.string().optional(),
+    ratingCustomerName: z.string().nullable().optional(),
+    ratingUserId: z.number().optional(),
+    ratingUserName: z.string().nullable().optional(),
+  }).passthrough()).optional(),
+  page: z.number().optional(),
+  count: z.number().optional(),
+  pages: z.number().optional(),
+}).passthrough();
+
+const ReportDateSchema = z.string().regex(
+  /^\d{4}-\d{2}-\d{2}(T[\d:.]+([+-]\d{2}:\d{2}|Z)?)?$/,
+  'Report dates must be ISO 8601 strings'
+);
+const ReportIdListSchema = z.array(
+  z.string().regex(/^\d+$/, 'Report filter IDs must be numeric')
+).min(1).max(50);
+const ReportConversationTypesSchema = z.array(z.enum(['email', 'chat', 'phone'])).min(1).max(3);
+
+const ReportBaseInputObjectSchema = z.object({
+  start: ReportDateSchema.describe('Start of the reporting interval, ISO 8601'),
+  end: ReportDateSchema.describe('End of the reporting interval, ISO 8601'),
+  previousStart: ReportDateSchema.optional().describe('Optional start of the comparison interval'),
+  previousEnd: ReportDateSchema.optional().describe('Optional end of the comparison interval'),
+  mailboxes: ReportIdListSchema.optional().describe('Inbox IDs to filter by'),
+  tags: ReportIdListSchema.optional().describe('Tag IDs to filter by'),
+  types: ReportConversationTypesSchema.optional().describe('Conversation types to filter by'),
+  folders: ReportIdListSchema.optional().describe('Folder IDs to filter by'),
+});
+
+export const ReportBaseInputSchema = ReportBaseInputObjectSchema.refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const GetCompanyReportInputSchema = ReportBaseInputSchema;
+export const GetConversationsReportInputSchema = ReportBaseInputSchema;
+export const GetHappinessReportInputSchema = ReportBaseInputSchema;
+
+export const GetHappinessRatingsReportInputSchema = ReportBaseInputObjectSchema.extend({
+  page: z.number().int().min(1).default(1),
+  sortField: z.enum(['number', 'modifiedAt', 'rating']).default('modifiedAt'),
+  sortOrder: z.enum(['ASC', 'DESC', 'asc', 'desc']).default('DESC')
+    .transform((value) => value.toUpperCase() as 'ASC' | 'DESC'),
+  rating: z.enum(['great', 'ok', 'all', 'not-good']).optional(),
+}).refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
 // Customer & Organization Input Schemas
 export const GetCustomerInputSchema = z.object({
   customerId: z.string().regex(/^\d+$/, 'Customer ID must be numeric').describe('Customer ID'),
@@ -525,6 +592,8 @@ export type SavedReply = z.infer<typeof SavedReplySchema>;
 export type Workflow = z.infer<typeof WorkflowSchema>;
 export type Webhook = z.infer<typeof WebhookSchema>;
 export type SatisfactionRating = z.infer<typeof SatisfactionRatingSchema>;
+export type ReportResponse = z.infer<typeof ReportResponseSchema>;
+export type HappinessRatingsReport = z.infer<typeof HappinessRatingsReportSchema>;
 export type SearchInboxesInput = z.infer<typeof SearchInboxesInputSchema>;
 export type SearchConversationsInput = z.infer<typeof SearchConversationsInputSchema>;
 export type GetThreadsInput = z.infer<typeof GetThreadsInputSchema>;
@@ -559,5 +628,10 @@ export type ListWorkflowsInput = z.infer<typeof ListWorkflowsInputSchema>;
 export type ListWebhooksInput = z.infer<typeof ListWebhooksInputSchema>;
 export type GetWebhookInput = z.infer<typeof GetWebhookInputSchema>;
 export type GetSatisfactionRatingInput = z.infer<typeof GetSatisfactionRatingInputSchema>;
+export type ReportBaseInput = z.infer<typeof ReportBaseInputSchema>;
+export type GetCompanyReportInput = z.infer<typeof GetCompanyReportInputSchema>;
+export type GetConversationsReportInput = z.infer<typeof GetConversationsReportInputSchema>;
+export type GetHappinessReportInput = z.infer<typeof GetHappinessReportInputSchema>;
+export type GetHappinessRatingsReportInput = z.infer<typeof GetHappinessRatingsReportInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,6 +23,9 @@ import {
   Workflow,
   Webhook,
   SatisfactionRating,
+  ReportResponse,
+  HappinessRatingsReport,
+  ReportBaseInput,
   ServerTime,
   SearchInboxesInputSchema,
   SearchConversationsInputSchema,
@@ -59,6 +62,10 @@ import {
   ListWebhooksInputSchema,
   GetWebhookInputSchema,
   GetSatisfactionRatingInputSchema,
+  GetCompanyReportInputSchema,
+  GetConversationsReportInputSchema,
+  GetHappinessReportInputSchema,
+  GetHappinessRatingsReportInputSchema,
 } from '../schema/types.js';
 
 type ConversationStatus = 'active' | 'pending' | 'closed' | 'spam';
@@ -160,6 +167,22 @@ export class ToolHandler {
 
   private appendQueryClause(existingQuery: string | undefined, clause: string): string {
     return existingQuery ? `(${existingQuery}) AND (${clause})` : `(${clause})`;
+  }
+
+  private buildReportQueryParams(input: ReportBaseInput): Record<string, string | number> {
+    const params: Record<string, string | number> = {
+      start: this.normalizeApiDateParam(input.start) ?? input.start,
+      end: this.normalizeApiDateParam(input.end) ?? input.end,
+    };
+
+    if (input.previousStart) params.previousStart = this.normalizeApiDateParam(input.previousStart) ?? input.previousStart;
+    if (input.previousEnd) params.previousEnd = this.normalizeApiDateParam(input.previousEnd) ?? input.previousEnd;
+    if (input.mailboxes) params.mailboxes = input.mailboxes.join(',');
+    if (input.tags) params.tags = input.tags.join(',');
+    if (input.types) params.types = input.types.join(',');
+    if (input.folders) params.folders = input.folders.join(',');
+
+    return params;
   }
 
   /**
@@ -809,6 +832,82 @@ export class ToolHandler {
           required: ['ratingId'],
         },
       },
+      {
+        name: 'getCompanyReport',
+        description: 'Get the Help Scout company overall report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getConversationsReport',
+        description: 'Get the Help Scout conversations overall report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getHappinessReport',
+        description: 'Get the Help Scout happiness overall report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getHappinessRatingsReport',
+        description: 'Get Help Scout happiness rating rows for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            sortField: { type: 'string', enum: ['number', 'modifiedAt', 'rating'], default: 'modifiedAt' },
+            sortOrder: { type: 'string', enum: ['ASC', 'DESC'], default: 'DESC' },
+            rating: { type: 'string', enum: ['great', 'ok', 'all', 'not-good'], description: 'Rating value filter' },
+          },
+          required: ['start', 'end'],
+        },
+      },
     ];
   }
 
@@ -977,6 +1076,18 @@ export class ToolHandler {
           break;
         case 'getSatisfactionRating':
           result = await this.getSatisfactionRating(request.params.arguments || {});
+          break;
+        case 'getCompanyReport':
+          result = await this.getCompanyReport(request.params.arguments || {});
+          break;
+        case 'getConversationsReport':
+          result = await this.getConversationsReport(request.params.arguments || {});
+          break;
+        case 'getHappinessReport':
+          result = await this.getHappinessReport(request.params.arguments || {});
+          break;
+        case 'getHappinessRatingsReport':
+          result = await this.getHappinessRatingsReport(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -1787,6 +1898,62 @@ export class ToolHandler {
           ratingId: input.ratingId,
           rating,
           usage: 'Use satisfaction rating data as read-only quality context; this tool does not compute reports or trends.',
+        }, null, 2),
+      }],
+    };
+  }
+
+  private async getCompanyReport(args: unknown): Promise<CallToolResult> {
+    const input = GetCompanyReportInputSchema.parse(args);
+    const params = this.buildReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/company', params);
+
+    return this.formatReportResult('company', params, report);
+  }
+
+  private async getConversationsReport(args: unknown): Promise<CallToolResult> {
+    const input = GetConversationsReportInputSchema.parse(args);
+    const params = this.buildReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/conversations', params);
+
+    return this.formatReportResult('conversations', params, report);
+  }
+
+  private async getHappinessReport(args: unknown): Promise<CallToolResult> {
+    const input = GetHappinessReportInputSchema.parse(args);
+    const params = this.buildReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/happiness', params);
+
+    return this.formatReportResult('happiness', params, report);
+  }
+
+  private async getHappinessRatingsReport(args: unknown): Promise<CallToolResult> {
+    const input = GetHappinessRatingsReportInputSchema.parse(args);
+    const params = {
+      ...this.buildReportQueryParams(input),
+      page: input.page,
+      sortField: input.sortField,
+      sortOrder: input.sortOrder,
+      ...(input.rating ? { rating: input.rating } : {}),
+    };
+    const report = await helpScoutClient.get<HappinessRatingsReport>('/reports/happiness/ratings', params);
+
+    return this.formatReportResult('happinessRatings', params, report);
+  }
+
+  private formatReportResult(
+    reportType: string,
+    filters: Record<string, string | number>,
+    report: ReportResponse | HappinessRatingsReport
+  ): CallToolResult {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          reportType,
+          filters,
+          report,
+          usage: 'Reporting data is read-only Help Scout API output for the requested bounded interval; this tool does not compute dashboard summaries or trends beyond API-provided fields.',
         }, null, 2),
       }],
     };

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -21,6 +21,13 @@ const SERVER_PATH = resolve(import.meta.dirname, '../dist/cli.js');
 const REQUEST_TIMEOUT_MS = Number(process.env.MCP_DOGFOOD_TIMEOUT_MS ?? 90000);
 const SCENARIO_COOLDOWN_MS = Number(process.env.MCP_DOGFOOD_COOLDOWN_MS ?? 0);
 
+function daysAgoIso(days: number): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - days);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
 const GOLDEN = {
   customerId: process.env.MCP_DOGFOOD_CUSTOMER_ID ?? '860587086',
   customerEmail: process.env.MCP_DOGFOOD_CUSTOMER_EMAIL ?? 'testuser@meridian-testing.com',
@@ -37,6 +44,9 @@ const GOLDEN = {
   attachmentConversationId: process.env.MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID,
   attachmentId: process.env.MCP_DOGFOOD_ATTACHMENT_ID,
   satisfactionRatingId: process.env.MCP_DOGFOOD_SATISFACTION_RATING_ID,
+  reportStart: process.env.MCP_DOGFOOD_REPORT_START ?? daysAgoIso(30),
+  reportEnd: process.env.MCP_DOGFOOD_REPORT_END ?? daysAgoIso(0),
+  skipReports: process.env.MCP_DOGFOOD_SKIP_REPORTS === 'true',
 };
 
 const EXPECTED_TOOLS = [
@@ -76,6 +86,10 @@ const EXPECTED_TOOLS = [
   'listWebhooks',
   'getWebhook',
   'getSatisfactionRating',
+  'getCompanyReport',
+  'getConversationsReport',
+  'getHappinessReport',
+  'getHappinessRatingsReport',
 ] as const;
 
 type ToolName = typeof EXPECTED_TOOLS[number];
@@ -104,6 +118,9 @@ interface DogfoodContext {
   savedReplyId?: string;
   webhookId?: string;
   satisfactionRatingId?: string;
+  reportStart: string;
+  reportEnd: string;
+  skipReports: boolean;
   organizationPropertySlug?: string;
   createdAfter?: string;
   createdBefore?: string;
@@ -173,6 +190,9 @@ class McpDogfoodSession {
       attachmentConversationId: GOLDEN.attachmentConversationId,
       attachmentId: GOLDEN.attachmentId,
       satisfactionRatingId: GOLDEN.satisfactionRatingId,
+      reportStart: GOLDEN.reportStart,
+      reportEnd: GOLDEN.reportEnd,
+      skipReports: GOLDEN.skipReports,
     };
   }
 
@@ -570,6 +590,50 @@ function buildScenarios(): Scenario[] {
         const rating = getObject(data, 'rating');
         requireCondition(rating?.id, 'Missing satisfaction rating');
         requireCondition(typeof rating.rating === 'string', 'Missing rating value');
+      },
+    },
+    {
+      tool: 'getCompanyReport',
+      name: 'company overall report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId] }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing company report');
+        requireCondition(getObject(report, 'current'), 'Missing current company report data');
+      },
+    },
+    {
+      tool: 'getConversationsReport',
+      name: 'conversations overall report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId] }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing conversations report');
+        requireCondition(getObject(report, 'current'), 'Missing current conversations report data');
+      },
+    },
+    {
+      tool: 'getHappinessReport',
+      name: 'happiness overall report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId] }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing happiness report');
+        requireCondition(getObject(report, 'current'), 'Missing current happiness report data');
+      },
+    },
+    {
+      tool: 'getHappinessRatingsReport',
+      name: 'happiness ratings report rows',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], page: 1, sortField: 'modifiedAt', sortOrder: 'DESC', rating: 'all' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing happiness ratings report');
+        requireArray(report, ['results'], 'rating results');
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add direct Help Scout reporting tools for company, conversations, happiness, and happiness ratings endpoints.
- Require explicit bounded reporting windows and serialize supported Help Scout report filters directly to the Reporting API.
- Update MCP and MCPB tool inventories, live dogfood coverage, and the API parity roadmap.

## Testing
- npm test -- src/__tests__/tools.test.ts --runInBand --testNamePattern "report"
- npm run type-check
- npm test -- src/__tests__/mcpb-validation.test.ts --runInBand
- npm test -- src/__tests__/tools.test.ts --runInBand
- npm run lint
- npm run build
- npm test -- --runInBand
- npm run mcpb:build
- npm run dogfood:mcp
- npm run security (completed; existing repository-wide findings remain)
- semgrep --config .semgrep.yml . --json --quiet (confirmed touched-file findings are existing baseline ranges)
- git diff --check

Refs NAS-719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->