### PR TITLE
feat(NAS-1290,NAS-1291): complete read parity and write foundation

### DIFF
--- a/guides/architecture/mcp-tool-contract.md
+++ b/guides/architecture/mcp-tool-contract.md
@@ -109,10 +109,112 @@ Use names that match support workflows:
 - `getX` for direct ID or slug lookups.
 - `searchX` for user-entered query or filter workflows.
 - `summarizeX` only when the server creates a derived support summary.
+- Write-capable tools must use explicit verbs that name the mutation:
+  `createX`, `updateX`, `deleteX`, `setX`, `removeX`, `uploadX`, `runX`, or
+  another Help Scout-aligned verb when those are more precise.
 
 Avoid exposing raw Help Scout endpoint names when a workflow name is clearer.
-Avoid adding write verbs until write/automation tools have a separate permission
-and consent model.
+Avoid adding write verbs until the write-tool contract below is satisfied.
+
+## Write Tool Contract
+
+Write tools are direct Help Scout API parity tools. They are not operator
+workflow products, MCP Apps views, or hidden multi-step automations. Each write
+tool should map to one Help Scout mutation endpoint or one tightly scoped API
+operation family.
+
+### Mutation Classes
+
+Classify each write tool in its implementation notes, tests, and dogfood plan:
+
+- `nonDestructive`: creates disposable data or updates a reversible test
+  record without external customer visibility.
+- `reversible`: changes Help Scout state but can be restored by a documented
+  API call in the same dogfood lifecycle.
+- `externallyVisible`: can notify customers, publish Docs content, expose a
+  redirect, trigger a webhook, run a workflow, or otherwise affect people
+  outside the test process.
+- `destructive`: deletes records, removes contact paths, disables workflows,
+  removes redirects, deletes Docs content, or makes recovery impossible through
+  the same tool family.
+
+Externally visible and destructive tools require explicit confirmation metadata.
+
+### Confirmation Metadata
+
+For destructive or externally visible operations, the input schema must include
+confirmation fields that are hard to satisfy accidentally:
+
+```json
+{
+  "confirm": true,
+  "confirmOperation": "deleteCustomer",
+  "targetId": "12345"
+}
+```
+
+The exact confirmation string should name the operation and target. The tool
+must reject calls with missing, false, or mismatched confirmation before making a
+Help Scout request. Confirmation requirements belong in the tool description and
+validation tests.
+
+### Dry Run And Preview
+
+Use dry-run behavior only when it can be honest:
+
+- If the Help Scout API supports previewing or validating without mutation, call
+  the supported API path.
+- If no preview API exists, a `dryRun` mode may validate inputs and report the
+  request that would be sent, but it must clearly say that Help Scout state was
+  not checked.
+- Do not fake success by simulating Help Scout side effects locally.
+
+### Result Envelopes
+
+Write results should use a predictable envelope:
+
+```json
+{
+  "operation": "updateConversation",
+  "mutationClass": "reversible",
+  "target": { "type": "conversation", "id": "12345" },
+  "status": "succeeded",
+  "result": {},
+  "cleanup": {
+    "required": false,
+    "performed": false,
+    "instructions": null
+  }
+}
+```
+
+Validation failures should return model-correctable tool errors without sending
+an upstream request. Partial failures should name which sub-operation succeeded,
+which failed, and what cleanup remains. Never hide a cleanup failure.
+
+### Live Dogfood Lifecycle
+
+Every write-tool PR must prove live behavior against disposable fixtures:
+
+1. Create or discover a test-owned target with an `MCP-TEST:` marker or another
+   deterministic test marker.
+2. Perform the mutation through MCP over stdio, not by calling helper code
+   directly.
+3. Read the target back through an existing read tool or direct API contract
+   check to verify the Help Scout state.
+4. Restore or delete the fixture when the operation is reversible or disposable.
+5. Fail loudly if cleanup cannot be confirmed.
+
+Fixture setup belongs in idempotent seed scripts when it is reusable. PRs must
+update the dogfood fixture matrix with the records they create, reuse, skip, or
+cannot safely clean up.
+
+### Deny And Permission Behavior
+
+Permission errors, plan-limit errors, invalid IDs, and Help Scout validation
+errors are expected API outcomes. Return them as tool errors with the upstream
+status/code and model-correctable guidance. Do not retry non-idempotent writes
+unless the endpoint and request body are explicitly safe to repeat.
 
 ## Boundaries
 

