### PR TITLE
feat(NAS-719): add user reporting tools

### DIFF
--- a/guides/architecture/mcp-vs-cli.md
+++ b/guides/architecture/mcp-vs-cli.md
@@ -63,7 +63,7 @@ dependent PR.
 ## Testing Account Policy
 
 The connected Help Scout account is the complete test lane for dogfood. Test
-fixtures should be deterministic enough for broad tool coverage, but the server
+fixtures must be deterministic enough for broad tool coverage, but the server
 must tolerate normal Help Scout account variation:
 
 - Optional fields may be absent.
@@ -71,8 +71,18 @@ must tolerate normal Help Scout account variation:
 - Pagination may return fewer objects than requested.
 - Deleted or inaccessible IDs should return model-correctable tool errors.
 
-Test scripts may require known fixture IDs through environment variables. MCP
-tools should not assume those fixture IDs in production behavior.
+Every API-surface PR is responsible for loading or extending fixture data that
+exercises the core path and meaningful permutations for that surface before the
+PR is reviewed. Missing account data should drive fixture work, not weaker
+dogfood assertions.
+
+Use `npm run dogfood:seed` to load the shared customer, organization,
+conversation, and organization-member fixtures before authenticated dogfood
+runs. New API families should add their own idempotent seed data and wire it
+into that script when existing fixtures cannot produce non-empty coverage.
+
+Test scripts may require known fixture IDs through environment variables after
+seeding. MCP tools should not assume those fixture IDs in production behavior.
 
 ## No Docker Publishing In Feature PRs
 

--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -1,7 +1,19 @@
 # MCP Tool Surface Roadmap
 
-This roadmap sorts future Help Scout MCP work by likely support-team usage. It
-is a product map, not a release plan.
+This roadmap sorts direct Help Scout API-parity MCP work by likely support-team
+usage. It is a product map, not a release plan; deferred ideas are called out
+separately so they are not mistaken for current build scope.
+
+## Dogfood Fixture Rule
+
+Each direct API-surface PR must include or reuse idempotent dogfood seed data
+that exercises the core path and meaningful parameter permutations for that
+surface. If a live dogfood failure is caused by missing account data, fix the
+fixture setup instead of weakening coverage.
+
+Use `npm run dogfood:seed` before authenticated dogfood runs. When a new API
+family needs data that the shared seed set cannot create, add the family-specific
+seed step and wire it into that command.
 
 ## 1. Core Support Loop
 
@@ -25,6 +37,8 @@ Next:
 
 - Add narrower thread/attachment fixture coverage as the dogfood account gets
   richer test data.
+- Seed thread original-source and attachment fixtures so core support-loop
+  dogfood does not depend on optional account history.
 
 ## 2. Customer And Account Context
 
@@ -94,12 +108,25 @@ Current:
 - `getProductivityResolutionTimeReport`
 - `getProductivityResolvedReport`
 - `getProductivityResponseTimeReport`
+- `getUserReport`
+- `getUserConversationHistoryReport`
+- `getUserCustomersHelpedReport`
+- `getUserDrilldownReport`
+- `getUserHappinessReport`
+- `getUserRatingsReport`
+- `getUserRepliesReport`
+- `getUserResolutionsReport`
+- `getUserChatReport`
 
 Next:
 
 - Rating fixture coverage when the dogfood account has known rating data.
-- User and team report coverage.
-- Report drilldown coverage with strict pagination and bounded filters.
+- Seed reporting fixtures with assigned users, closed conversations, replies,
+  resolution history, and satisfaction ratings so report dogfood can assert
+  non-empty rows across company, conversation, productivity, happiness, and user
+  report families.
+- Remaining company and conversations drilldown coverage with strict pagination
+  and bounded filters.
 - Time-windowed trend queries that return compact, chartable data.
 - Guardrails to avoid large, slow account-wide report pulls by default.
 
@@ -129,9 +156,11 @@ Next:
 
 - Integration health metadata if available through supported APIs.
 
-## 7. MCP Apps Views
+## 7. Deferred MCP Apps Views
 
