### PR TITLE
fix: harden foundation release gates

### DIFF
--- a/src/__tests__/package-scripts.test.ts
+++ b/src/__tests__/package-scripts.test.ts
@@ -51,6 +51,25 @@ describe('package scripts', () => {
     }
   });
 
+  it('lets Docker live testing use process environment credentials without a .env file', () => {
+    const result = spawnSync('node', [
+      '-e',
+      [
+        'process.env.HELPSCOUT_APP_ID="env-app";',
+        'process.env.HELPSCOUT_APP_SECRET="env-secret";',
+        'const { loadEnvFile } = require("./tests/test-docker.cjs");',
+        'const env = loadEnvFile();',
+        'process.stdout.write(`${env.HELPSCOUT_APP_ID}:${env.HELPSCOUT_APP_SECRET}`);',
+      ].join(''),
+    ], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('env-app:env-secret');
+  });
+
   it('guards sync:plugin when the target checkout has local files', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'helpscout-sync-plugin-'));
     const pluginDir = path.join(tempRoot, 'helpscout-navigator');

--- a/src/__tests__/prompts.test.ts
+++ b/src/__tests__/prompts.test.ts
@@ -434,7 +434,7 @@ describe('PromptHandler', () => {
             name: 'list-inbox-activity',
             arguments: {
               inboxId: 'inbox-123',
-              hours: 24,
+              hours: 12,
             }
           }
         };
@@ -442,8 +442,8 @@ describe('PromptHandler', () => {
         const result = await promptHandler.getPrompt(request);
         const promptText = result.messages[0].content.text;
 
-        expect(promptText).toContain('If current time is "2025-06-11T15:04:00Z" and hours is 24');
-        expect(promptText).toContain('then 24 hours ago would be "2025-06-10T15:04:00Z"');
+        expect(promptText).toContain('If current time is "2025-06-11T15:04:00Z" and hours is 12');
+        expect(promptText).toContain('then 12 hours ago would be "2025-06-11T03:04:00Z"');
       });
 
       it('should include thread details when includeThreads is true', async () => {

--- a/src/__tests__/prompts.test.ts
+++ b/src/__tests__/prompts.test.ts
@@ -427,6 +427,25 @@ describe('PromptHandler', () => {
         expect(searchParams.extra).toBeUndefined();
       });
 
+      it('should keep the activity timestamp example internally consistent', async () => {
+        const request = {
+          method: 'prompts/get',
+          params: {
+            name: 'list-inbox-activity',
+            arguments: {
+              inboxId: 'inbox-123',
+              hours: 24,
+            }
+          }
+        };
+
+        const result = await promptHandler.getPrompt(request);
+        const promptText = result.messages[0].content.text;
+
+        expect(promptText).toContain('If current time is "2025-06-11T15:04:00Z" and hours is 24');
+        expect(promptText).toContain('then 24 hours ago would be "2025-06-10T15:04:00Z"');
+      });
+
       it('should include thread details when includeThreads is true', async () => {
         const request = {
           method: 'prompts/get',

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -443,7 +443,7 @@ Note: The exact tag names may vary by organization. Common urgent tag variations
 
 2. Calculate the timestamp ${hours} hours ago from the current time.
    - Subtract ${hours} hours from the current timestamp
-   - Example: If current time is "2025-06-11T15:04:00Z" and hours is 24,
+   - Example: If current time is "2025-06-11T15:04:00Z" and hours is ${hours},
      then ${hours} hours ago would be "${this.exampleHoursAgo(hours)}"
 
 3. Search for conversations in the specified inbox using the "searchConversations" tool:

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -9,6 +9,13 @@ export class PromptHandler {
       .join('\n');
   }
 
+  private exampleHoursAgo(hours: number): string {
+    const exampleNow = new Date('2025-06-11T15:04:00Z');
+    return new Date(exampleNow.getTime() - hours * 60 * 60 * 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+  }
+
   private parsePositiveHours(value: unknown): number | null {
     if (typeof value !== 'number' && typeof value !== 'string') {
       return null;
@@ -436,8 +443,8 @@ Note: The exact tag names may vary by organization. Common urgent tag variations
 
 2. Calculate the timestamp ${hours} hours ago from the current time.
    - Subtract ${hours} hours from the current timestamp
-   - Example: If current time is "2025-06-11T15:04:00Z" and hours is 24, 
-     then ${hours} hours ago would be "${new Date(new Date().getTime() - hours * 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z')}"
+   - Example: If current time is "2025-06-11T15:04:00Z" and hours is 24,
+     then ${hours} hours ago would be "${this.exampleHoursAgo(hours)}"
 
 3. Search for conversations in the specified inbox using the "searchConversations" tool:
    \`\`\`json

--- a/tests/test-docker.cjs
+++ b/tests/test-docker.cjs
@@ -11,7 +11,7 @@ const MCP_RESPONSE_TIMEOUT_MS = 30_000;
 function loadEnvFile() {
   const envPath = path.join(__dirname, '..', '.env');
   if (!fs.existsSync(envPath)) {
-    throw new Error('Missing .env file. Copy .env.example to .env and add Help Scout OAuth credentials.');
+    return process.env;
   }
 
   const env = {};
@@ -288,3 +288,4 @@ if (require.main === module) {
 }
 
 module.exports = DockerLiveTester;
+module.exports.loadEnvFile = loadEnvFile;


### PR DESCRIPTION
## Summary
- Make the live Docker smoke test usable with environment-provided Help Scout credentials when no local `.env` file exists.
- Fix the `list-inbox-activity` prompt so its timestamp example is deterministic and internally consistent.
- Add focused regressions for both release-gate behaviors.

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand --silent`
- `npm pack --dry-run`
- package tarball install smoke
- `npm run mcpb:build`
- `npm run test:contract`
- `npm run test:docker:ci`
- `npm run test:docker`
- `HELPSCOUT_DOCS_API_KEY=... npm run dogfood:seed`
- `npm run dogfood:full` with Docs fixtures pinned
- Security baseline comparison: no new findings against `main`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->