--- a/guides/architecture/mcp-vs-cli.md
+++ b/guides/architecture/mcp-vs-cli.md
@@ -76,6 +76,11 @@ exercises the core path and meaningful permutations for that surface before the
 PR is reviewed. Missing account data should drive fixture work, not weaker
 dogfood assertions.
 
+Write-capable API parity tools must also follow the write-tool contract in
+[`mcp-tool-contract.md`](./mcp-tool-contract.md): classify the mutation, require
+confirmation for destructive or externally visible actions, verify the mutation
+through MCP, and confirm cleanup.
+
 Use `npm run dogfood:seed` to load the shared customer, organization,
 conversation, and organization-member fixtures before authenticated dogfood
 runs. New API families should add their own idempotent seed data and wire it

--- a/guides/roadmap/mcp-tool-surface.md
+++ b/guides/roadmap/mcp-tool-surface.md
@@ -18,6 +18,17 @@ as Docs API fixtures, should no-op when their credentials are missing. Keep the
 detailed per-tool fixture map current in
 [`guides/testing/dogfood-fixture-matrix.md`](../testing/dogfood-fixture-matrix.md).
 
+## v1.9 Release Boundary
+
+As of the June 16, 2026 reconciliation against the official Help Scout Mailbox
+and Docs endpoint maps, v1.9 targets current official read endpoint parity plus
+the write-tool foundation. `listCustomersV3` closes the remaining direct
+read-only endpoint gap for `GET /v3/customers`.
+
+Do not add write tools to v1.9. Write-capable API parity work starts after the
+write-tool contract in [`guides/architecture/mcp-tool-contract.md`](../architecture/mcp-tool-contract.md)
+is merged and dogfooded.
+
 ## 1. Core Support Loop
 
 These are the highest-usage tools because they map directly to daily support
@@ -55,6 +66,7 @@ history matters before a reply.
 Current:
 
 - `listCustomers`
+- `listCustomersV3`
 - `getCustomer`
 - `searchCustomersByEmail`
 - `getCustomerContacts`
@@ -236,7 +248,9 @@ Next:
 ## 9. Write And Automation Tools
 
 Write tools are intentionally deferred. They require a stricter permission and
-confirmation model than read tools.
+confirmation model than read tools. Use the write-tool contract in
+[`guides/architecture/mcp-tool-contract.md`](../architecture/mcp-tool-contract.md)
+before implementing any mutation endpoint.
 
 Possible future families:
 

--- a/guides/testing/dogfood-fixture-matrix.md
+++ b/guides/testing/dogfood-fixture-matrix.md
@@ -66,9 +66,9 @@ IDs into production tool code.
 | Intent | What it proves | Example tools |
 | --- | --- | --- |
 | Discovery | The account has enough metadata to navigate later calls. | `listAllInboxes`, `listUsers`, `listTags` |
-| Narrowing | Filters correctly reduce or target data. | `searchConversations`, `listCustomers`, `listUsers` |
+| Narrowing | Filters correctly reduce or target data. | `searchConversations`, `listCustomers`, `listCustomersV3`, `listUsers` |
 | Retrieval | A discovered or seeded ID fetches the expected object. | `getCustomer`, `getThreads`, `getUser` |
-| Pagination | Page, size, cursor, or row controls are honored. | `listOrganizations`, `getUserDrilldownReport` |
+| Pagination | Page, size, cursor, or row controls are honored. | `listCustomersV3`, `listOrganizations`, `getUserDrilldownReport` |
 | Permutation | Sort, status, type, date, and boolean controls serialize correctly. | `searchConversations`, report tools |
 | Redaction | Sensitive message bodies hide when redaction is enabled. | `getConversationSummary`, `getThreads`, `getThreadsV3` |
 | Validation | Bad arguments fail before a Help Scout request or return a model-correctable error. | invalid ID and limit scenarios |