-Interactive views should compose existing tool data rather than introduce a
+MCP Apps views are future ideas, not current plan. Do not schedule these until
+the direct API-parity tool surface is complete. When they are revisited,
+interactive views should compose existing tool data rather than introduce a
 second data path.
 
 Candidate views:

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -278,6 +278,42 @@
     {
       "name": "getProductivityResponseTimeReport",
       "description": "Get Help Scout productivity response time series"
+    },
+    {
+      "name": "getUserReport",
+      "description": "Get the Help Scout user or team overall report"
+    },
+    {
+      "name": "getUserConversationHistoryReport",
+      "description": "Get Help Scout user conversation history rows"
+    },
+    {
+      "name": "getUserCustomersHelpedReport",
+      "description": "Get Help Scout user customers helped time series"
+    },
+    {
+      "name": "getUserDrilldownReport",
+      "description": "Get Help Scout user report drilldown conversations"
+    },
+    {
+      "name": "getUserHappinessReport",
+      "description": "Get Help Scout user happiness report"
+    },
+    {
+      "name": "getUserRatingsReport",
+      "description": "Get Help Scout user happiness rating rows"
+    },
+    {
+      "name": "getUserRepliesReport",
+      "description": "Get Help Scout user replies time series"
+    },
+    {
+      "name": "getUserResolutionsReport",
+      "description": "Get Help Scout user resolutions time series"
+    },
+    {
+      "name": "getUserChatReport",
+      "description": "Get Help Scout user or team chat report"
     }
   ],
   "prompts": [

--- a/mcp.json
+++ b/mcp.json
@@ -55,7 +55,16 @@
     "getProductivityRepliesSentReport",
     "getProductivityResolutionTimeReport",
     "getProductivityResolvedReport",
-    "getProductivityResponseTimeReport"
+    "getProductivityResponseTimeReport",
+    "getUserReport",
+    "getUserConversationHistoryReport",
+    "getUserCustomersHelpedReport",
+    "getUserDrilldownReport",
+    "getUserHappinessReport",
+    "getUserRatingsReport",
+    "getUserRepliesReport",
+    "getUserResolutionsReport",
+    "getUserChatReport"
   ],
   "prompts": [
     "search-last-7-days",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "jest",
     "test:contract": "TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm tests/api-contract.ts",
     "test:mcp": "npm run dogfood:mcp",
+    "dogfood:seed": "node --loader ts-node/esm tests/seed-test-data.ts && node --loader ts-node/esm tests/seed-org-customers.ts && node --loader ts-node/esm tests/seed-integration-data.ts",
     "dogfood:mcp": "npm run build && node --loader ts-node/esm tests/mcp-client-dogfood.ts",
     "dogfood:workflows": "npm run build && node --loader ts-node/esm tests/integration-workflows.ts",
     "dogfood:full": "npm run dogfood:mcp && npm run dogfood:workflows",

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -64,8 +64,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 46 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(46);
+    it('should have all 55 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(55);
 
       const expectedTools = [
         'searchInboxes',
@@ -113,7 +113,16 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'getProductivityRepliesSentReport',
         'getProductivityResolutionTimeReport',
         'getProductivityResolvedReport',
-        'getProductivityResponseTimeReport'
+        'getProductivityResponseTimeReport',
+        'getUserReport',
+        'getUserConversationHistoryReport',
+        'getUserCustomersHelpedReport',
+        'getUserDrilldownReport',
+        'getUserHappinessReport',
+        'getUserRatingsReport',
+        'getUserRepliesReport',
+        'getUserResolutionsReport',
+        'getUserChatReport'
       ];
 
       const toolNames = manifest.tools.map((tool: any) => tool.name);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -41,7 +41,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(46);
+      expect(tools).toHaveLength(55);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -89,6 +89,15 @@ describe('ToolHandler', () => {
         'getProductivityResolutionTimeReport',
         'getProductivityResolvedReport',
         'getProductivityResponseTimeReport',
+        'getUserReport',
+        'getUserConversationHistoryReport',
+        'getUserCustomersHelpedReport',
+        'getUserDrilldownReport',
+        'getUserHappinessReport',
+        'getUserRatingsReport',
+        'getUserRepliesReport',
+        'getUserResolutionsReport',
+        'getUserChatReport',
       ]);
     });
 
@@ -1148,6 +1157,253 @@ describe('ToolHandler', () => {
           viewBy: 'week',
         }));
         expect(response.report.current[0][expectedField]).toBe(10);
