### PR TITLE
test(NAS-719): improve live dogfood fixture discovery

### DIFF
--- a/guides/testing/dogfood-fixture-matrix.md
+++ b/guides/testing/dogfood-fixture-matrix.md
@@ -11,7 +11,9 @@ Run shared fixture setup before authenticated dogfood:
 npm run dogfood:seed
 ```
 
-Audit live account-only fixtures that cannot be created by the seed scripts:
+Audit live account-only fixtures that cannot be created by the seed scripts.
+When it verifies a fixture, the audit prints the matching `MCP_DOGFOOD_*`
+environment value so CI or local dogfood can pin the same record:
 
 ```bash
 npm run dogfood:audit
@@ -50,7 +52,7 @@ npm run dogfood:audit
 | `tests/seed-test-data.ts` | Golden customer, organization, customer contacts, address, customer property value, deterministic organization property definition/value, saved reply, and webhook. | customer profile, organization profile, contact retrieval, customer and organization property visibility, saved reply retrieval, webhook retrieval |
 | `tests/seed-org-customers.ts` | Fifteen organization members under Meridian Testing Corp. | organization member pagination |
 | `tests/seed-integration-data.ts` | `MCP-TEST:` conversations in active, pending, and closed states with customer and staff threads plus tags; report-rich closed fixtures are assigned to the test user; one fixture includes an attachment-bearing thread. | conversation search, status filters, tag filters, thread retrieval, workflow-style integration dogfood, user report row assertions, attachment retrieval |
-| `tests/audit-dogfood-account.ts` | Read-only audit of team membership, satisfaction rating, original-source, and attachment fixture readiness. | names account-only fixture gaps before dogfood runs |
+| `tests/audit-dogfood-account.ts` | Read-only audit of team membership, satisfaction rating, original-source, and attachment fixture readiness. It verifies pinned env IDs, discovers fixture IDs when possible, and scans recent live conversations for original-source coverage when seeded records cannot provide it. | names account-only fixture gaps before dogfood runs and prints env values for verified fixtures |
 
 ## Capability Coverage
 
@@ -59,12 +61,12 @@ npm run dogfood:audit
 | Inbox discovery | `searchInboxes`, `listAllInboxes` | Uses configured Client Support inbox and live account inbox list. | Discovery, narrowing, invalid limit validation. | None known. |
 | Conversation search | `searchConversations`, `advancedConversationSearch`, `comprehensiveConversationSearch`, `structuredConversationFilter` | `MCP-TEST:` conversations cover active, pending, closed, tags, customers, dates, and subjects. | Discovery, narrowing, pagination, permutation, validation. | Add a deterministic spam conversation only if Help Scout supports safe seed/cleanup for spam state. |
 | Conversation retrieval | `getConversationSummary`, `getThreads` | Seeded conversations include customer and staff threads, and one conversation fixture includes an attachment-bearing thread. | Retrieval, pagination, redaction, invalid ID validation, attachment discovery under thread `_embedded.attachments`. | Add a known original-source thread. |
-| Thread original source and attachments | `getOriginalSource`, `getAttachment` | Harness can use `MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID`, `MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID`, `MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID`, and `MCP_DOGFOOD_ATTACHMENT_ID`; attachment IDs are discovered from the seeded attachment fixture conversation. | Retrieval when fixture IDs are provided; attachment retrieval through seeded live fixture discovery. | Original source still requires known email-source fixture IDs. |
+| Thread original source and attachments | `getOriginalSource`, `getAttachment` | Harness can use `MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID`, `MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID`, `MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID`, and `MCP_DOGFOOD_ATTACHMENT_ID`; attachment IDs are discovered from the seeded attachment fixture conversation. Dogfood probes discovered thread IDs for readable original source before skipping. | Retrieval when fixture IDs are provided; attachment retrieval through seeded live fixture discovery; original-source retrieval when a readable source is discovered. | Original source still requires an inbound email-source fixture when no live thread exposes source data. |
 | Customer context | `getCustomer`, `listCustomers`, `searchCustomersByEmail`, `getCustomerContacts` | Golden customer and Meridian org members cover profile, email, name, mailbox, modified date, pagination, contacts, and invalid IDs. | Discovery, retrieval, narrowing, pagination, permutation, validation. | Add a customer with multiple values per contact type if future tools expose contact editing or richer contact filtering. |
 | Organization context | `getOrganization`, `listOrganizations`, `getOrganizationMembers`, `getOrganizationConversations` | Golden organization, fifteen org members, and seeded conversations cover include flags, sort fields, pagination, members, and conversations. | Retrieval, narrowing, pagination, permutation, validation. | Add organization property-heavy fixtures if property output schemas become stricter. |
 | Property metadata | `listCustomerProperties`, `listOrganizationProperties`, `getOrganizationProperty` | Customer property and deterministic organization property are seeded. | Discovery and retrieval. | None known. |
 | Tags | `listTags`, `getTag` | Seeded conversations use `mcp-test`; dogfood prefers that tag when present. | Discovery, narrowing, retrieval. | None known if tag creation remains stable through conversation seeding. |