@@ -92,7 +92,7 @@ IDs into production tool code.
 | Conversation search | `searchConversations`, `advancedConversationSearch`, `comprehensiveConversationSearch`, `structuredConversationFilter` | `MCP-TEST:` conversations cover active, pending, closed, tags, customers, dates, and subjects. | Discovery, narrowing, pagination, permutation, validation. | Add a deterministic spam conversation only if Help Scout supports safe seed/cleanup for spam state. |
 | Conversation retrieval | `getConversation`, `getConversationV3`, `getConversationSummary`, `getThreads`, `getThreadsV3` | Seeded conversations include raw conversation metadata, optional embedded threads, customer and staff threads, v3 conversation/thread retrieval, one conversation fixture includes an attachment-bearing thread, and a live inbound email-source fixture covers original-source discovery. | Retrieval, pagination, permutation, redaction, invalid ID validation, attachment discovery under thread `_embedded.attachments`. | None known. |
 | Thread original source and attachments | `getOriginalSource`, `getOriginalSourceRfc822`, `getAttachment`, `downloadAttachmentFile` | Harness can use `MCP_DOGFOOD_ORIGINAL_SOURCE_CONVERSATION_ID`, `MCP_DOGFOOD_ORIGINAL_SOURCE_THREAD_ID`, `MCP_DOGFOOD_ATTACHMENT_CONVERSATION_ID`, and `MCP_DOGFOOD_ATTACHMENT_ID`; attachment IDs are discovered from the seeded attachment fixture conversation and verified through data plus file endpoints. A real inbound email-source fixture now exists in the test account and is discoverable through audit/dogfood. | Retrieval when fixture IDs are provided; attachment data/file retrieval through seeded live fixture discovery; original-source JSON and RFC 822 retrieval when a readable source is discovered. | None known while the inbound email-source fixture remains available; pin the discovered conversation/thread IDs outside the repo when dogfood should avoid rediscovery. |
-| Customer context | `getCustomer`, `listCustomers`, `searchCustomersByEmail`, `getCustomerContacts`, `getCustomerAddress`, `listCustomerEmails`, `listCustomerPhones`, `listCustomerChats`, `listCustomerSocialProfiles`, `listCustomerWebsites` | Golden customer and Meridian org members cover profile, email, name, mailbox, modified date, pagination, aggregate contacts, and each direct contact sub-resource. | Discovery, retrieval, narrowing, pagination, permutation, validation. | Add a customer with multiple values per contact type if future tools expose contact editing or richer contact filtering. |
+| Customer context | `getCustomer`, `listCustomers`, `listCustomersV3`, `searchCustomersByEmail`, `getCustomerContacts`, `getCustomerAddress`, `listCustomerEmails`, `listCustomerPhones`, `listCustomerChats`, `listCustomerSocialProfiles`, `listCustomerWebsites` | Golden customer and Meridian org members cover profile, email, name, mailbox, modified date, v2 page pagination, v3 cursor pagination when available, aggregate contacts, and each direct contact sub-resource. | Discovery, retrieval, narrowing, pagination, permutation, validation. | Add a customer with multiple values per contact type if future tools expose contact editing or richer contact filtering. |
 | Organization context | `getOrganization`, `listOrganizations`, `getOrganizationMembers`, `getOrganizationConversations` | Golden organization, fifteen org members, and seeded conversations cover include flags, sort fields, pagination, members, and conversations. | Retrieval, narrowing, pagination, permutation, validation. | Add organization property-heavy fixtures if property output schemas become stricter. |
 | Property metadata | `listCustomerProperties`, `listOrganizationProperties`, `getOrganizationProperty` | Customer property and deterministic organization property are seeded. | Discovery and retrieval. | None known. |
 | Tags | `listTags`, `getTag` | Seeded conversations use `mcp-test`; dogfood prefers that tag when present. | Discovery, narrowing, retrieval. | None known if tag creation remains stable through conversation seeding. |
