### PR TITLE
feat(NAS-719): add productivity reporting tools

### DIFF
--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -88,11 +88,16 @@ Current:
 - `getConversationsReport`
 - `getHappinessReport`
 - `getHappinessRatingsReport`
+- `getProductivityReport`
+- `getProductivityFirstResponseTimeReport`
+- `getProductivityRepliesSentReport`
+- `getProductivityResolutionTimeReport`
+- `getProductivityResolvedReport`
+- `getProductivityResponseTimeReport`
 
 Next:
 
 - Rating fixture coverage when the dogfood account has known rating data.
-- Productivity report coverage.
 - User and team report coverage.
 - Report drilldown coverage with strict pagination and bounded filters.
 - Time-windowed trend queries that return compact, chartable data.

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -254,6 +254,30 @@
     {
       "name": "getHappinessRatingsReport",
       "description": "Get Help Scout happiness rating rows"
+    },
+    {
+      "name": "getProductivityReport",
+      "description": "Get the Help Scout productivity overall report"
+    },
+    {
+      "name": "getProductivityFirstResponseTimeReport",
+      "description": "Get Help Scout productivity first response time series"
+    },
+    {
+      "name": "getProductivityRepliesSentReport",
+      "description": "Get Help Scout productivity replies sent time series"
+    },
+    {
+      "name": "getProductivityResolutionTimeReport",
+      "description": "Get Help Scout productivity resolution time series"
+    },
+    {
+      "name": "getProductivityResolvedReport",
+      "description": "Get Help Scout productivity resolved conversations time series"
+    },
+    {
+      "name": "getProductivityResponseTimeReport",
+      "description": "Get Help Scout productivity response time series"
     }
   ],
   "prompts": [

--- a/mcp.json
+++ b/mcp.json
@@ -49,7 +49,13 @@
     "getCompanyReport",
     "getConversationsReport",
     "getHappinessReport",
-    "getHappinessRatingsReport"
+    "getHappinessRatingsReport",
+    "getProductivityReport",
+    "getProductivityFirstResponseTimeReport",
+    "getProductivityRepliesSentReport",
+    "getProductivityResolutionTimeReport",
+    "getProductivityResolvedReport",
+    "getProductivityResponseTimeReport"
   ],
   "prompts": [
     "search-last-7-days",

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 40 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(40);
+    it('should have all 46 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(46);
 
       const expectedTools = [
         'searchInboxes',
@@ -107,7 +107,13 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'getCompanyReport',
         'getConversationsReport',
         'getHappinessReport',
-        'getHappinessRatingsReport'
+        'getHappinessRatingsReport',
+        'getProductivityReport',
+        'getProductivityFirstResponseTimeReport',
+        'getProductivityRepliesSentReport',
+        'getProductivityResolutionTimeReport',
+        'getProductivityResolvedReport',
+        'getProductivityResponseTimeReport'
       ];
 
       const toolNames = manifest.tools.map((tool: any) => tool.name);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -41,7 +41,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(40);
+      expect(tools).toHaveLength(46);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -83,6 +83,12 @@ describe('ToolHandler', () => {
         'getConversationsReport',
         'getHappinessReport',
         'getHappinessRatingsReport',
+        'getProductivityReport',
+        'getProductivityFirstResponseTimeReport',
+        'getProductivityRepliesSentReport',
+        'getProductivityResolutionTimeReport',
+        'getProductivityResolvedReport',
+        'getProductivityResponseTimeReport',
       ]);
     });
 
@@ -1030,6 +1036,119 @@ describe('ToolHandler', () => {
         number: 222043,
         ratingId: 1,
       }));