-| Users and teams | `listUsers`, `getUser`, `listTeams`, `getTeamMembers` | Live users and teams are discovered; `getUser me` is deterministic for authenticated credentials. | Discovery, retrieval, inbox filter. | Team/member coverage depends on account team setup. Add an account fixture or documented 1Password-backed setup step if API cannot create teams. |
+| Users and teams | `listUsers`, `getUser`, `listTeams`, `getTeamMembers` | Live users and teams are discovered; `MCP_DOGFOOD_TEAM_ID` can pin a known team; `getUser me` is deterministic for authenticated credentials. | Discovery, retrieval, inbox filter. | Team/member coverage depends on account team setup. Add an account fixture or documented 1Password-backed setup step if API cannot create teams. |
 | Inbox metadata | `listInboxCustomFields`, `listInboxFolders`, `listSavedReplies`, `getSavedReply` | Inbox custom fields and folders are discovered from Client Support. A deterministic saved reply is seeded in Client Support. | Discovery, retrieval. | None known for saved replies. |
 | Workflows | `listWorkflows` | Discovers live account workflows. | Discovery. | Add a stable workflow fixture or account setup note if workflow APIs cannot create read-only test workflows. |
 | Webhooks | `listWebhooks`, `getWebhook` | A deterministic test webhook is seeded with a non-routable callback URL and Client Support mailbox scope. | Discovery and retrieval. | None known. |
@@ -79,9 +81,9 @@ npm run dogfood:audit
 
 | Skip source | Current reason | Preferred fix |
 | --- | --- | --- |
-| `getOriginalSource` | No known original-source fixture IDs. | Add original-source conversation/thread discovery to seed output or environment setup. |
-| `getSatisfactionRating` | No known satisfaction rating fixture ID. | Seed or configure a known rating and expose `MCP_DOGFOOD_SATISFACTION_RATING_ID`. |
-| `getTeamMembers` | No team may exist in the test account. | Configure or seed a team with at least one member. |
+| `getOriginalSource` | No known original-source fixture IDs. | Send or import an inbound email fixture, then use `npm run dogfood:audit` output to set `MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID` and `MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID`. |
+| `getSatisfactionRating` | No known satisfaction rating fixture ID. | Submit a known rating, then use `npm run dogfood:audit` output to set `MCP_DOGFOOD_SATISFACTION_RATING_ID`. |
+| `getTeamMembers` | No team may exist in the test account. | Configure a team with at least one member, then use `npm run dogfood:audit` output to set `MCP_DOGFOOD_TEAM_ID` if discovery should be pinned. |
 | Docs API tools | Docs API requires separate `HELPSCOUT_DOCS_API_KEY`, and the shared seed command cannot create Docs knowledge base fixtures. | Configure a Docs API key and stable Docs records, then set the `MCP_DOGFOOD_DOCS_*` environment IDs when auto-discovery is insufficient. |
 
 ## PR Checklist For New API Surfaces

--- a/tests/audit-dogfood-account.ts
+++ b/tests/audit-dogfood-account.ts
@@ -25,6 +25,7 @@ interface AuditResult {
   name: string;
   status: 'PASS' | 'GAP';
   detail: string;
+  env?: Record<string, string>;
 }
 
 let accessToken: string | null = null;
