### PR TITLE
test(NAS-719): audit live dogfood fixture gaps

### DIFF
--- a/guides/testing/dogfood-fixture-matrix.md
+++ b/guides/testing/dogfood-fixture-matrix.md
@@ -11,6 +11,12 @@ Run shared fixture setup before authenticated dogfood:
 npm run dogfood:seed
 ```
 
+Audit live account-only fixtures that cannot be created by the seed scripts:
+
+```bash
+npm run dogfood:audit
+```
+
 ## Fixture Rules
 
 - Every new API-surface PR must add or reuse deterministic seed data for the
@@ -43,7 +49,8 @@ npm run dogfood:seed
 | --- | --- | --- |
 | `tests/seed-test-data.ts` | Golden customer, organization, customer contacts, address, customer property value, deterministic organization property definition/value, saved reply, and webhook. | customer profile, organization profile, contact retrieval, customer and organization property visibility, saved reply retrieval, webhook retrieval |
 | `tests/seed-org-customers.ts` | Fifteen organization members under Meridian Testing Corp. | organization member pagination |
-| `tests/seed-integration-data.ts` | `MCP-TEST:` conversations in active, pending, and closed states with customer and staff threads plus tags; report-rich closed fixtures are assigned to the test user; one fixture attempts attachment upload for accounts where Help Scout exposes the uploaded attachment in thread responses. | conversation search, status filters, tag filters, thread retrieval, workflow-style integration dogfood, user report row assertions, attachment retrieval when an uploaded attachment ID is discoverable |
+| `tests/seed-integration-data.ts` | `MCP-TEST:` conversations in active, pending, and closed states with customer and staff threads plus tags; report-rich closed fixtures are assigned to the test user; one fixture includes an attachment-bearing thread. | conversation search, status filters, tag filters, thread retrieval, workflow-style integration dogfood, user report row assertions, attachment retrieval |
+| `tests/audit-dogfood-account.ts` | Read-only audit of team membership, satisfaction rating, original-source, and attachment fixture readiness. | names account-only fixture gaps before dogfood runs |
 
 ## Capability Coverage
 
@@ -51,8 +58,8 @@ npm run dogfood:seed
 | --- | --- | --- | --- | --- |
 | Inbox discovery | `searchInboxes`, `listAllInboxes` | Uses configured Client Support inbox and live account inbox list. | Discovery, narrowing, invalid limit validation. | None known. |
 | Conversation search | `searchConversations`, `advancedConversationSearch`, `comprehensiveConversationSearch`, `structuredConversationFilter` | `MCP-TEST:` conversations cover active, pending, closed, tags, customers, dates, and subjects. | Discovery, narrowing, pagination, permutation, validation. | Add a deterministic spam conversation only if Help Scout supports safe seed/cleanup for spam state. |
-| Conversation retrieval | `getConversationSummary`, `getThreads` | Seeded conversations include customer and staff threads, and one conversation fixture requests attachment upload. | Retrieval, pagination, redaction, invalid ID validation, attachment discovery when Help Scout exposes uploaded attachments under thread `_embedded.attachments`. | Add a known original-source thread. |
-| Thread original source and attachments | `getOriginalSource`, `getAttachment` | Harness can use `MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID`, `MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID`, `MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID`, and `MCP_DOGFOOD_ATTACHMENT_ID`; attachment IDs are also discovered from `getThreads` when present. | Retrieval when fixture IDs are provided or attachment IDs are discoverable. | Original source still requires known email-source fixture IDs. Attachment upload returns no ID, so accounts that do not expose uploaded attachments in thread responses still need explicit attachment fixture IDs. |
+| Conversation retrieval | `getConversationSummary`, `getThreads` | Seeded conversations include customer and staff threads, and one conversation fixture includes an attachment-bearing thread. | Retrieval, pagination, redaction, invalid ID validation, attachment discovery under thread `_embedded.attachments`. | Add a known original-source thread. |
+| Thread original source and attachments | `getOriginalSource`, `getAttachment` | Harness can use `MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID`, `MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID`, `MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID`, and `MCP_DOGFOOD_ATTACHMENT_ID`; attachment IDs are discovered from the seeded attachment fixture conversation. | Retrieval when fixture IDs are provided; attachment retrieval through seeded live fixture discovery. | Original source still requires known email-source fixture IDs. |
 | Customer context | `getCustomer`, `listCustomers`, `searchCustomersByEmail`, `getCustomerContacts` | Golden customer and Meridian org members cover profile, email, name, mailbox, modified date, pagination, contacts, and invalid IDs. | Discovery, retrieval, narrowing, pagination, permutation, validation. | Add a customer with multiple values per contact type if future tools expose contact editing or richer contact filtering. |
 | Organization context | `getOrganization`, `listOrganizations`, `getOrganizationMembers`, `getOrganizationConversations` | Golden organization, fifteen org members, and seeded conversations cover include flags, sort fields, pagination, members, and conversations. | Retrieval, narrowing, pagination, permutation, validation. | Add organization property-heavy fixtures if property output schemas become stricter. |
 | Property metadata | `listCustomerProperties`, `listOrganizationProperties`, `getOrganizationProperty` | Customer property and deterministic organization property are seeded. | Discovery and retrieval. | None known. |
@@ -72,7 +79,6 @@ npm run dogfood:seed
 | Skip source | Current reason | Preferred fix |
 | --- | --- | --- |
 | `getOriginalSource` | No known original-source fixture IDs. | Add original-source conversation/thread discovery to seed output or environment setup. |
-| `getAttachment` | Attachment upload succeeds but may not expose an attachment ID in thread responses. | Keep seeded upload coverage and set `MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID` / `MCP_DOGFOOD_ATTACHMENT_ID` when the account has a discoverable attachment fixture. |
 | `getSatisfactionRating` | No known satisfaction rating fixture ID. | Seed or configure a known rating and expose `MCP_DOGFOOD_SATISFACTION_RATING_ID`. |
 | `getTeamMembers` | No team may exist in the test account. | Configure or seed a team with at least one member. |
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dogfood:mcp": "npm run build && node --loader ts-node/esm tests/mcp-client-dogfood.ts",
     "dogfood:workflows": "npm run build && node --loader ts-node/esm tests/integration-workflows.ts",
     "dogfood:full": "npm run dogfood:mcp && npm run dogfood:workflows",
+    "dogfood:audit": "node --loader ts-node/esm tests/audit-dogfood-account.ts",
     "test:forensic": "node --loader ts-node/esm tests/test-all-tools-edge-cases.ts",
     "test:docker": "node tests/test-docker.cjs",
     "test:docker:ci": "node tests/test-docker-ci.cjs",

--- a/src/__tests__/dogfood-fixtures.test.ts
+++ b/src/__tests__/dogfood-fixtures.test.ts
@@ -25,11 +25,13 @@ describe('dogfood seed fixtures', () => {
     expect(INTEGRATION_ACCOUNT_FIXTURES.webhook.mailboxIds).toEqual([Number(INTEGRATION_CONSTANTS.inboxId)]);
   });
 
-  it('defines a conversation fixture with an uploadable attachment', () => {
-    const attachmentFixtures = INTEGRATION_SEED_CONVERSATIONS.filter((conversation) => conversation.attachment);
+  it('defines a thread fixture with an uploadable attachment', () => {
+    const attachmentFixtures = INTEGRATION_SEED_CONVERSATIONS.flatMap((conversation) =>
+      conversation.threads.flatMap((thread) => thread.attachments || [])
+    );
 
     expect(attachmentFixtures.length).toBeGreaterThanOrEqual(1);
-    expect(attachmentFixtures[0].attachment).toEqual(expect.objectContaining({
+    expect(attachmentFixtures[0]).toEqual(expect.objectContaining({
       fileName: expect.stringMatching(/^mcp-test-/),
       mimeType: 'text/plain',
       data: expect.any(String),

--- a/src/__tests__/package-scripts.test.ts
+++ b/src/__tests__/package-scripts.test.ts
@@ -4,6 +4,13 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 
 describe('package scripts', () => {
+  it('exposes a dogfood account audit command', () => {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+
+    expect(packageJson.scripts['dogfood:audit']).toBe('node --loader ts-node/esm tests/audit-dogfood-account.ts');
+    expect(fs.existsSync(path.join(process.cwd(), 'tests/audit-dogfood-account.ts'))).toBe(true);
+  });
+
   it('keeps operational scripts aligned with documented Help Scout credential names', () => {
     const credentialScripts = [
       'scripts/check-conversations.ts',

--- a/tests/audit-dogfood-account.ts
+++ b/tests/audit-dogfood-account.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env -S node --loader ts-node/esm
+/**
+ * Read-only audit for live Help Scout dogfood fixture readiness.
+ *
+ * This does not mutate the account. It identifies account-level gaps that the
+ * seed scripts cannot create through documented Help Scout API endpoints.
+ */
+
+import 'dotenv/config';
+import axios, { AxiosInstance } from 'axios';
+import { INTEGRATION_CONSTANTS } from './dogfood-fixtures.js';
+
+const CLIENT_ID =
+  process.env.HELPSCOUT_APP_ID ||
+  process.env.HELPSCOUT_CLIENT_ID ||
+  process.env.HELPSCOUT_API_KEY ||
+  '';
+const CLIENT_SECRET =
+  process.env.HELPSCOUT_APP_SECRET ||
+  process.env.HELPSCOUT_CLIENT_SECRET ||
+  '';
+const BASE_URL = process.env.HELPSCOUT_BASE_URL || 'https://api.helpscout.net/v2/';
+
+interface AuditResult {
+  name: string;
+  status: 'PASS' | 'GAP';
+  detail: string;
+}
+
+let accessToken: string | null = null;
+
+async function authenticate(): Promise<string> {
+  if (accessToken) return accessToken;
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error('Missing Help Scout credentials.');
+  }
+
+  try {
+    const res = await axios.post('https://api.helpscout.net/v2/oauth2/token', {
+      grant_type: 'client_credentials',
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+    accessToken = res.data.access_token;
+    return accessToken!;
+  } catch (err) {
+    throw new Error(`Help Scout authentication failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function api(): Promise<AxiosInstance> {
+  try {
+    const token = await authenticate();
+    return axios.create({
+      baseURL: BASE_URL,
+      timeout: 30000,
+      headers: { Authorization: `Bearer ${token}` },
+      validateStatus: () => true,
+    });
+  } catch {
+    throw new Error('Unable to create Help Scout API client.');
+  }
+}
+
+function daysAgoIso(days: number): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - days);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+async function auditTeams(client: AxiosInstance): Promise<AuditResult> {
+  try {
+    const res = await client.get('/teams', { params: { page: 1 } });
+    const teams = res.status === 200 ? (res.data?._embedded?.teams || []) : [];
+    if (teams.length > 0) {
+      return { name: 'getTeamMembers', status: 'PASS', detail: `teamId=${teams[0].id}` };
+    }
+
+    return {
+      name: 'getTeamMembers',
+      status: 'GAP',
+      detail: 'No teams returned by GET /teams; create a Help Scout Team with at least one member in account settings.',
+    };
+  } catch (err) {
+    return { name: 'getTeamMembers', status: 'GAP', detail: `Team audit failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+async function auditSatisfactionRating(client: AxiosInstance): Promise<AuditResult> {
+  try {
+    const envId = process.env.MCP_DOGFOOD_SATISFACTION_RATING_ID;
+    if (envId) {
+      const res = await client.get(`/ratings/${envId}`);
+      if (res.status === 200) {
+        return { name: 'getSatisfactionRating', status: 'PASS', detail: `ratingId=${envId}` };
+      }
+    }
+
+    const res = await client.get('/reports/happiness/ratings', {
+      params: {
+        start: daysAgoIso(30),
+        end: daysAgoIso(0),
+        mailboxes: INTEGRATION_CONSTANTS.inboxId,
+        page: 1,
+        sortField: 'modifiedAt',
+        sortOrder: 'DESC',
+        rating: 'all',
+      },
+    });
+    const ratings = res.status === 200 ? (res.data?._embedded?.results || res.data?.results || []) : [];
+    const rating = ratings.find((item: any) => item.id);
+    if (rating?.id) {
+      return { name: 'getSatisfactionRating', status: 'PASS', detail: `ratingId=${rating.id}` };
+    }
+
+    return {
+      name: 'getSatisfactionRating',
+      status: 'GAP',
+      detail: 'No rating row found in the 30-day happiness ratings report; submit a customer satisfaction rating and set MCP_DOGFOOD_SATISFACTION_RATING_ID if needed.',
+    };
+  } catch (err) {
+    return { name: 'getSatisfactionRating', status: 'GAP', detail: `Satisfaction rating audit failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+async function listSeededConversations(client: AxiosInstance): Promise<Array<{ id: number; subject?: string }>> {
+  try {
+    const res = await client.get('/conversations', {
+      params: {
+        query: '(subject:"MCP-TEST:")',
+        mailbox: INTEGRATION_CONSTANTS.inboxId,
+        status: 'all',
+        page: 1,
+      },
+    });
+    return res.status === 200 ? (res.data?._embedded?.conversations || []) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function auditOriginalSource(client: AxiosInstance, conversations: Array<{ id: number }>): Promise<AuditResult> {
+  try {
+    const envConversationId = process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID;
+    const envThreadId = process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID;
+    if (envConversationId && envThreadId) {
+      const res = await client.get(`/conversations/${envConversationId}/threads/${envThreadId}/original-source`);
+      if (res.status === 200) {
+        return { name: 'getOriginalSource', status: 'PASS', detail: `conversationId=${envConversationId} threadId=${envThreadId}` };
+      }
+    }
+
+    for (const conversation of conversations.slice(0, 25)) {
+      const threadsRes = await client.get(`/conversations/${conversation.id}/threads`, { params: { page: 1, size: 25 } });
+      const threads = threadsRes.status === 200 ? (threadsRes.data?._embedded?.threads || []) : [];
+      for (const thread of threads) {
+        if (!thread.id) continue;
+        const sourceRes = await client.get(`/conversations/${conversation.id}/threads/${thread.id}/original-source`);
+        if (sourceRes.status === 200) {
+          return { name: 'getOriginalSource', status: 'PASS', detail: `conversationId=${conversation.id} threadId=${thread.id}` };
+        }
+      }
+    }
+
+    return {
+      name: 'getOriginalSource',
+      status: 'GAP',
+      detail: 'No seeded MCP-TEST thread exposes original email source; create or import an inbound email fixture and set MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID plus MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID.',
+    };
+  } catch (err) {
+    return { name: 'getOriginalSource', status: 'GAP', detail: `Original-source audit failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+async function auditAttachment(client: AxiosInstance, conversations: Array<{ id: number }>): Promise<AuditResult> {
+  try {
+    for (const conversation of conversations) {
+      const threadsRes = await client.get(`/conversations/${conversation.id}/threads`, { params: { page: 1, size: 25 } });
+      const threads = threadsRes.status === 200 ? (threadsRes.data?._embedded?.threads || []) : [];
+      for (const thread of threads) {
+        const attachments = [
+          ...(thread.attachments || []),
+          ...(thread._embedded?.attachments || []),
+        ];
+        const attachment = attachments.find((item: any) => item.id);
+        if (!attachment?.id) continue;
+
+        const dataRes = await client.get(`/conversations/${conversation.id}/attachments/${attachment.id}/data`);
+        if (dataRes.status === 200) {
+          return { name: 'getAttachment', status: 'PASS', detail: `conversationId=${conversation.id} attachmentId=${attachment.id}` };
+        }
+      }
+    }
+
+    return {
+      name: 'getAttachment',
+      status: 'GAP',
+      detail: 'No seeded MCP-TEST attachment with readable data was found; run npm run dogfood:seed and check the attachment fixture conversation.',
+    };
+  } catch (err) {
+    return { name: 'getAttachment', status: 'GAP', detail: `Attachment audit failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+async function main(): Promise<void> {
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    process.stdout.write('SKIP: Missing live Help Scout credentials for dogfood account audit.\n');
+    return;
+  }
+
+  let results: AuditResult[];
+  try {
+    const client = await api();
+    const conversations = await listSeededConversations(client);
+    results = [
+      await auditTeams(client),
+      await auditSatisfactionRating(client),
+      await auditOriginalSource(client, conversations),
+      await auditAttachment(client, conversations),
+    ];
+  } catch {
+    process.stderr.write('Fatal dogfood account audit failure.\n');
+    process.exit(1);
+  }
+
+  for (const result of results) {
+    process.stdout.write(`${result.status}: ${result.name} - ${result.detail}\n`);
+  }
+
+  const gaps = results.filter((result) => result.status === 'GAP');
+  if (gaps.length > 0) {
+    process.stdout.write(`\n${gaps.length} dogfood account fixture gap(s) remain.\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal dogfood account audit failure: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/tests/dogfood-fixtures.ts
+++ b/tests/dogfood-fixtures.ts
@@ -1,6 +1,11 @@
 export interface ThreadDef {
   type: 'customer' | 'reply' | 'customer-follow-up';
   text: string;
+  attachments?: Array<{
+    fileName: string;
+    mimeType: string;
+    data: string;
+  }>;
 }
 
 export interface ConversationDef {
@@ -14,11 +19,6 @@ export interface ConversationDef {
   reportFixture?: boolean;
   createdAtDaysAgo?: number;
   closedAtDaysAgo?: number;
-  attachment?: {
-    fileName: string;
-    mimeType: string;
-    data: string;
-  };
 }
 
 export const INTEGRATION_CONSTANTS = {
@@ -135,11 +135,6 @@ export const INTEGRATION_SEED_CONVERSATIONS: ConversationDef[] = [
     tags: ['mcp-test'],
     status: 'active',
     createdAtDaysAgo: 2,
-    attachment: {
-      fileName: 'mcp-test-export-diagnostics.txt',
-      mimeType: 'text/plain',
-      data: Buffer.from('MCP dogfood attachment fixture for getAttachment coverage.\n', 'utf8').toString('base64'),
-    },
     threads: [
       {
         type: 'customer',
@@ -152,6 +147,15 @@ export const INTEGRATION_SEED_CONVERSATIONS: ConversationDef[] = [
       {
         type: 'customer-follow-up',
         text: "Thanks for the workaround. Quick follow-up: we're also seeing the same timeout when exporting from the analytics dashboard, even with smaller datasets around 5,000 rows. Might be related?",
+      },
+      {
+        type: 'reply',
+        text: 'I attached a small diagnostics note so the attachment retrieval path can be verified against this test conversation.',
+        attachments: [{
+          fileName: 'mcp-test-export-diagnostics.txt',
+          mimeType: 'text/plain',
+          data: Buffer.from('MCP dogfood attachment fixture for getAttachment coverage.\n', 'utf8').toString('base64'),
+        }],
       },
     ],
   },

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -40,6 +40,7 @@ const GOLDEN = {
   inboxName: process.env.MCP_DOGFOOD_INBOX_NAME ?? 'Client Support',
   tag: process.env.MCP_DOGFOOD_TAG ?? 'mcp-test',
   searchTerm: process.env.MCP_DOGFOOD_SEARCH_TERM ?? 'test',
+  attachmentSubject: process.env.MCP_DOGFOOD_ATTACHMENT_SUBJECT ?? 'MCP-TEST: Data export CSV failure',
   originalSourceConversationId: process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID,
   originalSourceThreadId: process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID,
   attachmentConversationId: process.env.MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID,
@@ -889,9 +890,16 @@ function buildScenarios(): Scenario[] {
     {
       tool: 'searchConversations',
       name: 'tag filter',
-      args: (ctx) => ({ inboxId: ctx.inboxId, tag: GOLDEN.tag, limit: 5 }),
+      args: (ctx) => ({ inboxId: ctx.inboxId, tag: GOLDEN.tag, limit: 10 }),
       validate: (data) => {
         requireArray(data, ['results', 'conversations'], 'conversations');
+      },
+      after: (data, _result, ctx) => {
+        const conversations = getArray(data, ['results', 'conversations']) as JsonObject[];
+        const fixture = conversations.find((conversation) =>
+          getString(conversation.subject) === GOLDEN.attachmentSubject
+        );
+        if (fixture?.id) ctx.attachmentConversationId = String(fixture.id);
       },
     },
     {
@@ -1141,6 +1149,28 @@ function buildScenarios(): Scenario[] {
       expectError: true,
       validate: (data) => {
         requireCondition(data !== undefined, 'Expected validation response');
+      },
+    },
+    {
+      tool: 'getThreads',
+      name: 'attachment fixture threads',
+      skipIf: (ctx) => ctx.attachmentConversationId
+        ? undefined
+        : 'No attachment fixture conversation available',
+      args: (ctx) => ({ conversationId: ctx.attachmentConversationId ?? '1', limit: 10 }),
+      validate: (data) => {
+        requireArray(data, ['threads'], 'threads');
+      },
+      after: (data, _result, ctx) => {
+        if (ctx.attachmentId) return;
+        const threads = getArray(data, ['threads']) as JsonObject[];
+        for (const thread of threads) {
+          const attachment = getThreadAttachments(thread).find((item) => item.id);
+          if (attachment?.id) {
+            ctx.attachmentId = String(attachment.id);
+            break;
+          }
+        }
       },
     },
     {

--- a/tests/seed-integration-data.ts
+++ b/tests/seed-integration-data.ts
@@ -197,14 +197,20 @@ async function createConversation(def: ConversationDef): Promise<number> {
   );
 }
 
-async function addReplyThread(conversationId: number, text: string, finalStatus: string, customerEmail: string): Promise<boolean> {
+async function addReplyThread(
+  conversationId: number,
+  thread: { text: string; attachments?: ConversationDef['threads'][number]['attachments'] },
+  finalStatus: string,
+  customerEmail: string
+): Promise<boolean> {
   const client = await api();
   const res = await client.post(`/conversations/${conversationId}/reply`, {
-    text,
+    text: thread.text,
     user: INTEGRATION_CONSTANTS.userId,
     customer: { email: customerEmail },
     status: finalStatus,
     imported: true,
+    ...(thread.attachments?.length ? { attachments: thread.attachments } : {}),
   });
 
   if (res.status !== 201 && res.status !== 200) {
@@ -250,7 +256,7 @@ async function seedConversation(def: ConversationDef): Promise<number> {
       // Use the conversation's final status for the last reply; keep active for intermediate ones
       const isLast = i === def.threads.length - 1;
       const threadStatus = isLast ? def.status : 'active';
-      if (await addReplyThread(convId, thread.text, threadStatus, def.customerEmail)) {
+      if (await addReplyThread(convId, thread, threadStatus, def.customerEmail)) {
         log(`  Added staff reply (thread ${i + 1})`);
       }
     } else if (thread.type === 'customer-follow-up') {
@@ -259,8 +265,6 @@ async function seedConversation(def: ConversationDef): Promise<number> {
       }
     }
   }
-
-  await ensureAttachment({ id: convId, subject: def.subject, status: def.status, assigneeId: def.assigneeId }, def);
 
   return convId;
 }
@@ -309,7 +313,7 @@ async function backfillMissingThreads(existing: ExistingConversation, def: Conve
     if (thread.type === 'reply') {
       const isLast = i === def.threads.length - 1;
       const threadStatus = isLast ? def.status : 'active';
-      if (await addReplyThread(existing.id, thread.text, threadStatus, def.customerEmail)) {
+      if (await addReplyThread(existing.id, thread, threadStatus, def.customerEmail)) {
         log(`  Backfilled staff reply on conversation ${existing.id}`);
       }
     } else if (thread.type === 'customer-follow-up') {
@@ -320,6 +324,10 @@ async function backfillMissingThreads(existing: ExistingConversation, def: Conve
   }
 }
 
+function threadAttachmentFixtures(def: ConversationDef): NonNullable<ConversationDef['threads'][number]['attachments']> {
+  return def.threads.flatMap((thread) => thread.attachments || []);
+}
+
 function attachmentExists(threads: ExistingThread[], fileName: string): boolean {
   return threads.some((thread) =>
     [...(thread.attachments || []), ...(thread._embedded?.attachments || [])].some((attachment) =>
@@ -328,32 +336,25 @@ function attachmentExists(threads: ExistingThread[], fileName: string): boolean 
   );
 }
 
-async function uploadAttachment(conversationId: number, threadId: number, def: ConversationDef): Promise<void> {
-  if (!def.attachment) return;
-  const client = await api();
-  const res = await client.post(`/conversations/${conversationId}/threads/${threadId}/attachments`, def.attachment);
-
-  if (res.status === 201 || res.status === 200) {
-    log(`  Uploaded attachment "${def.attachment.fileName}" on conversation ${conversationId}`);
-    return;
-  }
-
-  log(`  Warning: attachment upload on conversation ${conversationId} returned ${res.status}: ${JSON.stringify(res.data)}`);
-}
-
 async function ensureAttachment(existing: ExistingConversation, def: ConversationDef): Promise<void> {
-  if (!def.attachment) return;
+  const attachmentFixtures = threadAttachmentFixtures(def);
+  if (attachmentFixtures.length === 0) return;
 
   const threads = await getThreads(existing.id);
-  if (attachmentExists(threads, def.attachment.fileName)) return;
+  const missingAttachment = attachmentFixtures.find((attachment) => !attachmentExists(threads, attachment.fileName));
+  if (!missingAttachment) return;
 
-  const targetThread = threads.find((thread) => thread.id);
-  if (!targetThread?.id) {
-    log(`  Warning: no thread ID available for attachment upload on conversation ${existing.id}`);
+  const attachmentThread = def.threads.find((thread) =>
+    (thread.attachments || []).some((attachment) => attachment.fileName === missingAttachment.fileName)
+  );
+  if (!attachmentThread || attachmentThread.type !== 'reply') {
+    log(`  Warning: no reply thread fixture available for attachment "${missingAttachment.fileName}"`);
     return;
   }
 
-  await uploadAttachment(existing.id, targetThread.id, def);
+  if (await addReplyThread(existing.id, attachmentThread, def.status, def.customerEmail)) {
+    log(`  Backfilled attachment thread "${missingAttachment.fileName}" on conversation ${existing.id}`);
+  }
 }
 
 async function ensureExistingConversationFixtures(existing: ExistingConversation[]): Promise<void> {


### PR DESCRIPTION
## Summary
- Move the attachment dogfood fixture onto a thread-level reply and let the MCP dogfood matrix discover it from seeded conversations.
- Add a read-only dogfood account audit command for live fixtures that cannot be created by the seed scripts.
- Update the dogfood fixture matrix to show attachment coverage and the remaining account-owned gaps.

## Testing
- npm run type-check
- npm run lint
- npm test -- --runInBand --silent
- npm run build
- npm run test:contract
- npm run dogfood:seed
- npm run dogfood:workflows
- npm run dogfood:mcp
- semgrep --config .semgrep.yml tests/audit-dogfood-account.ts
- npm run security exits 0; repository-wide scan still reports the existing baseline findings.
- npm run dogfood:audit intentionally exits 1 while live account-only fixtures remain: no Help Scout team, no satisfaction rating ID, and no original-source email fixture. Attachment audit passes.

Closes NAS-719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->