+    });
+
+    it('should get productivity reports with office hours and view granularity', async () => {
+      const reportArgs = {
+        start: '2024-01-01T00:00:00Z',
+        end: '2024-01-31T23:59:59Z',
+        previousStart: '2023-12-01T00:00:00Z',
+        previousEnd: '2023-12-31T23:59:59Z',
+        mailboxes: ['359402'],
+        tags: ['123'],
+        types: ['email'],
+        folders: ['456'],
+        officeHours: true,
+      };
+
+      nock(baseURL)
+        .get('/reports/productivity')
+        .query({
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+          officeHours: 'true',
+        })
+        .reply(200, {
+          current: {
+            totalConversations: 12,
+            firstResponseTime: 42,
+            repliesSent: 31,
+          },
+          previous: {
+            totalConversations: 10,
+            firstResponseTime: 50,
+            repliesSent: 29,
+          },
+        });
+
+      const overallResult = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getProductivityReport',
+          arguments: reportArgs,
+        },
+      });
+
+      const overallResponse = JSON.parse((overallResult.content[0] as { type: 'text'; text: string }).text);
+      expect(overallResult.isError).toBeUndefined();
+      expect(overallResponse.reportType).toBe('productivity');
+      expect(overallResponse.filters).toEqual(expect.objectContaining({
+        mailboxes: '359402',
+        tags: '123',
+        types: 'email',
+        folders: '456',
+        officeHours: 'true',
+      }));
+      expect(overallResponse.report.current.firstResponseTime).toBe(42);
+
+      for (const [toolName, path, reportType, expectedField] of [
+        ['getProductivityFirstResponseTimeReport', '/reports/productivity/first-response-time', 'productivityFirstResponseTime', 'time'],
+        ['getProductivityRepliesSentReport', '/reports/productivity/replies-sent', 'productivityRepliesSent', 'replies'],
+        ['getProductivityResolutionTimeReport', '/reports/productivity/resolution-time', 'productivityResolutionTime', 'time'],
+        ['getProductivityResolvedReport', '/reports/productivity/resolved', 'productivityResolved', 'resolved'],
+        ['getProductivityResponseTimeReport', '/reports/productivity/response-time', 'productivityResponseTime', 'time'],
+      ] as const) {
+        nock(baseURL)
+          .get(path)
+          .query({
+            start: reportArgs.start,
+            end: reportArgs.end,
+            previousStart: reportArgs.previousStart,
+            previousEnd: reportArgs.previousEnd,
+            mailboxes: '359402',
+            tags: '123',
+            types: 'email',
+            folders: '456',
+            officeHours: 'true',
+            viewBy: 'week',
+          })
+          .reply(200, {
+            current: [{
+              date: '2024-01-01T00:00:00Z',
+              [expectedField]: 10,
+            }],
+            previous: [{
+              date: '2023-12-01T00:00:00Z',
+              [expectedField]: 20,
+            }],
+          });
+
+        const result = await toolHandler.callTool({
+          method: 'tools/call',
+          params: {
+            name: toolName,
+            arguments: {
+              ...reportArgs,
+              viewBy: 'week',
+            },
+          },
+        });
+
+        const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+        expect(result.isError).toBeUndefined();
+        expect(response.reportType).toBe(reportType);
+        expect(response.filters).toEqual(expect.objectContaining({
+          officeHours: 'true',
+          viewBy: 'week',
+        }));
+        expect(response.report.current[0][expectedField]).toBe(10);
+      }
     });
 
     it('should require comparison report dates to be paired', async () => {

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -389,6 +389,7 @@ const ReportIdListSchema = z.array(
   z.string().regex(/^\d+$/, 'Report filter IDs must be numeric')
 ).min(1).max(50);
 const ReportConversationTypesSchema = z.array(z.enum(['email', 'chat', 'phone'])).min(1).max(3);
+const ReportViewBySchema = z.enum(['day', 'week', 'month']);
 
 const ReportBaseInputObjectSchema = z.object({
   start: ReportDateSchema.describe('Start of the reporting interval, ISO 8601'),
@@ -409,6 +410,28 @@ export const ReportBaseInputSchema = ReportBaseInputObjectSchema.refine(
 export const GetCompanyReportInputSchema = ReportBaseInputSchema;
 export const GetConversationsReportInputSchema = ReportBaseInputSchema;
 export const GetHappinessReportInputSchema = ReportBaseInputSchema;
+
+const ProductivityReportBaseInputObjectSchema = ReportBaseInputObjectSchema.extend({
+  officeHours: z.boolean().optional().describe('Whether to take office hours into consideration'),
+});
+
+export const GetProductivityReportInputSchema = ProductivityReportBaseInputObjectSchema.refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const ProductivityTimelineReportInputSchema = ProductivityReportBaseInputObjectSchema.extend({
+  viewBy: ReportViewBySchema.default('day').describe('Report granularity: day, week, or month'),
+}).refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const GetProductivityFirstResponseTimeReportInputSchema = ProductivityTimelineReportInputSchema;
+export const GetProductivityRepliesSentReportInputSchema = ProductivityTimelineReportInputSchema;
+export const GetProductivityResolutionTimeReportInputSchema = ProductivityTimelineReportInputSchema;
+export const GetProductivityResolvedReportInputSchema = ProductivityTimelineReportInputSchema;
+export const GetProductivityResponseTimeReportInputSchema = ProductivityTimelineReportInputSchema;
 
 export const GetHappinessRatingsReportInputSchema = ReportBaseInputObjectSchema.extend({
   page: z.number().int().min(1).default(1),
@@ -633,5 +656,7 @@ export type GetCompanyReportInput = z.infer<typeof GetCompanyReportInputSchema>;
 export type GetConversationsReportInput = z.infer<typeof GetConversationsReportInputSchema>;
 export type GetHappinessReportInput = z.infer<typeof GetHappinessReportInputSchema>;
 export type GetHappinessRatingsReportInput = z.infer<typeof GetHappinessRatingsReportInputSchema>;
+export type GetProductivityReportInput = z.infer<typeof GetProductivityReportInputSchema>;
+export type ProductivityTimelineReportInput = z.infer<typeof ProductivityTimelineReportInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -66,6 +66,12 @@ import {
   GetConversationsReportInputSchema,
   GetHappinessReportInputSchema,
   GetHappinessRatingsReportInputSchema,
+  GetProductivityReportInputSchema,
+  GetProductivityFirstResponseTimeReportInputSchema,
+  GetProductivityRepliesSentReportInputSchema,
+  GetProductivityResolutionTimeReportInputSchema,
+  GetProductivityResolvedReportInputSchema,
+  GetProductivityResponseTimeReportInputSchema,
 } from '../schema/types.js';
 
 type ConversationStatus = 'active' | 'pending' | 'closed' | 'spam';
@@ -182,6 +188,15 @@ export class ToolHandler {
     if (input.types) params.types = input.types.join(',');
     if (input.folders) params.folders = input.folders.join(',');
 
+    return params;
+  }
+
+  private buildProductivityReportQueryParams(
+    input: ReportBaseInput & { officeHours?: boolean; viewBy?: 'day' | 'week' | 'month' }
+  ): Record<string, string | number> {
+    const params = this.buildReportQueryParams(input);
+    if (typeof input.officeHours === 'boolean') params.officeHours = String(input.officeHours);
+    if (input.viewBy) params.viewBy = input.viewBy;
     return params;
   }
 
@@ -908,6 +923,125 @@ export class ToolHandler {
           required: ['start', 'end'],
         },
       },
+      {
+        name: 'getProductivityReport',
+        description: 'Get the Help Scout productivity overall report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getProductivityFirstResponseTimeReport',
+        description: 'Get Help Scout productivity first response time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getProductivityRepliesSentReport',
+        description: 'Get Help Scout productivity replies sent time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getProductivityResolutionTimeReport',
+        description: 'Get Help Scout productivity resolution time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getProductivityResolvedReport',
+        description: 'Get Help Scout productivity resolved conversations time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['start', 'end'],
+        },
+      },
+      {
+        name: 'getProductivityResponseTimeReport',
+        description: 'Get Help Scout productivity response time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['start', 'end'],
+        },
+      },
     ];
   }
 
@@ -1088,6 +1222,24 @@ export class ToolHandler {
           break;
         case 'getHappinessRatingsReport':
           result = await this.getHappinessRatingsReport(request.params.arguments || {});
+          break;
+        case 'getProductivityReport':
+          result = await this.getProductivityReport(request.params.arguments || {});
+          break;
+        case 'getProductivityFirstResponseTimeReport':
+          result = await this.getProductivityFirstResponseTimeReport(request.params.arguments || {});
+          break;
+        case 'getProductivityRepliesSentReport':
+          result = await this.getProductivityRepliesSentReport(request.params.arguments || {});
+          break;
+        case 'getProductivityResolutionTimeReport':
+          result = await this.getProductivityResolutionTimeReport(request.params.arguments || {});
+          break;
+        case 'getProductivityResolvedReport':
+          result = await this.getProductivityResolvedReport(request.params.arguments || {});
+          break;
+        case 'getProductivityResponseTimeReport':
+          result = await this.getProductivityResponseTimeReport(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -1939,6 +2091,54 @@ export class ToolHandler {
     const report = await helpScoutClient.get<HappinessRatingsReport>('/reports/happiness/ratings', params);
 
     return this.formatReportResult('happinessRatings', params, report);
+  }
+
+  private async getProductivityReport(args: unknown): Promise<CallToolResult> {
+    const input = GetProductivityReportInputSchema.parse(args);
+    const params = this.buildProductivityReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/productivity', params);
+
+    return this.formatReportResult('productivity', params, report);
+  }
+
+  private async getProductivityFirstResponseTimeReport(args: unknown): Promise<CallToolResult> {
+    const input = GetProductivityFirstResponseTimeReportInputSchema.parse(args);
+    const params = this.buildProductivityReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/productivity/first-response-time', params);
+
+    return this.formatReportResult('productivityFirstResponseTime', params, report);
+  }
+
+  private async getProductivityRepliesSentReport(args: unknown): Promise<CallToolResult> {
+    const input = GetProductivityRepliesSentReportInputSchema.parse(args);
+    const params = this.buildProductivityReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/productivity/replies-sent', params);
+
+    return this.formatReportResult('productivityRepliesSent', params, report);
+  }
+
+  private async getProductivityResolutionTimeReport(args: unknown): Promise<CallToolResult> {
+    const input = GetProductivityResolutionTimeReportInputSchema.parse(args);
+    const params = this.buildProductivityReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/productivity/resolution-time', params);
+
+    return this.formatReportResult('productivityResolutionTime', params, report);
+  }
+
+  private async getProductivityResolvedReport(args: unknown): Promise<CallToolResult> {
+    const input = GetProductivityResolvedReportInputSchema.parse(args);
+    const params = this.buildProductivityReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/productivity/resolved', params);
+
+    return this.formatReportResult('productivityResolved', params, report);
+  }
+
+  private async getProductivityResponseTimeReport(args: unknown): Promise<CallToolResult> {
+    const input = GetProductivityResponseTimeReportInputSchema.parse(args);
+    const params = this.buildProductivityReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/productivity/response-time', params);
+
+    return this.formatReportResult('productivityResponseTime', params, report);
   }
 
   private formatReportResult(

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -90,6 +90,12 @@ const EXPECTED_TOOLS = [
   'getConversationsReport',
   'getHappinessReport',
   'getHappinessRatingsReport',
+  'getProductivityReport',
+  'getProductivityFirstResponseTimeReport',
+  'getProductivityRepliesSentReport',
+  'getProductivityResolutionTimeReport',
+  'getProductivityResolvedReport',
+  'getProductivityResponseTimeReport',
 ] as const;
 
 type ToolName = typeof EXPECTED_TOOLS[number];
@@ -634,6 +640,72 @@ function buildScenarios(): Scenario[] {
         const report = getObject(data, 'report');
         requireCondition(report, 'Missing happiness ratings report');
         requireArray(report, ['results'], 'rating results');
+      },
+    },
+    {
+      tool: 'getProductivityReport',
+      name: 'productivity overall report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing productivity report');
+        requireCondition(getObject(report, 'current'), 'Missing current productivity report data');
+      },
+    },
+    {
+      tool: 'getProductivityFirstResponseTimeReport',
+      name: 'productivity first response time series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false, viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing first response time report');
+        requireArray(report, ['current'], 'first response time points');
+      },
+    },
+    {
+      tool: 'getProductivityRepliesSentReport',
+      name: 'productivity replies sent series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false, viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing replies sent report');
+        requireArray(report, ['current'], 'replies sent points');
+      },
+    },
+    {
+      tool: 'getProductivityResolutionTimeReport',
+      name: 'productivity resolution time series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false, viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing resolution time report');
+        requireArray(report, ['current'], 'resolution time points');
+      },
+    },
+    {
+      tool: 'getProductivityResolvedReport',
+      name: 'productivity resolved series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false, viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing resolved report');
+        requireArray(report, ['current'], 'resolved points');
+      },
+    },
+    {
+      tool: 'getProductivityResponseTimeReport',
+      name: 'productivity response time series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false, viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing response time report');
+        requireArray(report, ['current'], 'response time points');
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add direct Help Scout productivity reporting tools for the overall productivity report and five time-series productivity endpoints.
- Serialize bounded reporting filters plus officeHours and viewBy directly to the Reporting API.
- Update MCP/MCPB inventories, dogfood coverage, and the API parity roadmap.

## Testing
- npm run type-check
- npm test -- src/__tests__/tools.test.ts --runInBand --testNamePattern "productivity|report"
- npm test -- src/__tests__/mcpb-validation.test.ts --runInBand
- npm test -- src/__tests__/tools.test.ts --runInBand
- npm run lint
- npm run build
- npm test -- --runInBand
- npm run mcpb:build
- npm run dogfood:mcp
- npm run security (completed; existing repository-wide findings remain)
- semgrep --config .semgrep.yml src/tools/index.ts src/schema/types.ts src/__tests__/tools.test.ts src/__tests__/mcpb-validation.test.ts tests/mcp-client-dogfood.ts --json --quiet (confirmed touched-file findings are existing baseline ranges)
- git diff --check

Refs NAS-719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->