@@ -127,3 +127,9 @@ Before opening a PR that adds or changes MCP API tools:
 - Update this matrix with the tool-call intents, fixtures, and remaining skips.
 - Keep skips narrow and name the missing fixture explicitly.
 - Run `npm run dogfood:seed` before authenticated dogfood when the surface depends on seeded records.
+
+For write-capable API parity tools, also follow the write-tool contract in
+[`guides/architecture/mcp-tool-contract.md`](../architecture/mcp-tool-contract.md):
+classify the mutation, require confirmation metadata for destructive or
+externally visible operations, verify the mutation through MCP, and confirm
+fixture cleanup.

--- a/helpscout-mcp-extension/manifest.json
+++ b/helpscout-mcp-extension/manifest.json
@@ -173,6 +173,10 @@
       "description": "List customers by name or advanced query syntax using the v2 Customers API"
     },
     {
+      "name": "listCustomersV3",
+      "description": "List customers by name, email, query syntax, or cursor using the v3 Customers API"
+    },
+    {
       "name": "searchCustomersByEmail",
       "description": "Search customers by email address using the cursor-based v3 Customers API"
     },

--- a/src/__tests__/customer-org-tools.test.ts
+++ b/src/__tests__/customer-org-tools.test.ts
@@ -256,6 +256,78 @@ describe('Customer & Organization Tools', () => {
     });
   });
 