@@ -71,10 +72,29 @@ function daysAgoIso(days: number): string {
 
 async function auditTeams(client: AxiosInstance): Promise<AuditResult> {
   try {
+    const envTeamId = process.env.MCP_DOGFOOD_TEAM_ID;
+    if (envTeamId) {
+      const membersRes = await client.get(`/teams/${envTeamId}/members`, { params: { page: 1 } });
+      const members = membersRes.status === 200 ? (membersRes.data?._embedded?.users || []) : [];
+      if (members.length > 0) {
+        return {
+          name: 'getTeamMembers',
+          status: 'PASS',
+          detail: `teamId=${envTeamId}`,
+          env: { MCP_DOGFOOD_TEAM_ID: envTeamId },
+        };
+      }
+    }
+
     const res = await client.get('/teams', { params: { page: 1 } });
     const teams = res.status === 200 ? (res.data?._embedded?.teams || []) : [];
     if (teams.length > 0) {
-      return { name: 'getTeamMembers', status: 'PASS', detail: `teamId=${teams[0].id}` };
+      return {
+        name: 'getTeamMembers',
+        status: 'PASS',
+        detail: `teamId=${teams[0].id}`,
+        env: { MCP_DOGFOOD_TEAM_ID: String(teams[0].id) },
+      };
     }
 
     return {
@@ -93,7 +113,12 @@ async function auditSatisfactionRating(client: AxiosInstance): Promise<AuditResu
     if (envId) {
       const res = await client.get(`/ratings/${envId}`);
       if (res.status === 200) {
-        return { name: 'getSatisfactionRating', status: 'PASS', detail: `ratingId=${envId}` };
+        return {
+          name: 'getSatisfactionRating',
+          status: 'PASS',
+          detail: `ratingId=${envId}`,
+          env: { MCP_DOGFOOD_SATISFACTION_RATING_ID: envId },
+        };
       }
     }
 
@@ -111,7 +136,12 @@ async function auditSatisfactionRating(client: AxiosInstance): Promise<AuditResu
     const ratings = res.status === 200 ? (res.data?._embedded?.results || res.data?.results || []) : [];
     const rating = ratings.find((item: any) => item.id);
     if (rating?.id) {
-      return { name: 'getSatisfactionRating', status: 'PASS', detail: `ratingId=${rating.id}` };
+      return {
+        name: 'getSatisfactionRating',
+        status: 'PASS',
+        detail: `ratingId=${rating.id}`,
+        env: { MCP_DOGFOOD_SATISFACTION_RATING_ID: String(rating.id) },
+      };
     }
 
     return {
@@ -140,6 +170,39 @@ async function listSeededConversations(client: AxiosInstance): Promise<Array<{ i
   }
 }
 
+async function listRecentConversations(client: AxiosInstance): Promise<Array<{ id: number; subject?: string }>> {
+  try {
+    const res = await client.get('/conversations', {
+      params: {
+        mailbox: INTEGRATION_CONSTANTS.inboxId,
+        status: 'all',
+        page: 1,
+      },
+    });
+    return res.status === 200 ? (res.data?._embedded?.conversations || []) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function findOriginalSource(
+  client: AxiosInstance,
+  conversations: Array<{ id: number }>
+): Promise<{ conversationId: string; threadId: string } | null> {
+  for (const conversation of conversations.slice(0, 25)) {
+    const threadsRes = await client.get(`/conversations/${conversation.id}/threads`, { params: { page: 1, size: 25 } });
+    const threads = threadsRes.status === 200 ? (threadsRes.data?._embedded?.threads || []) : [];
+    for (const thread of threads) {
+      if (!thread.id) continue;
+      const sourceRes = await client.get(`/conversations/${conversation.id}/threads/${thread.id}/original-source`);
+      if (sourceRes.status === 200) {
+        return { conversationId: String(conversation.id), threadId: String(thread.id) };
+      }
+    }
+  }
+  return null;
+}
+
 async function auditOriginalSource(client: AxiosInstance, conversations: Array<{ id: number }>): Promise<AuditResult> {
   try {
     const envConversationId = process.env.MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID;
@@ -147,26 +210,48 @@ async function auditOriginalSource(client: AxiosInstance, conversations: Array<{
     if (envConversationId && envThreadId) {
       const res = await client.get(`/conversations/${envConversationId}/threads/${envThreadId}/original-source`);
       if (res.status === 200) {
-        return { name: 'getOriginalSource', status: 'PASS', detail: `conversationId=${envConversationId} threadId=${envThreadId}` };
+        return {
+          name: 'getOriginalSource',
+          status: 'PASS',
+          detail: `conversationId=${envConversationId} threadId=${envThreadId}`,
+          env: {
+            MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID: envConversationId,
+            MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID: envThreadId,
+          },
+        };
       }
     }
 
-    for (const conversation of conversations.slice(0, 25)) {
-      const threadsRes = await client.get(`/conversations/${conversation.id}/threads`, { params: { page: 1, size: 25 } });
-      const threads = threadsRes.status === 200 ? (threadsRes.data?._embedded?.threads || []) : [];
-      for (const thread of threads) {
-        if (!thread.id) continue;
-        const sourceRes = await client.get(`/conversations/${conversation.id}/threads/${thread.id}/original-source`);
-        if (sourceRes.status === 200) {
-          return { name: 'getOriginalSource', status: 'PASS', detail: `conversationId=${conversation.id} threadId=${thread.id}` };
-        }
-      }
+    const seeded = await findOriginalSource(client, conversations);
+    if (seeded) {
+      return {
+        name: 'getOriginalSource',
+        status: 'PASS',
+        detail: `conversationId=${seeded.conversationId} threadId=${seeded.threadId}`,
+        env: {
+          MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID: seeded.conversationId,
+          MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID: seeded.threadId,
+        },
+      };
+    }
+
+    const recent = await findOriginalSource(client, await listRecentConversations(client));
+    if (recent) {
+      return {
+        name: 'getOriginalSource',
+        status: 'PASS',
+        detail: `conversationId=${recent.conversationId} threadId=${recent.threadId} (recent live conversation)`,
+        env: {
+          MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID: recent.conversationId,
+          MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID: recent.threadId,
+        },
+      };
     }
 
     return {
       name: 'getOriginalSource',
       status: 'GAP',
-      detail: 'No seeded MCP-TEST thread exposes original email source; create or import an inbound email fixture and set MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID plus MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID.',
+      detail: 'No seeded or recent live thread exposes original email source; create or import an inbound email fixture and set MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID plus MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID.',
     };
   } catch (err) {
     return { name: 'getOriginalSource', status: 'GAP', detail: `Original-source audit failed: ${err instanceof Error ? err.message : String(err)}` };
@@ -188,7 +273,15 @@ async function auditAttachment(client: AxiosInstance, conversations: Array<{ id:
 
         const dataRes = await client.get(`/conversations/${conversation.id}/attachments/${attachment.id}/data`);
         if (dataRes.status === 200) {
-          return { name: 'getAttachment', status: 'PASS', detail: `conversationId=${conversation.id} attachmentId=${attachment.id}` };
+          return {
+            name: 'getAttachment',
+            status: 'PASS',
+            detail: `conversationId=${conversation.id} attachmentId=${attachment.id}`,
+            env: {
+              MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID: String(conversation.id),
+              MCP_DOGFOOD_ATTACHMENT_ID: String(attachment.id),
+            },
+          };
         }
       }
     }
@@ -226,6 +319,14 @@ async function main(): Promise<void> {
 
   for (const result of results) {
     process.stdout.write(`${result.status}: ${result.name} - ${result.detail}\n`);
+  }
+
+  const envHints = results.flatMap((result) => Object.entries(result.env || {}));
+  if (envHints.length > 0) {
+    process.stdout.write('\nDiscovered dogfood fixture env:\n');
+    for (const [key, value] of envHints) {
+      process.stdout.write(`${key}=${value}\n`);
+    }
   }
 
   const gaps = results.filter((result) => result.status === 'GAP');

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -46,6 +46,7 @@ const GOLDEN = {
   attachmentConversationId: process.env.MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID,
   attachmentId: process.env.MCP_DOGFOOD_ATTACHMENT_ID,
   satisfactionRatingId: process.env.MCP_DOGFOOD_SATISFACTION_RATING_ID,
+  teamId: process.env.MCP_DOGFOOD_TEAM_ID,
   docsSiteId: process.env.MCP_DOGFOOD_DOCS_SITE_ID,
   docsCollectionId: process.env.MCP_DOGFOOD_DOCS_COLLECTION_ID,
   docsCategoryId: process.env.MCP_DOGFOOD_DOCS_CATEGORY_ID,
@@ -149,6 +150,7 @@ interface DogfoodContext {
   conversationNumber?: number;
   originalSourceConversationId?: string;
   originalSourceThreadId?: string;
+  originalSourceProbeSkipped?: string;
   attachmentConversationId?: string;
   attachmentId?: string;
   assigneeId?: number;
@@ -182,7 +184,7 @@ interface Scenario {
   expectError?: boolean;
   skipIf?: (ctx: DogfoodContext) => string | undefined;
   validate: (data: unknown, result: CallToolResult, ctx: DogfoodContext) => void;
-  after?: (data: unknown, result: CallToolResult, ctx: DogfoodContext) => void;
+  after?: (data: unknown, result: CallToolResult, ctx: DogfoodContext, session: McpDogfoodSession) => void | Promise<void>;
 }
 
 interface ScenarioResult {
@@ -238,6 +240,7 @@ class McpDogfoodSession {
       attachmentConversationId: GOLDEN.attachmentConversationId,
       attachmentId: GOLDEN.attachmentId,
       satisfactionRatingId: GOLDEN.satisfactionRatingId,
+      teamId: GOLDEN.teamId,
       docsSiteId: GOLDEN.docsSiteId,
       docsCollectionId: GOLDEN.docsCollectionId,
       docsCategoryId: GOLDEN.docsCategoryId,
@@ -311,6 +314,12 @@ function getThreadAttachments(thread: JsonObject): JsonObject[] {
   return [];
 }
 
+function getThreadId(thread: JsonObject): string | undefined {
+  const id = thread.id;
+  if (typeof id === 'string' || typeof id === 'number') return String(id);
+  return undefined;
+}
+
 function requireCondition(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
@@ -324,6 +333,35 @@ function requireArray(data: unknown, keys: string[], label: string): unknown[] {
 function requirePositiveMetric(data: Record<string, unknown>, keys: string[], label: string): void {
   const found = keys.some((key) => typeof data[key] === 'number' && data[key] > 0);
   requireCondition(found, `${label} did not include a positive metric in ${keys.join(', ')}`);
+}
+
+async function probeOriginalSourceFixture(
+  session: McpDogfoodSession,
+  ctx: DogfoodContext,
+  conversationId: string | undefined,
+  threads: JsonObject[]
+): Promise<void> {
+  if (ctx.originalSourceConversationId && ctx.originalSourceThreadId) return;
+  if (!conversationId) return;
+
+  for (const thread of threads) {
+    const threadId = getThreadId(thread);
+    if (!threadId) continue;
+
+    try {
+      const result = await session.callTool('getOriginalSource', { conversationId, threadId });
+      const data = parseToolData(result);
+      const originalSource = getObject(data, 'originalSource');
+      if (!result.isError && originalSource && 'original' in originalSource) {
+        ctx.originalSourceConversationId = conversationId;
+        ctx.originalSourceThreadId = threadId;
+        ctx.originalSourceProbeSkipped = undefined;
+        return;
+      }
+    } catch (err) {
+      ctx.originalSourceProbeSkipped = err instanceof Error ? err.message : String(err);
+    }
+  }
 }
 
 function isRedactedBody(body: unknown): boolean {
@@ -383,7 +421,7 @@ async function runScenario(session: McpDogfoodSession, ctx: DogfoodContext, scen
       throw new Error(`Unexpected tool error: ${textFromResult(result).slice(0, 300)}`);
     }
     scenario.validate(data, result, ctx);
-    scenario.after?.(data, result, ctx);
+    await scenario.after?.(data, result, ctx, session);
     const durationMs = Date.now() - start;
     results.push({ name: scenario.name, tool: scenario.tool, status: 'PASS', durationMs });
     process.stderr.write(` PASS (${durationMs}ms)\n`);
@@ -1173,18 +1211,20 @@ function buildScenarios(): Scenario[] {
       validate: (data) => {
         requireArray(data, ['threads'], 'threads');
       },
-      after: (data, _result, ctx) => {
+      after: async (data, _result, ctx, session) => {
         const threads = getArray(data, ['threads']) as JsonObject[];
-        if (ctx.attachmentId) return;
-        for (const thread of threads) {
-          const attachments = getThreadAttachments(thread);
-          const attachment = attachments.find((item) => item.id);
-          if (attachment?.id) {
-            ctx.attachmentConversationId = ctx.conversationId;
-            ctx.attachmentId = String(attachment.id);
-            break;
+        if (!ctx.attachmentId) {
+          for (const thread of threads) {
+            const attachments = getThreadAttachments(thread);
+            const attachment = attachments.find((item) => item.id);
+            if (attachment?.id) {
+              ctx.attachmentConversationId = ctx.conversationId;
+              ctx.attachmentId = String(attachment.id);
+              break;
+            }
           }
         }
+        await probeOriginalSourceFixture(session, ctx, ctx.conversationId, threads);
       },
     },
     {
@@ -1215,16 +1255,18 @@ function buildScenarios(): Scenario[] {
       validate: (data) => {
         requireArray(data, ['threads'], 'threads');
       },
-      after: (data, _result, ctx) => {
-        if (ctx.attachmentId) return;
+      after: async (data, _result, ctx, session) => {
         const threads = getArray(data, ['threads']) as JsonObject[];
-        for (const thread of threads) {
-          const attachment = getThreadAttachments(thread).find((item) => item.id);
-          if (attachment?.id) {
-            ctx.attachmentId = String(attachment.id);
-            break;
+        if (!ctx.attachmentId) {
+          for (const thread of threads) {
+            const attachment = getThreadAttachments(thread).find((item) => item.id);
+            if (attachment?.id) {
+              ctx.attachmentId = String(attachment.id);
+              break;
+            }
           }
         }
+        await probeOriginalSourceFixture(session, ctx, ctx.attachmentConversationId, threads);
       },
     },
     {
@@ -1723,7 +1765,49 @@ async function runRedactionMatrix(baseCtx: DogfoodContext): Promise<void> {
   }
 }
 
-function printSummary(): void {
+function printFixtureHints(ctx: DogfoodContext): void {
+  const hints: string[] = [];
+
+  if (ctx.attachmentConversationId && ctx.attachmentId) {
+    hints.push(`MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID=${ctx.attachmentConversationId}`);
+    hints.push(`MCP_DOGFOOD_ATTACHMENT_ID=${ctx.attachmentId}`);
+  }
+
+  if (ctx.originalSourceConversationId && ctx.originalSourceThreadId) {
+    hints.push(`MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID=${ctx.originalSourceConversationId}`);
+    hints.push(`MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID=${ctx.originalSourceThreadId}`);
+  }
+
+  if (ctx.satisfactionRatingId) {
+    hints.push(`MCP_DOGFOOD_SATISFACTION_RATING_ID=${ctx.satisfactionRatingId}`);
+  }
+
+  if (ctx.teamId) {
+    hints.push(`MCP_DOGFOOD_TEAM_ID=${ctx.teamId}`);
+  }
+
+  process.stderr.write('\nFixture hints:\n');
+  if (hints.length > 0) {
+    for (const hint of hints) process.stderr.write(`  ${hint}\n`);
+  } else {
+    process.stderr.write('  No optional live fixture IDs were discovered.\n');
+  }
+
+  if (!ctx.teamId) {
+    process.stderr.write('  Missing team fixture: create a Help Scout team with at least one member.\n');
+  }
+  if (!ctx.satisfactionRatingId) {
+    process.stderr.write('  Missing satisfaction rating fixture: submit a rating and rerun dogfood to discover its ID.\n');
+  }
+  if (!ctx.originalSourceConversationId || !ctx.originalSourceThreadId) {
+    process.stderr.write('  Missing original-source fixture: send/import a real inbound email thread and rerun dogfood.\n');
+  }
+  if (!process.env.HELPSCOUT_DOCS_API_KEY) {
+    process.stderr.write('  Missing Docs fixture: set HELPSCOUT_DOCS_API_KEY and stable Docs records for non-skipping Docs dogfood.\n');
+  }
+}
+
+function printSummary(ctx: DogfoodContext): void {
   process.stderr.write('\n=== MCP Dogfood Summary ===\n\n');
   const byStatus = {
     pass: results.filter((result) => result.status === 'PASS'),
@@ -1752,6 +1836,7 @@ function printSummary(): void {
   const totalMs = results.reduce((sum, result) => sum + result.durationMs, 0);
   process.stderr.write(`\n${byStatus.pass.length} passed, ${byStatus.fail.length} failed, ${results.length} total`);
   process.stderr.write(` (${(totalMs / 1000).toFixed(1)}s summed tool time)\n\n`);
+  printFixtureHints(ctx);
 
   if (byStatus.fail.length > 0) process.exitCode = 1;
 }
@@ -1768,7 +1853,7 @@ async function main(): Promise<void> {
 
   const ctx = await runMainMatrix();
   await runRedactionMatrix(ctx);
-  printSummary();
+  printSummary(ctx);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Promotes discovered live fixture IDs into the dogfood context and prints reusable `MCP_DOGFOOD_*` hints.
- Adds read-only audit support for pinned team/rating/original-source IDs and broader original-source discovery from recent conversations.
- Updates the fixture matrix with current setup requirements and pinning workflow.

## Testing
- npm run type-check
- npm run lint
- npm test -- --runInBand --silent
- npm run test:contract
- npm run build
- npm run dogfood:seed
- npm run dogfood:mcp
- npm run dogfood:workflows
- npm run dogfood:audit (expected exit 1: account still lacks team, satisfaction rating, and original-source fixtures; attachment fixture discovered)
- npm run mcpb:build
- npm run security (exits 0 with existing baseline findings)

Closes NAS-719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->