+      }
+    });
+
+    it('should get user report family data with documented filters', async () => {
+      const reportArgs = {
+        user: '12345',
+        start: '2024-01-01T00:00:00Z',
+        end: '2024-01-31T23:59:59Z',
+        previousStart: '2023-12-01T00:00:00Z',
+        previousEnd: '2023-12-31T23:59:59Z',
+        mailboxes: ['359402'],
+        tags: ['123'],
+        types: ['email'],
+        folders: ['456'],
+      };
+
+      nock(baseURL)
+        .get('/reports/user')
+        .query({
+          user: reportArgs.user,
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+          officeHours: 'false',
+        })
+        .reply(200, {
+          user: { id: 12345, name: 'Ada Lovelace' },
+          current: { totalReplies: 42 },
+          previous: { totalReplies: 21 },
+        });
+
+      const overallResult = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getUserReport',
+          arguments: { ...reportArgs, officeHours: false },
+        },
+      });
+      const overallResponse = JSON.parse((overallResult.content[0] as { type: 'text'; text: string }).text);
+      expect(overallResult.isError).toBeUndefined();
+      expect(overallResponse.reportType).toBe('user');
+      expect(overallResponse.filters).toEqual(expect.objectContaining({
+        user: '12345',
+        officeHours: 'false',
+      }));
+      expect(overallResponse.report.current.totalReplies).toBe(42);
+
+      nock(baseURL)
+        .get('/reports/user/conversation-history')
+        .query({
+          user: reportArgs.user,
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+          officeHours: 'true',
+          status: 'closed',
+          page: 2,
+          sortField: 'responseTime',
+          sortOrder: 'ASC',
+        })
+        .reply(200, {
+          results: [{ id: 987, number: 123, responseTime: 300 }],
+          page: 2,
+          count: 3,
+          pages: 2,
+        });
+
+      const historyResult = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getUserConversationHistoryReport',
+          arguments: {
+            ...reportArgs,
+            officeHours: true,
+            status: 'closed',
+            page: 2,
+            sortField: 'responseTime',
+            sortOrder: 'asc',
+          },
+        },
+      });
+      const historyResponse = JSON.parse((historyResult.content[0] as { type: 'text'; text: string }).text);
+      expect(historyResult.isError).toBeUndefined();
+      expect(historyResponse.reportType).toBe('userConversationHistory');
+      expect(historyResponse.filters).toEqual(expect.objectContaining({
+        officeHours: 'true',
+        status: 'closed',
+        page: 2,
+        sortOrder: 'ASC',
+      }));
+      expect(historyResponse.report.results[0].responseTime).toBe(300);
+
+      for (const [toolName, path, reportType, expectedField] of [
+        ['getUserCustomersHelpedReport', '/reports/user/customers-helped', 'userCustomersHelped', 'customers'],
+        ['getUserRepliesReport', '/reports/user/replies', 'userReplies', 'replies'],
+        ['getUserResolutionsReport', '/reports/user/resolutions', 'userResolutions', 'resolved'],
+      ] as const) {
+        nock(baseURL)
+          .get(path)
+          .query({
+            user: reportArgs.user,
+            start: reportArgs.start,
+            end: reportArgs.end,
+            previousStart: reportArgs.previousStart,
+            previousEnd: reportArgs.previousEnd,
+            mailboxes: '359402',
+            tags: '123',
+            types: 'email',
+            folders: '456',
+            viewBy: 'week',
+          })
+          .reply(200, {
+            current: [{
+              date: '2024-01-01T00:00:00Z',
+              [expectedField]: 10,
+            }],
+            previous: [{
+              date: '2023-12-01T00:00:00Z',
+              [expectedField]: 20,
+            }],
+          });
+
+        const result = await toolHandler.callTool({
+          method: 'tools/call',
+          params: {
+            name: toolName,
+            arguments: {
+              ...reportArgs,
+              viewBy: 'week',
+            },
+          },
+        });
+
+        const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+        expect(result.isError).toBeUndefined();
+        expect(response.reportType).toBe(reportType);
+        expect(response.filters).toEqual(expect.objectContaining({
+          user: '12345',
+          viewBy: 'week',
+        }));
+        expect(response.report.current[0][expectedField]).toBe(10);
+      }
+
+      nock(baseURL)
+        .get('/reports/user/drilldown')
+        .query({
+          user: reportArgs.user,
+          start: reportArgs.start,
+          end: reportArgs.end,
+          mailboxes: '359402',
+          tags: '123',
+          types: 'email',
+          folders: '456',
+          page: 1,
+          rows: 50,
+        })
+        .reply(200, {
+          conversations: {
+            count: 1,
+            page: 1,
+            pages: 1,
+            results: [{ id: 987, number: 123, subject: 'Billing' }],
+          },
+        });
+
+      const drilldownResult = await toolHandler.callTool({
+        method: 'tools/call',
+        params: {
+          name: 'getUserDrilldownReport',
+          arguments: {
+            user: reportArgs.user,
+            start: reportArgs.start,
+            end: reportArgs.end,
+            mailboxes: reportArgs.mailboxes,
+            tags: reportArgs.tags,
+            types: reportArgs.types,
+            folders: reportArgs.folders,
+            page: 1,
+            rows: 50,
+          },
+        },
+      });
+      const drilldownResponse = JSON.parse((drilldownResult.content[0] as { type: 'text'; text: string }).text);
+      expect(drilldownResult.isError).toBeUndefined();
+      expect(drilldownResponse.reportType).toBe('userDrilldown');
+      expect(drilldownResponse.report.conversations.results[0].number).toBe(123);
+
+      for (const [toolName, path, reportType, responseBody] of [
+        ['getUserHappinessReport', '/reports/user/happiness', 'userHappiness', { current: { greatCount: 4 } }],
+        ['getUserRatingsReport', '/reports/user/ratings', 'userRatings', { results: [{ ratingId: 1 }], page: 1, count: 1, pages: 1 }],
+        ['getUserChatReport', '/reports/user/chat', 'userChat', { current: { newConversations: 2 } }],
+      ] as const) {
+        const query: Record<string, string | number> = {
+          user: reportArgs.user,
+          start: reportArgs.start,
+          end: reportArgs.end,
+          previousStart: reportArgs.previousStart,
+          previousEnd: reportArgs.previousEnd,
+          mailboxes: '359402',
+          tags: '123',
+        };
+        if (toolName === 'getUserHappinessReport') {
+          query.types = 'email';
+          query.folders = '456';
+        }
+        if (toolName === 'getUserRatingsReport') {
+          query.types = 'email';
+          query.folders = '456';
+          query.page = 1;
+          query.sortField = 'rating';
+          query.sortOrder = 'DESC';
+          query.rating = 'great';
+        }
+        if (toolName === 'getUserChatReport') {
+          query.officeHours = 'true';
+        }
+
+        nock(baseURL)
+          .get(path)
+          .query(query)
+          .reply(200, responseBody);
+
+        const result = await toolHandler.callTool({
+          method: 'tools/call',
+          params: {
+            name: toolName,
+            arguments: {
+              ...reportArgs,
+              ...(toolName === 'getUserRatingsReport' ? { sortField: 'rating', sortOrder: 'desc', rating: 'great' } : {}),
+              ...(toolName === 'getUserChatReport' ? { types: undefined, folders: undefined, officeHours: true } : {}),
+            },
+          },
+        });
+
+        const response = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+        expect(result.isError).toBeUndefined();
+        expect(response.reportType).toBe(reportType);
       }
     });
 

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -388,8 +388,18 @@ const ReportDateSchema = z.string().regex(
 const ReportIdListSchema = z.array(
   z.string().regex(/^\d+$/, 'Report filter IDs must be numeric')
 ).min(1).max(50);
+const ReportIdSchema = z.union([
+  z.string().regex(/^\d+$/, 'Report IDs must be numeric'),
+  z.number().int().positive(),
+]).transform(String);
 const ReportConversationTypesSchema = z.array(z.enum(['email', 'chat', 'phone'])).min(1).max(3);
 const ReportViewBySchema = z.enum(['day', 'week', 'month']);
+const ReportSortOrderSchema = z.enum(['ASC', 'DESC', 'asc', 'desc'])
+  .default('DESC')
+  .transform((value) => value.toUpperCase() as 'ASC' | 'DESC');
+const OptionalReportSortOrderSchema = z.enum(['ASC', 'DESC', 'asc', 'desc'])
+  .transform((value) => value.toUpperCase() as 'ASC' | 'DESC')
+  .optional();
 
 const ReportBaseInputObjectSchema = z.object({
   start: ReportDateSchema.describe('Start of the reporting interval, ISO 8601'),
@@ -400,6 +410,10 @@ const ReportBaseInputObjectSchema = z.object({
   tags: ReportIdListSchema.optional().describe('Tag IDs to filter by'),
   types: ReportConversationTypesSchema.optional().describe('Conversation types to filter by'),
   folders: ReportIdListSchema.optional().describe('Folder IDs to filter by'),
+});
+const ReportCurrentInputObjectSchema = ReportBaseInputObjectSchema.omit({
+  previousStart: true,
+  previousEnd: true,
 });
 
 export const ReportBaseInputSchema = ReportBaseInputObjectSchema.refine(
@@ -436,9 +450,77 @@ export const GetProductivityResponseTimeReportInputSchema = ProductivityTimeline
 export const GetHappinessRatingsReportInputSchema = ReportBaseInputObjectSchema.extend({
   page: z.number().int().min(1).default(1),
   sortField: z.enum(['number', 'modifiedAt', 'rating']).default('modifiedAt'),
-  sortOrder: z.enum(['ASC', 'DESC', 'asc', 'desc']).default('DESC')
-    .transform((value) => value.toUpperCase() as 'ASC' | 'DESC'),
+  sortOrder: ReportSortOrderSchema,
   rating: z.enum(['great', 'ok', 'all', 'not-good']).optional(),
+}).refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+const UserReportBaseInputObjectSchema = ReportBaseInputObjectSchema.extend({
+  user: ReportIdSchema.describe('User ID or team ID for the report'),
+});
+
+const UserOfficeHoursReportInputObjectSchema = UserReportBaseInputObjectSchema.extend({
+  officeHours: z.boolean().optional().describe('Whether to take office hours into consideration'),
+});
+
+export const GetUserReportInputSchema = UserOfficeHoursReportInputObjectSchema.refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const UserTimelineReportInputSchema = UserReportBaseInputObjectSchema.extend({
+  viewBy: ReportViewBySchema.default('day').describe('Report granularity: day, week, or month'),
+}).refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const GetUserCustomersHelpedReportInputSchema = UserTimelineReportInputSchema;
+export const GetUserRepliesReportInputSchema = UserTimelineReportInputSchema;
+export const GetUserResolutionsReportInputSchema = UserTimelineReportInputSchema;
+
+export const GetUserHappinessReportInputSchema = UserReportBaseInputObjectSchema.refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const GetUserRatingsReportInputSchema = UserReportBaseInputObjectSchema.extend({
+  page: z.number().int().min(1).default(1),
+  sortField: z.enum(['number', 'modifiedAt', 'rating']).optional(),
+  sortOrder: OptionalReportSortOrderSchema,
+  rating: z.enum(['great', 'ok', 'all', 'not-good']).optional(),
+}).refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const GetUserConversationHistoryReportInputSchema = UserOfficeHoursReportInputObjectSchema.extend({
+  status: z.enum(['active', 'pending', 'closed']).optional(),
+  page: z.number().int().min(1).default(1),
+  sortField: z.enum(['number', 'repliesSent', 'responseTime', 'resolveTime']).default('number'),
+  sortOrder: ReportSortOrderSchema,
+}).refine(
+  (data) => (!!data.previousStart) === (!!data.previousEnd),
+  { message: 'previousStart and previousEnd must be provided together' }
+);
+
+export const GetUserDrilldownReportInputSchema = ReportCurrentInputObjectSchema.extend({
+  user: ReportIdSchema.describe('User ID or team ID for the report'),
+  page: z.number().int().min(1).default(1),
+  rows: z.number().int().min(1).max(50).default(25),
+});
+
+export const GetUserChatReportInputSchema = z.object({
+  user: ReportIdSchema.describe('User ID or team ID for the report'),
+  start: ReportDateSchema.describe('Start of the reporting interval, ISO 8601'),
+  end: ReportDateSchema.describe('End of the reporting interval, ISO 8601'),
+  previousStart: ReportDateSchema.optional().describe('Optional start of the comparison interval'),
+  previousEnd: ReportDateSchema.optional().describe('Optional end of the comparison interval'),
+  mailboxes: ReportIdListSchema.optional().describe('Inbox IDs to filter by'),
+  tags: ReportIdListSchema.optional().describe('Tag IDs to filter by'),
+  officeHours: z.boolean().optional().describe('Whether to take office hours into consideration'),
 }).refine(
   (data) => (!!data.previousStart) === (!!data.previousEnd),
   { message: 'previousStart and previousEnd must be provided together' }
@@ -658,5 +740,7 @@ export type GetHappinessReportInput = z.infer<typeof GetHappinessReportInputSche
 export type GetHappinessRatingsReportInput = z.infer<typeof GetHappinessRatingsReportInputSchema>;
 export type GetProductivityReportInput = z.infer<typeof GetProductivityReportInputSchema>;
 export type ProductivityTimelineReportInput = z.infer<typeof ProductivityTimelineReportInputSchema>;
+export type GetUserReportInput = z.infer<typeof GetUserReportInputSchema>;
+export type UserTimelineReportInput = z.infer<typeof UserTimelineReportInputSchema>;
 export type ServerTime = z.infer<typeof ServerTimeSchema>;
 export type ApiError = z.infer<typeof ErrorSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -72,6 +72,15 @@ import {
   GetProductivityResolutionTimeReportInputSchema,
   GetProductivityResolvedReportInputSchema,
   GetProductivityResponseTimeReportInputSchema,
+  GetUserReportInputSchema,
+  GetUserConversationHistoryReportInputSchema,
+  GetUserCustomersHelpedReportInputSchema,
+  GetUserDrilldownReportInputSchema,
+  GetUserHappinessReportInputSchema,
+  GetUserRatingsReportInputSchema,
+  GetUserRepliesReportInputSchema,
+  GetUserResolutionsReportInputSchema,
+  GetUserChatReportInputSchema,
 } from '../schema/types.js';
 
 type ConversationStatus = 'active' | 'pending' | 'closed' | 'spam';
@@ -197,6 +206,34 @@ export class ToolHandler {
     const params = this.buildReportQueryParams(input);
     if (typeof input.officeHours === 'boolean') params.officeHours = String(input.officeHours);
     if (input.viewBy) params.viewBy = input.viewBy;
+    return params;
+  }
+
+  private buildUserReportQueryParams(
+    input: ReportBaseInput & {
+      user: string;
+      officeHours?: boolean;
+      viewBy?: 'day' | 'week' | 'month';
+      status?: 'active' | 'pending' | 'closed';
+      page?: number;
+      rows?: number;
+      sortField?: string;
+      sortOrder?: 'ASC' | 'DESC';
+      rating?: 'great' | 'ok' | 'all' | 'not-good';
+    }
+  ): Record<string, string | number> {
+    const params: Record<string, string | number> = {
+      ...this.buildReportQueryParams(input),
+      user: input.user,
+    };
+    if (typeof input.officeHours === 'boolean') params.officeHours = String(input.officeHours);
+    if (input.viewBy) params.viewBy = input.viewBy;
+    if (input.status) params.status = input.status;
+    if (input.page) params.page = input.page;
+    if (input.rows) params.rows = input.rows;
+    if (input.sortField) params.sortField = input.sortField;
+    if (input.sortOrder) params.sortOrder = input.sortOrder;
+    if (input.rating) params.rating = input.rating;
     return params;
   }
 
@@ -1042,6 +1079,189 @@ export class ToolHandler {
           required: ['start', 'end'],
         },
       },
+      {
+        name: 'getUserReport',
+        description: 'Get the Help Scout user or team overall report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserConversationHistoryReport',
+        description: 'Get Help Scout user conversation history rows for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            status: { type: 'string', enum: ['active', 'pending', 'closed'], description: 'Conversation status filter' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            sortField: { type: 'string', enum: ['number', 'repliesSent', 'responseTime', 'resolveTime'], default: 'number' },
+            sortOrder: { type: 'string', enum: ['ASC', 'DESC', 'asc', 'desc'], default: 'DESC' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserCustomersHelpedReport',
+        description: 'Get Help Scout user customers helped time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserDrilldownReport',
+        description: 'Get Help Scout user report drilldown conversations for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            rows: { type: 'number', minimum: 1, maximum: 50, default: 25, description: 'Rows per page' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserHappinessReport',
+        description: 'Get Help Scout user happiness report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserRatingsReport',
+        description: 'Get Help Scout user happiness rating rows for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            page: { type: 'number', minimum: 1, default: 1, description: 'Page number' },
+            sortField: { type: 'string', enum: ['number', 'modifiedAt', 'rating'] },
+            sortOrder: { type: 'string', enum: ['ASC', 'DESC', 'asc', 'desc'] },
+            rating: { type: 'string', enum: ['great', 'ok', 'all', 'not-good'], description: 'Rating filter' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserRepliesReport',
+        description: 'Get Help Scout user replies time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserResolutionsReport',
+        description: 'Get Help Scout user resolutions time series for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            types: { type: 'array', items: { type: 'string', enum: ['email', 'chat', 'phone'] }, description: 'Conversation types to filter by' },
+            folders: { type: 'array', items: { type: 'string' }, description: 'Folder IDs to filter by' },
+            viewBy: { type: 'string', enum: ['day', 'week', 'month'], default: 'day', description: 'Report granularity' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
+      {
+        name: 'getUserChatReport',
+        description: 'Get Help Scout user or team chat report for a bounded time range.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: { type: 'string', description: 'User ID or team ID for the report' },
+            start: { type: 'string', description: 'Start of the reporting interval, ISO 8601' },
+            end: { type: 'string', description: 'End of the reporting interval, ISO 8601' },
+            previousStart: { type: 'string', description: 'Optional comparison interval start, ISO 8601' },
+            previousEnd: { type: 'string', description: 'Optional comparison interval end, ISO 8601' },
+            mailboxes: { type: 'array', items: { type: 'string' }, description: 'Inbox IDs to filter by' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tag IDs to filter by' },
+            officeHours: { type: 'boolean', description: 'Whether to take office hours into consideration' },
+          },
+          required: ['user', 'start', 'end'],
+        },
+      },
     ];
   }
 
@@ -1240,6 +1460,33 @@ export class ToolHandler {
           break;
         case 'getProductivityResponseTimeReport':
           result = await this.getProductivityResponseTimeReport(request.params.arguments || {});
+          break;
+        case 'getUserReport':
+          result = await this.getUserReport(request.params.arguments || {});
+          break;
+        case 'getUserConversationHistoryReport':
+          result = await this.getUserConversationHistoryReport(request.params.arguments || {});
+          break;
+        case 'getUserCustomersHelpedReport':
+          result = await this.getUserCustomersHelpedReport(request.params.arguments || {});
+          break;
+        case 'getUserDrilldownReport':
+          result = await this.getUserDrilldownReport(request.params.arguments || {});
+          break;
+        case 'getUserHappinessReport':
+          result = await this.getUserHappinessReport(request.params.arguments || {});
+          break;
+        case 'getUserRatingsReport':
+          result = await this.getUserRatingsReport(request.params.arguments || {});
+          break;
+        case 'getUserRepliesReport':
+          result = await this.getUserRepliesReport(request.params.arguments || {});
+          break;
+        case 'getUserResolutionsReport':
+          result = await this.getUserResolutionsReport(request.params.arguments || {});
+          break;
+        case 'getUserChatReport':
+          result = await this.getUserChatReport(request.params.arguments || {});
           break;
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
@@ -2139,6 +2386,78 @@ export class ToolHandler {
     const report = await helpScoutClient.get<ReportResponse>('/reports/productivity/response-time', params);
 
     return this.formatReportResult('productivityResponseTime', params, report);
+  }
+
+  private async getUserReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user', params);
+
+    return this.formatReportResult('user', params, report);
+  }
+
+  private async getUserConversationHistoryReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserConversationHistoryReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/conversation-history', params);
+
+    return this.formatReportResult('userConversationHistory', params, report);
+  }
+
+  private async getUserCustomersHelpedReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserCustomersHelpedReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/customers-helped', params);
+
+    return this.formatReportResult('userCustomersHelped', params, report);
+  }
+
+  private async getUserDrilldownReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserDrilldownReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/drilldown', params);
+
+    return this.formatReportResult('userDrilldown', params, report);
+  }
+
+  private async getUserHappinessReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserHappinessReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/happiness', params);
+
+    return this.formatReportResult('userHappiness', params, report);
+  }
+
+  private async getUserRatingsReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserRatingsReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/ratings', params);
+
+    return this.formatReportResult('userRatings', params, report);
+  }
+
+  private async getUserRepliesReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserRepliesReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/replies', params);
+
+    return this.formatReportResult('userReplies', params, report);
+  }
+
+  private async getUserResolutionsReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserResolutionsReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/resolutions', params);
+
+    return this.formatReportResult('userResolutions', params, report);
+  }
+
+  private async getUserChatReport(args: unknown): Promise<CallToolResult> {
+    const input = GetUserChatReportInputSchema.parse(args);
+    const params = this.buildUserReportQueryParams(input);
+    const report = await helpScoutClient.get<ReportResponse>('/reports/user/chat', params);
+
+    return this.formatReportResult('userChat', params, report);
   }
 
   private formatReportResult(

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -96,6 +96,15 @@ const EXPECTED_TOOLS = [
   'getProductivityResolutionTimeReport',
   'getProductivityResolvedReport',
   'getProductivityResponseTimeReport',
+  'getUserReport',
+  'getUserConversationHistoryReport',
+  'getUserCustomersHelpedReport',
+  'getUserDrilldownReport',
+  'getUserHappinessReport',
+  'getUserRatingsReport',
+  'getUserRepliesReport',
+  'getUserResolutionsReport',
+  'getUserChatReport',
 ] as const;
 
 type ToolName = typeof EXPECTED_TOOLS[number];
@@ -706,6 +715,106 @@ function buildScenarios(): Scenario[] {
         const report = getObject(data, 'report');
         requireCondition(report, 'Missing response time report');
         requireArray(report, ['current'], 'response time points');
+      },
+    },
+    {
+      tool: 'getUserReport',
+      name: 'user overall report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user report');
+        requireCondition(getObject(report, 'current'), 'Missing current user report data');
+      },
+    },
+    {
+      tool: 'getUserConversationHistoryReport',
+      name: 'user conversation history rows',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false, page: 1 }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user conversation history report');
+        requireArray(report, ['results'], 'user conversation history rows');
+      },
+    },
+    {
+      tool: 'getUserCustomersHelpedReport',
+      name: 'user customers helped series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user customers helped report');
+        requireArray(report, ['current'], 'customers helped points');
+      },
+    },
+    {
+      tool: 'getUserDrilldownReport',
+      name: 'user drilldown conversations',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], page: 1, rows: 10 }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        const conversations = getObject(report, 'conversations');
+        requireCondition(conversations, 'Missing user drilldown conversations');
+        requireArray(conversations, ['results'], 'user drilldown rows');
+      },
+    },
+    {
+      tool: 'getUserHappinessReport',
+      name: 'user happiness report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId] }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user happiness report');
+        requireCondition(getObject(report, 'current'), 'Missing current user happiness report data');
+      },
+    },
+    {
+      tool: 'getUserRatingsReport',
+      name: 'user happiness rating rows',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], page: 1, rating: 'all' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user ratings report');
+        requireArray(report, ['results'], 'user rating rows');
+      },
+    },
+    {
+      tool: 'getUserRepliesReport',
+      name: 'user replies series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user replies report');
+        requireArray(report, ['current'], 'user reply points');
+      },
+    },
+    {
+      tool: 'getUserResolutionsReport',
+      name: 'user resolutions series',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], viewBy: 'day' }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user resolutions report');
+        requireArray(report, ['current'], 'user resolution points');
+      },
+    },
+    {
+      tool: 'getUserChatReport',
+      name: 'user chat report',
+      skipIf: (ctx) => ctx.skipReports ? 'Reporting scenarios disabled by MCP_DOGFOOD_SKIP_REPORTS' : undefined,
+      args: (ctx) => ({ user: ctx.userId ?? '0', start: ctx.reportStart, end: ctx.reportEnd, mailboxes: [ctx.inboxId], officeHours: false }),
+      validate: (data) => {
+        const report = getObject(data, 'report');
+        requireCondition(report, 'Missing user chat report');
+        requireCondition(getObject(report, 'current'), 'Missing current user chat report data');
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add direct Help Scout user/team reporting tools for overall, conversation history, customers helped, drilldown, happiness, ratings, replies, resolutions, and chat endpoints.
- Serialize documented user report filters including user/team id, bounded dates, view granularity, pagination, sorting, ratings, status, and office-hours controls.
- Update MCP/MCPB inventories, dogfood coverage, and API-parity testing guidance, including a shared seed command for the dogfood account.

## Testing
- npm run dogfood:seed
- npm run type-check
- npm test -- src/__tests__/tools.test.ts --runInBand --testNamePattern "user report"
- npm run dogfood:mcp
- npm test -- --runInBand --silent
- npm run lint
- npm run build
- npm run mcpb:build
- npm run security (completed; existing repository-wide findings remain)
- semgrep --config .semgrep.yml src/tools/index.ts src/schema/types.ts src/__tests__/tools.test.ts src/__tests__/mcpb-validation.test.ts tests/mcp-client-dogfood.ts package.json guides/architecture/mcp-vs-cli.md guides/roadmap/mcp-tool-surface.md --json --quiet (completed; touched-file findings are existing baseline patterns)
- git diff --check

Refs NAS-719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->