+  describe('listCustomersV3', () => {
+    it('should list customers through the direct v3 endpoint with official filters and cursor links', async () => {
+      nock('https://api.helpscout.net')
+        .get('/v3/customers')
+        .query((query) => (
+          query.firstName === 'Jane' &&
+          query.lastName === 'Doe' &&
+          query.email === 'jane@example.com' &&
+          query.createdSince === '2024-01-01T00:00:00Z' &&
+          query.modifiedSince === '2024-06-01T00:00:00Z' &&
+          query.query === '(email:"jane@example.com")' &&
+          query.cursor === 'cursor-1'
+        ))
+        .reply(200, {
+          _embedded: {
+            customers: [
+              { id: 1, firstName: 'Jane', lastName: 'Doe', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-06-01T00:00:00Z',
+                _embedded: { emails: [{ id: 1, value: 'jane@example.com', type: 'work' }] } },
+            ],
+          },
+          _links: {
+            self: { href: 'https://api.helpscout.net/v3/customers?cursor=cursor-1' },
+            first: { href: 'https://api.helpscout.net/v3/customers' },
+            next: { href: 'https://api.helpscout.net/v3/customers?cursor=cursor-2' },
+          },
+        });
+
+      const result = await toolHandler.callTool(makeRequest('listCustomersV3', {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@example.com',
+        createdSince: '2024-01-01T00:00:00Z',
+        modifiedSince: '2024-06-01T00:00:00Z',
+        query: '(email:"jane@example.com")',
+        cursor: 'cursor-1',
+      }));
+      const data = parseResult(result);
+
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].firstName).toBe('Jane');
+      expect(data.returnedCount).toBe(1);
+      expect(data.links.next.href).toContain('cursor-2');
+      expect(data.nextCursor).toBe('cursor-2');
+      expect(data.pagination.type).toBe('cursor');
+    });
+
+    it('should return an empty v3 customer result shape', async () => {
+      nock('https://api.helpscout.net')
+        .get('/v3/customers')
+        .query(true)
+        .reply(200, {
+          _embedded: { customers: [] },
+          _links: { self: { href: 'https://api.helpscout.net/v3/customers' } },
+        });
+
+      const result = await toolHandler.callTool(makeRequest('listCustomersV3', { firstName: 'Nobody' }));
+      const data = parseResult(result);
+
+      expect(data.results).toEqual([]);
+      expect(data.returnedCount).toBe(0);
+      expect(data.links.self.href).toContain('/v3/customers');
+      expect(data.nextCursor).toBeUndefined();
+    });
+
+    it('should reject whitespace-only cursors before making a request', async () => {
+      const result = await toolHandler.callTool(makeRequest('listCustomersV3', { cursor: '   ' }));
+
+      expect(result.isError).toBe(true);
+      expect(nock.isDone()).toBe(false);
+    });
+  });
+
   describe('getCustomer - error handling', () => {
     it('should propagate 429 rate limit from address endpoint', async () => {
       nock(baseURL)

--- a/src/__tests__/mcpb-validation.test.ts
+++ b/src/__tests__/mcpb-validation.test.ts
@@ -67,8 +67,8 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
       expect(userConfig.personal_access_token).toBeUndefined();
     });
 
-    it('should have all 101 MCP tools declared', () => {
-      expect(manifest.tools).toHaveLength(101);
+    it('should have all 102 MCP tools declared', () => {
+      expect(manifest.tools).toHaveLength(102);
 
       const expectedTools = [
         'searchInboxes',
@@ -86,6 +86,7 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'structuredConversationFilter',
         'getCustomer',
         'listCustomers',
+        'listCustomersV3',
         'searchCustomersByEmail',
         'getCustomerContacts',
         'getCustomerAddress',
@@ -342,6 +343,7 @@ describeIfNotSkipped('MCPB Extension Validation', () => {
         'getInbox',
         'getCustomer',
         'listCustomers',
+        'listCustomersV3',
         'searchCustomersByEmail',
         'getCustomerContacts',
         'getCustomerAddress',

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,5 +1,6 @@
 import { 
   AdvancedConversationSearchInputSchema,
+  GetCompanyReportInputSchema,
   GetOrganizationConversationsInputSchema,
   GetOrganizationMembersInputSchema,
   GetThreadsInputSchema,
@@ -204,6 +205,46 @@ describe('Schema Validation', () => {
       ];
 
       cases.forEach(parse => expect(parse).toThrow());
+    });
+  });
+
+  describe('report date schemas', () => {
+    it('should accept valid date-only and datetime report inputs', () => {
+      expect(GetCompanyReportInputSchema.parse({
+        start: '2026-01-01',
+        end: '2026-01-31T23:59:59Z',
+      })).toEqual(expect.objectContaining({
+        start: '2026-01-01',
+        end: '2026-01-31T23:59:59Z',
+      }));
+
+      expect(GetCompanyReportInputSchema.parse({
+        start: '2026-02-01T00:00:00.250-06:00',
+        end: '2026-02-28T23:59:59+05:30',
+      })).toEqual(expect.objectContaining({
+        start: '2026-02-01T00:00:00.250-06:00',
+        end: '2026-02-28T23:59:59+05:30',
+      }));
+    });
+
+    it('should reject malformed or impossible report dates', () => {
+      const invalidDateCases = [
+        '2026-99-99',
+        '2026-02-31',
+        '2026-01-01T99:00:00Z',
+        '2026-01-01T23:99:00Z',
+        '2026-01-01T23:59:99Z',
+        '2026-01-01T23:59:59+99:00',
+        '2026-01-01T23:59:59+05:99',
+        '2026-01-01T',
+      ];
+
+      for (const invalidDate of invalidDateCases) {
+        expect(() => GetCompanyReportInputSchema.parse({
+          start: invalidDate,
+          end: '2026-01-31',
+        })).toThrow('Report dates must be valid ISO 8601 strings');
+      }
     });
   });
 });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -45,7 +45,7 @@ describe('ToolHandler', () => {
     it('should return all available tools', async () => {
       const tools = await toolHandler.listTools();
       
-      expect(tools).toHaveLength(101);
+      expect(tools).toHaveLength(102);
       expect(tools.map(t => t.name)).toEqual([
         'searchInboxes',
         'searchConversations',
@@ -62,6 +62,7 @@ describe('ToolHandler', () => {
         'structuredConversationFilter',
         'getCustomer',
         'listCustomers',
+        'listCustomersV3',
         'searchCustomersByEmail',
         'getCustomerContacts',
         'getCustomerAddress',

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ ${inboxes.length > 0 ? inboxList : '  No inboxes found - check API credentials'}
 | Complex filters (email domain, multiple tags) | advancedConversationSearch |
 | Lookup by ticket number (#12345) | structuredConversationFilter |
 | Browse customers by name or query | listCustomers |
+| Browse customers with v3 cursor filters | listCustomersV3 |
 | Find a customer by email | searchCustomersByEmail |
 | Get a full customer profile | getCustomer |
 | Get customer contact channels | getCustomerContacts |
@@ -123,7 +124,7 @@ ${inboxes.length > 0 ? inboxList : '  No inboxes found - check API credentials'}
 ## Workflow Patterns
 - **Ticket investigation**: searchConversations → getConversation/getConversationSummary → getThreads
 - **Keyword research**: comprehensiveConversationSearch → getThreads for details
-- **Customer history**: searchCustomersByEmail → getCustomer → structuredConversationFilter/getThreads
+- **Customer history**: listCustomersV3/searchCustomersByEmail → getCustomer → structuredConversationFilter/getThreads
 - **Account review**: listOrganizations/getOrganization → getOrganizationMembers → getOrganizationConversations
 
 ## Notes

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -664,6 +664,16 @@ export const ListCustomersInputSchema = z.object({
   page: z.number().int().min(1).default(1),
 });
 
+export const ListCustomersV3InputSchema = z.object({
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  email: z.string().optional().describe('Email address filter'),
+  createdSince: z.string().optional().describe('ISO 8601 date - only customers created after this date'),
+  modifiedSince: z.string().optional().describe('ISO 8601 date - only customers modified after this date'),
+  query: z.string().optional().describe('Advanced v3 query syntax, e.g. (email:"john@example.com")'),
+  cursor: z.string().trim().min(1, 'Cursor cannot be empty').optional().describe('Cursor for v3 pagination (from nextCursor in previous response)'),
+});
+
 export const SearchCustomersByEmailInputSchema = z.object({
   email: z.string().describe('Email address to search for'),
   firstName: z.string().optional(),

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -427,9 +427,44 @@ export const HappinessRatingsReportSchema = z.object({
   pages: z.number().optional(),
 }).passthrough();
 
-const ReportDateSchema = z.string().regex(
-  /^\d{4}-\d{2}-\d{2}(T[\d:.]+([+-]\d{2}:\d{2}|Z)?)?$/,
-  'Report dates must be ISO 8601 strings'
+const isValidReportDate = (value: string): boolean => {
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|([+-])(\d{2}):(\d{2}))?)?$/
+  );
+
+  if (!match) return false;
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, offsetSign, offsetHourText, offsetMinuteText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const normalizedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    normalizedDate.getUTCFullYear() !== year ||
+    normalizedDate.getUTCMonth() !== month - 1 ||
+    normalizedDate.getUTCDate() !== day
+  ) {
+    return false;
+  }
+
+  if (hourText === undefined) return true;
+
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = secondText === undefined ? 0 : Number(secondText);
+
+  if (hour > 23 || minute > 59 || second > 59) return false;
+  if (offsetSign === undefined) return true;
+
+  const offsetHour = Number(offsetHourText);
+  const offsetMinute = Number(offsetMinuteText);
+  return offsetHour <= 23 && offsetMinute <= 59;
+};
+
+const ReportDateSchema = z.string().refine(
+  isValidReportDate,
+  'Report dates must be valid ISO 8601 strings'
 );
 const ReportIdListSchema = z.array(
   z.string().regex(/^\d+$/, 'Report filter IDs must be numeric')

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -43,6 +43,7 @@ import {
   StructuredConversationFilterInputSchema,
   GetCustomerInputSchema,
   ListCustomersInputSchema,
+  ListCustomersV3InputSchema,
   SearchCustomersByEmailInputSchema,
   GetCustomerContactsInputSchema,
   GetCustomerAddressInputSchema,
@@ -846,6 +847,22 @@ export class ToolHandler {
             sortField: { type: 'string', enum: ['createdAt', 'firstName', 'lastName', 'modifiedAt'], default: 'createdAt' },
             sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' },
             page: { type: 'number', minimum: 1, default: 1, description: 'Page number (API returns 50 results per page)' },
+          },
+        },
+      },
+      {
+        name: 'listCustomersV3',
+        description: 'List or search customers through the v3 Customers API. Supports first name, last name, email, created/modified dates, query syntax, and cursor-based pagination.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string', description: 'Filter by first name' },
+            lastName: { type: 'string', description: 'Filter by last name' },
+            email: { type: 'string', description: 'Filter by email address' },
+            createdSince: { type: 'string', description: 'ISO 8601 date - only customers created after this date' },
+            modifiedSince: { type: 'string', description: 'ISO 8601 date - only customers modified after this date' },
+            query: { type: 'string', description: 'Advanced v3 query syntax, e.g. (email:"john@example.com")' },
+            cursor: { type: 'string', description: 'Cursor for pagination (from nextCursor in previous response)' },
           },
         },
       },
@@ -2201,6 +2218,9 @@ export class ToolHandler {
           break;
         case 'listCustomers':
           result = await this.listCustomers(request.params.arguments || {});
+          break;
+        case 'listCustomersV3':
+          result = await this.listCustomersV3(request.params.arguments || {});
           break;
         case 'searchCustomersByEmail':
           result = await this.searchCustomersByEmail(request.params.arguments || {});
@@ -4956,6 +4976,73 @@ export class ToolHandler {
     };
   }
 
+  private extractV3NextCursor(links?: { next?: { href: string } }): string | undefined {
+    const nextHref = links?.next?.href;
+    if (!nextHref) return undefined;
+    try {
+      const url = new URL(nextHref);
+      return url.searchParams.get('cursor') || nextHref;
+    } catch (parseError) {
+      logger.debug('Could not parse v3 next link as URL, using raw href as cursor', {
+        nextHref,
+        error: parseError instanceof Error ? parseError.message : String(parseError),
+      });
+      return nextHref;
+    }
+  }
+
+  private async fetchCustomersV3(params: Record<string, unknown>): Promise<{
+    customers: Customer[];
+    links?: { self?: { href: string }; first?: { href: string }; next?: { href: string } };
+    nextCursor?: string;
+  }> {
+    const v3Url = this.buildV3ApiUrl('/customers');
+    const v3Response = await helpScoutClient.get<{
+      _embedded: { customers: Customer[] };
+      _links?: { self?: { href: string }; first?: { href: string }; next?: { href: string } };
+    }>(v3Url, params);
+
+    const customers = v3Response._embedded?.customers || [];
+    const nextCursor = this.extractV3NextCursor(v3Response._links);
+
+    return {
+      customers,
+      links: v3Response._links,
+      nextCursor,
+    };
+  }
+
+  private async listCustomersV3(args: unknown): Promise<CallToolResult> {
+    const input = ListCustomersV3InputSchema.parse(args);
+
+    const params: Record<string, unknown> = {
+      firstName: input.firstName,
+      lastName: input.lastName,
+      email: input.email,
+      query: input.query,
+      modifiedSince: this.normalizeApiDateParam(input.modifiedSince),
+      createdSince: this.normalizeApiDateParam(input.createdSince),
+      cursor: input.cursor,
+    };
+
+    const { customers, links, nextCursor } = await this.fetchCustomersV3(params);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          results: customers.map(c => this.formatCustomer(c)),
+          returnedCount: customers.length,
+          links,
+          nextCursor,
+          pagination: { type: 'cursor', hasNext: Boolean(nextCursor) },
+          note: 'v3 API uses cursor-based pagination. Pass nextCursor value back as cursor parameter for more results.',
+          usage: 'Use customer.id with getCustomer for full profile with sub-resources.',
+        }, null, 2),
+      }],
+    };
+  }
+
   // NAS-728: v3 Customer search with email filter
   private async searchCustomersByEmail(args: unknown): Promise<CallToolResult> {
     const input = SearchCustomersByEmailInputSchema.parse(args);
@@ -4970,29 +5057,7 @@ export class ToolHandler {
       cursor: input.cursor,
     };
 
-    const v3Url = this.buildV3ApiUrl('/customers');
-    const v3Response = await helpScoutClient.get<{
-      _embedded: { customers: Customer[] };
-      _links?: { next?: { href: string } };
-    }>(v3Url, params);
-
-    const customers = v3Response._embedded?.customers || [];
-
-    // Extract cursor token from v3 next link (full URL -> just the cursor param value)
-    let nextCursor: string | undefined;
-    const nextHref = v3Response._links?.next?.href;
-    if (nextHref) {
-      try {
-        const url = new URL(nextHref);
-        nextCursor = url.searchParams.get('cursor') || nextHref;
-      } catch (parseError) {
-        logger.debug('Could not parse v3 next link as URL, using raw href as cursor', {
-          nextHref,
-          error: parseError instanceof Error ? parseError.message : String(parseError),
-        });
-        nextCursor = nextHref;
-      }
-    }
+    const { customers, nextCursor } = await this.fetchCustomersV3(params);
 
     return {
       content: [{

--- a/tests/api-contract.ts
+++ b/tests/api-contract.ts
@@ -237,6 +237,13 @@ const cases: ContractCase[] = [
     schema: CustomerSchema,
   },
   {
+    name: 'GET /v3/customers',
+    endpoint: 'https://api.helpscout.net/v3/customers',
+    extract: (response) => embedded(response, 'customers'),
+    after: (items) => { ctx.customerId = ctx.customerId ?? firstId(items); },
+    schema: CustomerSchema,
+  },
+  {
     name: 'GET /v2/customers/{id}',
     endpoint: '',
     skipIf: (context) => context.customerId ? undefined : 'No customer available from list/conversation response',

--- a/tests/mcp-client-dogfood.ts
+++ b/tests/mcp-client-dogfood.ts
@@ -76,6 +76,7 @@ const EXPECTED_TOOLS = [
   'structuredConversationFilter',
   'getCustomer',
   'listCustomers',
+  'listCustomersV3',
   'searchCustomersByEmail',
   'getCustomerContacts',
   'getCustomerAddress',
@@ -1726,6 +1727,36 @@ function buildScenarios(): Scenario[] {
         const customers = getArray(data, ['results', 'customers']) as JsonObject[];
         if (customers[0]?.id) ctx.customerId = String(customers[0].id);
         if (typeof obj.nextCursor === 'string') ctx.nextCustomerCursor = obj.nextCursor;
+      },
+    },
+    {
+      tool: 'listCustomersV3',
+      name: 'v3 first-name listing',
+      args: (ctx) => ({ firstName: GOLDEN.customerFirstName, createdSince: dateDaysAgo(365), modifiedSince: dateDaysAgo(365) }),
+      validate: (data) => {
+        const customers = requireArray(data, ['results', 'customers'], 'customers') as JsonObject[];
+        requireCondition(customers.some((customer) => String(customer.id) === GOLDEN.customerId), 'Golden customer not found in v3 list');
+      },
+      after: (data, _result, ctx) => {
+        const obj = data as JsonObject;
+        if (typeof obj.nextCursor === 'string') ctx.nextCustomerCursor = obj.nextCursor;
+      },
+    },
+    {
+      tool: 'listCustomersV3',
+      name: 'v3 query syntax listing',
+      args: (ctx) => ({ query: `(email:"${ctx.customerEmail}")` }),
+      validate: (data) => {
+        requireArray(data, ['results', 'customers'], 'customers');
+      },
+    },
+    {
+      tool: 'listCustomersV3',
+      name: 'v3 cursor pagination',
+      skipIf: (ctx) => ctx.nextCustomerCursor ? undefined : 'no next customer cursor returned by prior v3 call',
+      args: (ctx) => ({ firstName: GOLDEN.customerFirstName, cursor: ctx.nextCustomerCursor ?? 'not-a-real-cursor' }),
+      validate: (data) => {
+        requireCondition(data !== undefined, 'Expected v3 cursor response');
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add `listCustomersV3` for direct `GET /v3/customers` API parity with v3 filters, cursor pagination, HAL links, and live dogfood coverage.
- Share v3 customer cursor handling with the existing email search path while preserving existing v2 `listCustomers` behavior.
- Document the v1.9 read-parity release boundary and the write-tool safety contract for future mutation endpoint work.

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand --silent`
- `npm run test:contract`
- Docs dogfood seed with configured Docs API key
- `npm run dogfood:full` with Docs fixtures pinned
- Security scan baseline comparison: no new findings against `main`

Closes NAS-1290
Closes NAS-1291
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->