### PR TITLE
refactor: request-scoped Help Scout client seam (NAS-1488)

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+
+// The last test imports the real axios client, whose config module needs
+// credentials at load time.
+process.env.HELPSCOUT_CLIENT_ID = process.env.HELPSCOUT_CLIENT_ID || 'test-client-id';
+process.env.HELPSCOUT_CLIENT_SECRET = process.env.HELPSCOUT_CLIENT_SECRET || 'test-client-secret';
+
+import {
+  getClient,
+  setDefaultHelpScoutApi,
+  withHelpScoutApi,
+  type HelpScoutApi,
+} from '../utils/api.js';
+
+function stubApi(label: string): HelpScoutApi {
+  const unreachable = () => Promise.reject(new Error(`unexpected call on ${label}`));
+  return {
+    get: unreachable,
+    getAllPages: unreachable,
+    getRaw: unreachable,
+    post: unreachable,
+    put: unreachable,
+    patch: unreachable,
+    delete: unreachable,
+    // Not part of HelpScoutApi; lets assertions tell instances apart.
+    ...( { label } as object ),
+  } as HelpScoutApi;
+}
+
+function labelOf(api: HelpScoutApi): string {
+  return (api as unknown as { label: string }).label;
+}
+
+describe('Help Scout client seam', () => {
+  it('refuses to resolve when no client has been configured', async () => {
+    jest.resetModules();
+    const fresh = await import('../utils/api.js');
+    expect(() => fresh.getClient()).toThrow('No Help Scout client is configured');
+  });
+
+  it('resolves the process default outside any request context', () => {
+    setDefaultHelpScoutApi(stubApi('default'));
+    expect(labelOf(getClient())).toBe('default');
+  });
+
+  it('carries a request-scoped client across awaits and restores the default after', async () => {
+    setDefaultHelpScoutApi(stubApi('default'));
+    const scoped = stubApi('user-scoped');
+
+    const seenInside = await withHelpScoutApi(scoped, async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      return labelOf(getClient());
+    });
+
+    expect(seenInside).toBe('user-scoped');
+    expect(labelOf(getClient())).toBe('default');
+  });
+
+  it('isolates concurrent request contexts from each other', async () => {
+    setDefaultHelpScoutApi(stubApi('default'));
+
+    const [a, b] = await Promise.all([
+      withHelpScoutApi(stubApi('user-a'), async () => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        return labelOf(getClient());
+      }),
+      withHelpScoutApi(stubApi('user-b'), async () => {
+        return labelOf(getClient());
+      }),
+    ]);
+
+    expect(a).toBe('user-a');
+    expect(b).toBe('user-b');
+  });
+
+  it('registers the stdio singleton as the default when the client module loads', async () => {
+    jest.resetModules();
+    const fresh = await import('../utils/api.js');
+    const { helpScoutClient } = await import('../utils/helpscout-client.js');
+    expect(fresh.getClient()).toBe(helpScoutClient);
+  });
+});

--- a/src/__tests__/customer-org-tools.test.ts
+++ b/src/__tests__/customer-org-tools.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the handler modules no longer import it themselves.
+import '../utils/helpscout-client.js';
 import { ToolHandler } from '../tools/index.js';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { cache } from '../utils/cache.js';

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the handler modules no longer import it themselves.
+import '../utils/helpscout-client.js';
 import { ToolHandler } from '../tools/index.js';
 import {
   GatewayHandler,

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the handler modules no longer import it themselves.
+import '../utils/helpscout-client.js';
 import { ToolHandler } from '../tools/index.js';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 

--- a/src/__tests__/resources.test.ts
+++ b/src/__tests__/resources.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the handler modules no longer import it themselves.
+import '../utils/helpscout-client.js';
 import { ResourceHandler } from '../resources/index.js';
 import { cache } from '../utils/cache.js';
 import { config } from '../utils/config.js';

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the handler modules no longer import it themselves.
+import '../utils/helpscout-client.js';
 import { ToolHandler } from '../tools/index.js';
 import { cache } from '../utils/cache.js';
 import { config } from '../utils/config.js';

--- a/src/__tests__/v1.6-edge-cases.test.ts
+++ b/src/__tests__/v1.6-edge-cases.test.ts
@@ -167,6 +167,9 @@ describe('v1.6.0 Edge Cases', () => {
 
       // Fresh import
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });
@@ -441,6 +444,9 @@ describe('v1.6.0 Edge Cases', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });
@@ -537,6 +543,9 @@ describe('v1.6.0 Edge Cases', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });

--- a/src/__tests__/v1.6-stress.test.ts
+++ b/src/__tests__/v1.6-stress.test.ts
@@ -48,6 +48,9 @@ describe('v1.6.0 Stress Tests', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });
@@ -129,6 +132,9 @@ describe('v1.6.0 Stress Tests', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });
@@ -291,6 +297,9 @@ describe('v1.6.0 Stress Tests', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });
@@ -360,6 +369,9 @@ describe('v1.6.0 Stress Tests', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });
@@ -452,6 +464,9 @@ describe('v1.6.0 Stress Tests', () => {
         });
 
       jest.resetModules();
+      // The tool layer no longer loads the axios client; import it so the
+      // fresh module registry registers the default behind getClient().
+      await import('../utils/helpscout-client.js');
       const toolsModule = await import('../tools/index.js');
       toolHandler = toolsModule.toolHandler;
     });

--- a/src/__tests__/writes.test.ts
+++ b/src/__tests__/writes.test.ts
@@ -1,4 +1,7 @@
 import nock from 'nock';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the handler modules no longer import it themselves.
+import '../utils/helpscout-client.js';
 import { WriteHandler, WriteOperation } from '../tools/writes.js';
 import { cache } from '../utils/cache.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,5 +1,5 @@
 import { TextResourceContents, Resource } from '@modelcontextprotocol/sdk/types.js';
-import { helpScoutClient, PaginatedResponse } from '../utils/helpscout-client.js';
+import { getClient, type PaginatedResponse } from '../utils/api.js';
 import { Inbox, Conversation, Thread, ServerTime } from '../schema/types.js';
 import { logger } from '../utils/logger.js';
 import { config } from '../utils/config.js';
@@ -56,7 +56,7 @@ export class ResourceHandler {
 
   private async getInboxesResource(uri: string, params: Record<string, string>): Promise<TextResourceContents> {
     try {
-      const response = await helpScoutClient.get<PaginatedResponse<Inbox>>('/mailboxes', {
+      const response = await getClient().get<PaginatedResponse<Inbox>>('/mailboxes', {
         page: parseResourceIntegerParam(params, 'page', 1, 1, 10000),
         size: parseResourceIntegerParam(params, 'size', 50, 1, 50),
       });
@@ -90,7 +90,7 @@ export class ResourceHandler {
       if (params.tag) queryParams.tag = params.tag;
       if (params.modifiedSince) queryParams.modifiedSince = params.modifiedSince;
 
-      const response = await helpScoutClient.get<PaginatedResponse<Conversation>>('/conversations', queryParams);
+      const response = await getClient().get<PaginatedResponse<Conversation>>('/conversations', queryParams);
 
       const conversations = response._embedded?.conversations || [];
 
@@ -119,7 +119,7 @@ export class ResourceHandler {
     }
 
     try {
-      const response = await helpScoutClient.get<PaginatedResponse<Thread>>(`/conversations/${conversationId}/threads`, {
+      const response = await getClient().get<PaginatedResponse<Thread>>(`/conversations/${conversationId}/threads`, {
         page: parseResourceIntegerParam(params, 'page', 1, 1, 10000),
         size: parseResourceIntegerParam(params, 'size', 50, 1, 50),
       });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,5 @@
 import { Tool, CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { PaginatedResponse, helpScoutClient } from '../utils/helpscout-client.js';
+import { getClient, type PaginatedResponse } from '../utils/api.js';
 import { DocsCollectionEnvelope, helpScoutDocsClient } from '../utils/helpscout-docs-client.js';
 import { createMcpToolError, isApiError } from '../utils/mcp-errors.js';
 import { HelpScoutAPIConstraints, ToolCallContext } from '../utils/api-constraints.js';
@@ -1650,7 +1650,7 @@ export class ToolHandler {
       // The v2 API returns fixed 25-item pages and ignores size=, so `limit`
       // acts as a per-call cap here: slice below 25 and flag it, and callers
       // wanting more than one page follow nextPage.
-      const response = await helpScoutClient.get<PaginatedResponse<Conversation>>('/conversations', {
+      const response = await getClient().get<PaginatedResponse<Conversation>>('/conversations', {
         ...baseParams,
         status: input.status,
       });
@@ -1772,7 +1772,7 @@ export class ToolHandler {
     // includeSystemActors routes to the v3 conversation endpoint, which
     // preserves the user/team/system_user person types (v2 collapses
     // system_user into user).
-    const conversation = await helpScoutClient.get<Record<string, unknown>>(
+    const conversation = await getClient().get<Record<string, unknown>>(
       input.includeSystemActors
         ? this.buildV3ApiUrl(`/conversations/${input.conversationId}`)
         : `/conversations/${input.conversationId}`,
@@ -1806,7 +1806,7 @@ export class ToolHandler {
     const input = GetConversationSummaryInputSchema.parse(args);
     
     // Get conversation details
-    const conversation = await helpScoutClient.get<Conversation>(`/conversations/${input.conversationId}`);
+    const conversation = await getClient().get<Conversation>(`/conversations/${input.conversationId}`);
     
     // Get ALL threads to find first customer message and latest staff reply.
     // The endpoint is 25/page and ignores `size`, so a single call would only
@@ -1815,7 +1815,7 @@ export class ToolHandler {
     // and an unbounded loop over a huge conversation risks rate limits and
     // client timeouts. The truncated flag tells callers when the summary was
     // computed over a partial thread set.
-    const { items: threads, truncated: threadsTruncated } = await helpScoutClient.getAllPages<Thread>(
+    const { items: threads, truncated: threadsTruncated } = await getClient().getAllPages<Thread>(
       `/conversations/${input.conversationId}/threads`,
       'threads',
       {},
@@ -1878,7 +1878,7 @@ export class ToolHandler {
     // includeSystemActors routes to the v3 threads endpoint, which preserves the
     // user/team/system_user person types (v2 collapses system_user into user).
     if (input.includeSystemActors) {
-      const { items: threads, totalElements, truncated } = await helpScoutClient.getAllPages<Record<string, unknown>>(
+      const { items: threads, totalElements, truncated } = await getClient().getAllPages<Record<string, unknown>>(
         this.buildV3ApiUrl(`/conversations/${input.conversationId}/threads`),
         'threads',
         { page: input.page },
@@ -1907,7 +1907,7 @@ export class ToolHandler {
       };
     }
 
-    const { items: threads, totalElements, truncated } = await helpScoutClient.getAllPages<Thread>(
+    const { items: threads, totalElements, truncated } = await getClient().getAllPages<Thread>(
       `/conversations/${input.conversationId}/threads`,
       'threads',
       { page: input.page },
@@ -1961,7 +1961,7 @@ export class ToolHandler {
     // "List ALL inboxes" must mean all: /mailboxes is 50/page and ignores
     // `size`, so loop pages up to `limit` instead of returning only the first 50
     // and mislabeling it as the total.
-    const { items: allInboxes, totalElements, truncated } = await helpScoutClient.getAllPages<Inbox>(
+    const { items: allInboxes, totalElements, truncated } = await getClient().getAllPages<Inbox>(
       '/mailboxes',
       'mailboxes',
       {},
@@ -2005,7 +2005,7 @@ export class ToolHandler {
 
   private async getInbox(args: unknown): Promise<CallToolResult> {
     const input = GetInboxInputSchema.parse(args);
-    const inbox = await helpScoutClient.get<Inbox>(`/mailboxes/${input.inboxId}`);
+    const inbox = await getClient().get<Inbox>(`/mailboxes/${input.inboxId}`);
 
     const payload: Record<string, unknown> = {
       inbox,
@@ -2055,7 +2055,7 @@ export class ToolHandler {
   ): Promise<Record<string, unknown>> {
     switch (part) {
       case 'fields': {
-        const response = await helpScoutClient.get<PaginatedResponse<InboxCustomField>>(`/mailboxes/${inboxId}/fields`);
+        const response = await getClient().get<PaginatedResponse<InboxCustomField>>(`/mailboxes/${inboxId}/fields`);
         const fields = response._embedded?.fields || [];
         return {
           customFields: {
@@ -2066,7 +2066,7 @@ export class ToolHandler {
         };
       }
       case 'folders': {
-        const response = await helpScoutClient.get<PaginatedResponse<InboxFolder>>(`/mailboxes/${inboxId}/folders`);
+        const response = await getClient().get<PaginatedResponse<InboxFolder>>(`/mailboxes/${inboxId}/folders`);
         const folders = response._embedded?.folders || [];
         return {
           folders: {
@@ -2077,7 +2077,7 @@ export class ToolHandler {
         };
       }
       case 'routing': {
-        const routing = await helpScoutClient.get<InboxRouting>(`/mailboxes/${inboxId}/routing`, undefined, { ttl: 300 });
+        const routing = await getClient().get<InboxRouting>(`/mailboxes/${inboxId}/routing`, undefined, { ttl: 300 });
         return { routing };
       }
     }
@@ -2085,7 +2085,7 @@ export class ToolHandler {
 
   private async listTags(args: unknown): Promise<CallToolResult> {
     const input = ListTagsInputSchema.parse(args);
-    const response = await helpScoutClient.get<PaginatedResponse<Tag>>('/tags', {
+    const response = await getClient().get<PaginatedResponse<Tag>>('/tags', {
       page: input.page,
     });
 
@@ -2114,7 +2114,7 @@ export class ToolHandler {
 
   private async listCustomerProperties(args: unknown): Promise<CallToolResult> {
     ListCustomerPropertiesInputSchema.parse(args);
-    const response = await helpScoutClient.get<{
+    const response = await getClient().get<{
       _embedded?: { 'customer-properties'?: PropertyDefinition[] };
     }>('/customer-properties');
     const properties = response._embedded?.['customer-properties'] || [];
@@ -2135,7 +2135,7 @@ export class ToolHandler {
 
   private async listOrganizationProperties(args: unknown): Promise<CallToolResult> {
     ListOrganizationPropertiesInputSchema.parse(args);
-    const response = await helpScoutClient.get<{
+    const response = await getClient().get<{
       _embedded?: { 'organization-properties'?: PropertyDefinition[] };
     }>('/organizations/properties');
     const properties = response._embedded?.['organization-properties'] || [];
@@ -2156,7 +2156,7 @@ export class ToolHandler {
 
   private async getOrganizationProperty(args: unknown): Promise<CallToolResult> {
     const input = GetOrganizationPropertyInputSchema.parse(args);
-    const property = await helpScoutClient.get<PropertyDefinition>(`/organizations/properties/${input.slug}`);
+    const property = await getClient().get<PropertyDefinition>(`/organizations/properties/${input.slug}`);
 
     return {
       content: [{
@@ -2173,7 +2173,7 @@ export class ToolHandler {
 
   private async getTag(args: unknown): Promise<CallToolResult> {
     const input = GetTagInputSchema.parse(args);
-    const tag = await helpScoutClient.get<Tag>(`/tags/${input.tagId}`);
+    const tag = await getClient().get<Tag>(`/tags/${input.tagId}`);
 
     return {
       content: [{
@@ -2194,7 +2194,7 @@ export class ToolHandler {
     // does not expose. It supersedes the standard-user listing and ignores
     // includeStatuses (statuses do not apply to system actors).
     if (input.includeSystemActors) {
-      const response = await helpScoutClient.get<PaginatedResponse<SystemUser>>(
+      const response = await getClient().get<PaginatedResponse<SystemUser>>(
         this.buildV3ApiUrl('/system-users'),
         { page: input.page }
       );
@@ -2224,9 +2224,9 @@ export class ToolHandler {
     // includeStatuses additionally calls /users/status ONCE (it returns all
     // user statuses in a single call). We never fan out per user.
     const [usersResponse, statusesResult] = await Promise.allSettled([
-      helpScoutClient.get<PaginatedResponse<User>>('/users', params),
+      getClient().get<PaginatedResponse<User>>('/users', params),
       input.includeStatuses
-        ? helpScoutClient.get<PaginatedResponse<UserStatus>>('/users/status', { page: 1 })
+        ? getClient().get<PaginatedResponse<UserStatus>>('/users/status', { page: 1 })
         : Promise.resolve(null),
     ]);
 
@@ -2278,7 +2278,7 @@ export class ToolHandler {
     // returns the system actor record (v2 /users collapses these). It takes
     // precedence over includeStatus, which does not apply to system actors.
     if (input.includeSystemActors) {
-      const systemUser = await helpScoutClient.get<SystemUser>(
+      const systemUser = await getClient().get<SystemUser>(
         this.buildV3ApiUrl(`/system-users/${input.userId}`)
       );
 
@@ -2304,9 +2304,9 @@ export class ToolHandler {
     // includeStatus adds the /users/{id}/status sub-fetch. Surface a per-call
     // error rather than failing the whole call if only the status lookup fails.
     const [userResult, statusResult] = await Promise.allSettled([
-      helpScoutClient.get<User>(path),
+      getClient().get<User>(path),
       input.includeStatus
-        ? helpScoutClient.get<UserStatus>(
+        ? getClient().get<UserStatus>(
             input.userId === 'me' ? '/users/me/status' : `/users/${input.userId}/status`
           )
         : Promise.resolve(null),
@@ -2342,7 +2342,7 @@ export class ToolHandler {
 
   private async listTeams(args: unknown): Promise<CallToolResult> {
     const input = ListTeamsInputSchema.parse(args);
-    const response = await helpScoutClient.get<PaginatedResponse<Team>>('/teams', {
+    const response = await getClient().get<PaginatedResponse<Team>>('/teams', {
       page: input.page,
     });
     const teams = response._embedded?.teams || [];
@@ -2365,7 +2365,7 @@ export class ToolHandler {
 
   private async getTeamMembers(args: unknown): Promise<CallToolResult> {
     const input = GetTeamMembersInputSchema.parse(args);
-    const response = await helpScoutClient.get<PaginatedResponse<User>>(`/teams/${input.teamId}/members`, {
+    const response = await getClient().get<PaginatedResponse<User>>(`/teams/${input.teamId}/members`, {
       page: input.page,
     });
     const members = response._embedded?.users || [];
@@ -2389,7 +2389,7 @@ export class ToolHandler {
 
   private async listSavedReplies(args: unknown): Promise<CallToolResult> {
     const input = ListSavedRepliesInputSchema.parse(args);
-    const response = await helpScoutClient.get<SavedReply[] | PaginatedResponse<SavedReply>>(
+    const response = await getClient().get<SavedReply[] | PaginatedResponse<SavedReply>>(
       `/mailboxes/${input.inboxId}/saved-replies`,
       { includeChatReplies: input.includeChatReplies }
     );
@@ -2417,7 +2417,7 @@ export class ToolHandler {
 
   private async getSavedReply(args: unknown): Promise<CallToolResult> {
     const input = GetSavedReplyInputSchema.parse(args);
-    const savedReply = await helpScoutClient.get<SavedReply>(`/mailboxes/${input.inboxId}/saved-replies/${input.replyId}`);
+    const savedReply = await getClient().get<SavedReply>(`/mailboxes/${input.inboxId}/saved-replies/${input.replyId}`);
 
     return {
       content: [{
@@ -2453,7 +2453,7 @@ export class ToolHandler {
 
     // The Help Scout endpoint selects format via the Accept header.
     if (input.format === 'rfc822') {
-      const response = await helpScoutClient.getRaw<string>(endpoint, undefined, {
+      const response = await getClient().getRaw<string>(endpoint, undefined, {
         responseType: 'text',
         headers: { Accept: 'message/rfc822' },
       });
@@ -2474,7 +2474,7 @@ export class ToolHandler {
       };
     }
 
-    const originalSource = await helpScoutClient.get<Record<string, unknown>>(endpoint);
+    const originalSource = await getClient().get<Record<string, unknown>>(endpoint);
     return {
       content: [{
         type: 'text',
@@ -2491,7 +2491,7 @@ export class ToolHandler {
 
   private async getAttachment(args: unknown): Promise<CallToolResult> {
     const input = GetAttachmentInputSchema.parse(args);
-    const attachment = await helpScoutClient.get<Record<string, unknown>>(
+    const attachment = await getClient().get<Record<string, unknown>>(
       `/conversations/${input.conversationId}/attachments/${input.attachmentId}/data`,
       undefined,
       { ttl: 0 }
@@ -2516,7 +2516,7 @@ export class ToolHandler {
 
   private async downloadAttachmentFile(args: unknown): Promise<CallToolResult> {
     const input = DownloadAttachmentFileInputSchema.parse(args);
-    const response = await helpScoutClient.getRaw<Buffer>(
+    const response = await getClient().getRaw<Buffer>(
       `/conversations/${input.conversationId}/attachments/${input.attachmentId}/file`,
       undefined,
       { responseType: 'arraybuffer' }
@@ -2549,7 +2549,7 @@ export class ToolHandler {
 
   private async listWorkflows(args: unknown): Promise<CallToolResult> {
     const input = ListWorkflowsInputSchema.parse(args);
-    const response = await helpScoutClient.get<PaginatedResponse<Workflow>>('/workflows', {
+    const response = await getClient().get<PaginatedResponse<Workflow>>('/workflows', {
       page: input.page,
     });
     const workflows = response._embedded?.workflows || [];
@@ -2572,7 +2572,7 @@ export class ToolHandler {
 
   private async listWebhooks(args: unknown): Promise<CallToolResult> {
     const input = ListWebhooksInputSchema.parse(args);
-    const response = await helpScoutClient.get<PaginatedResponse<Webhook>>('/webhooks', {
+    const response = await getClient().get<PaginatedResponse<Webhook>>('/webhooks', {
       page: input.page,
     });
     const webhooks = response._embedded?.webhooks || [];
@@ -2595,7 +2595,7 @@ export class ToolHandler {
 
   private async getWebhook(args: unknown): Promise<CallToolResult> {
     const input = GetWebhookInputSchema.parse(args);
-    const webhook = await helpScoutClient.get<Webhook>(`/webhooks/${input.webhookId}`);
+    const webhook = await getClient().get<Webhook>(`/webhooks/${input.webhookId}`);
 
     return {
       content: [{
@@ -2610,7 +2610,7 @@ export class ToolHandler {
 
   private async getSatisfactionRating(args: unknown): Promise<CallToolResult> {
     const input = GetSatisfactionRatingInputSchema.parse(args);
-    const rating = await helpScoutClient.get<SatisfactionRating>(`/ratings/${input.ratingId}`);
+    const rating = await getClient().get<SatisfactionRating>(`/ratings/${input.ratingId}`);
 
     return {
       content: [{
@@ -2629,18 +2629,18 @@ export class ToolHandler {
     switch (input.report) {
       case 'customers-helped': {
         const params = this.buildReportQueryParamsWithExtras(input, ['viewBy']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/company/customers-helped', params);
+        const report = await getClient().get<ReportResponse>('/reports/company/customers-helped', params);
         return this.formatReportResult('companyCustomersHelped', params, report);
       }
       case 'drilldown': {
         const params = this.buildReportQueryParamsWithExtras(input, ['page', 'rows', 'range', 'rangeId']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/company/drilldown', params);
+        const report = await getClient().get<ReportResponse>('/reports/company/drilldown', params);
         return this.formatReportResult('companyDrilldown', params, report);
       }
       case 'overall':
       default: {
         const params = this.buildReportQueryParams(input);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/company', params);
+        const report = await getClient().get<ReportResponse>('/reports/company', params);
         return this.formatReportResult('company', params, report);
       }
     }
@@ -2651,43 +2651,43 @@ export class ToolHandler {
     switch (input.report) {
       case 'volume-by-channel': {
         const params = this.buildReportQueryParamsWithExtras(input, ['viewBy']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/volume-by-channel', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/volume-by-channel', params);
         return this.formatReportResult('conversationVolumeByChannel', params, report);
       }
       case 'busy-times': {
         const params = this.buildReportQueryParams(input);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/busy-times', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/busy-times', params);
         return this.formatReportResult('conversationBusyTimes', params, report);
       }
       case 'drilldown': {
         const params = this.buildReportQueryParamsWithExtras(input, ['page', 'rows']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/drilldown', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/drilldown', params);
         return this.formatReportResult('conversationDrilldown', params, report);
       }
       case 'fields-drilldown': {
         const params = this.buildReportQueryParamsWithExtras(input, ['field', 'fieldid', 'page', 'rows']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/fields-drilldown', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/fields-drilldown', params);
         return this.formatReportResult('conversationFieldDrilldown', params, report);
       }
       case 'new': {
         const params = this.buildReportQueryParamsWithExtras(input, ['viewBy']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/new', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/new', params);
         return this.formatReportResult('conversationNew', params, report);
       }
       case 'new-drilldown': {
         const params = this.buildReportQueryParamsWithExtras(input, ['page', 'rows']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/new-drilldown', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/new-drilldown', params);
         return this.formatReportResult('conversationNewDrilldown', params, report);
       }
       case 'received-messages': {
         const params = this.buildReportQueryParamsWithExtras(input, ['viewBy']);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations/received-messages', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations/received-messages', params);
         return this.formatReportResult('conversationReceivedMessages', params, report);
       }
       case 'overall':
       default: {
         const params = this.buildReportQueryParams(input);
-        const report = await helpScoutClient.get<ReportResponse>('/reports/conversations', params);
+        const report = await getClient().get<ReportResponse>('/reports/conversations', params);
         return this.formatReportResult('conversations', params, report);
       }
     }
@@ -2705,7 +2705,7 @@ export class ToolHandler {
       'overall': { path: '/reports/productivity', reportType: 'productivity' },
     };
     const { path, reportType } = map[input.report] ?? map.overall;
-    const report = await helpScoutClient.get<ReportResponse>(path, params);
+    const report = await getClient().get<ReportResponse>(path, params);
     return this.formatReportResult(reportType, params, report);
   }
 
@@ -2724,7 +2724,7 @@ export class ToolHandler {
       'overall': { path: '/reports/user', reportType: 'user' },
     };
     const { path, reportType } = map[input.report] ?? map.overall;
-    const report = await helpScoutClient.get<ReportResponse>(path, params);
+    const report = await getClient().get<ReportResponse>(path, params);
     return this.formatReportResult(reportType, params, report);
   }
 
@@ -2738,25 +2738,25 @@ export class ToolHandler {
         sortOrder: input.sortOrder ?? 'DESC',
         ...(input.rating ? { rating: input.rating } : {}),
       };
-      const report = await helpScoutClient.get<HappinessRatingsReport>('/reports/happiness/ratings', params);
+      const report = await getClient().get<HappinessRatingsReport>('/reports/happiness/ratings', params);
       return this.formatReportResult('happinessRatings', params, report);
     }
     const params = this.buildReportQueryParams(input);
-    const report = await helpScoutClient.get<ReportResponse>('/reports/happiness', params);
+    const report = await getClient().get<ReportResponse>('/reports/happiness', params);
     return this.formatReportResult('happiness', params, report);
   }
 
   private async getChannelReport(args: unknown): Promise<CallToolResult> {
     const input = GetChannelReportInputSchemaUnion.parse(args);
     const params = this.buildReportQueryParamsWithExtras(input, ['officeHours']);
-    const report = await helpScoutClient.get<ReportResponse>(`/reports/${input.channel}`, params);
+    const report = await getClient().get<ReportResponse>(`/reports/${input.channel}`, params);
     return this.formatReportResult(input.channel, params, report);
   }
 
   private async getDocsReport(args: unknown): Promise<CallToolResult> {
     const input = GetDocsReportInputSchema.parse(args);
     const params = this.buildReportQueryParamsWithExtras(input);
-    const report = await helpScoutClient.get<ReportResponse>('/reports/docs', params);
+    const report = await getClient().get<ReportResponse>('/reports/docs', params);
 
     return this.formatReportResult('docs', params, report);
   }
@@ -3133,7 +3133,7 @@ export class ToolHandler {
   }> {
     const results = await Promise.allSettled(
       statuses.map(status =>
-        helpScoutClient.get<PaginatedResponse<Conversation>>('/conversations', {
+        getClient().get<PaginatedResponse<Conversation>>('/conversations', {
           ...baseParams,
           status,
         })
@@ -3294,8 +3294,8 @@ export class ToolHandler {
 
     // Fetch customer profile and address in parallel
     const [customerResponse, addressResponse] = await Promise.allSettled([
-      helpScoutClient.get<Customer>(`/customers/${input.customerId}`),
-      helpScoutClient.get<CustomerAddress>(`/customers/${input.customerId}/address`),
+      getClient().get<Customer>(`/customers/${input.customerId}`),
+      getClient().get<CustomerAddress>(`/customers/${input.customerId}/address`),
     ]);
 
     if (customerResponse.status === 'rejected') {
@@ -3394,7 +3394,7 @@ export class ToolHandler {
       modifiedSince: this.normalizeApiDateParam(input.modifiedSince),
     };
 
-    const response = await helpScoutClient.get<PaginatedResponse<Customer>>('/customers', params);
+    const response = await getClient().get<PaginatedResponse<Customer>>('/customers', params);
     const customers = response._embedded?.customers || [];
 
     // Slim view: strip _links and _embedded to keep response concise for browsing.
@@ -3446,7 +3446,7 @@ export class ToolHandler {
     nextCursor?: string;
   }> {
     const v3Url = this.buildV3ApiUrl('/customers');
-    const v3Response = await helpScoutClient.get<{
+    const v3Response = await getClient().get<{
       _embedded: { customers: Customer[] };
       _links?: { self?: { href: string }; first?: { href: string }; next?: { href: string } };
     }>(v3Url, params);
@@ -3511,12 +3511,12 @@ export class ToolHandler {
 
     // Fetch all 6 sub-resources in parallel via dedicated endpoints
     const [emailsRes, phonesRes, chatsRes, socialRes, websitesRes, addressRes] = await Promise.allSettled([
-      helpScoutClient.get<{ _embedded?: { emails?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/emails`),
-      helpScoutClient.get<{ _embedded?: { phones?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/phones`),
-      helpScoutClient.get<{ _embedded?: { chats?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/chats`),
-      helpScoutClient.get<{ _embedded?: Record<string, Array<{ id: number; value: string; type: string }>> }>(`/customers/${cid}/social-profiles`),
-      helpScoutClient.get<{ _embedded?: { websites?: Array<{ id: number; value: string }> } }>(`/customers/${cid}/websites`),
-      helpScoutClient.get<CustomerAddress>(`/customers/${cid}/address`),
+      getClient().get<{ _embedded?: { emails?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/emails`),
+      getClient().get<{ _embedded?: { phones?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/phones`),
+      getClient().get<{ _embedded?: { chats?: Array<{ id: number; value: string; type: string }> } }>(`/customers/${cid}/chats`),
+      getClient().get<{ _embedded?: Record<string, Array<{ id: number; value: string; type: string }>> }>(`/customers/${cid}/social-profiles`),
+      getClient().get<{ _embedded?: { websites?: Array<{ id: number; value: string }> } }>(`/customers/${cid}/websites`),
+      getClient().get<CustomerAddress>(`/customers/${cid}/address`),
     ]);
 
     // Helper: extract data or note the error
@@ -3591,7 +3591,7 @@ export class ToolHandler {
     if (input.includeCounts) params.includeCounts = true;
     if (input.includeProperties) params.includeProperties = true;
 
-    const org = await helpScoutClient.get<Organization>(
+    const org = await getClient().get<Organization>(
       `/organizations/${input.organizationId}`,
       params
     );
@@ -3613,7 +3613,7 @@ export class ToolHandler {
     const input = ListOrganizationsInputSchema.parse(args);
 
     // v2 API: page size is fixed at 50
-    const response = await helpScoutClient.get<PaginatedResponse<Organization>>('/organizations', {
+    const response = await getClient().get<PaginatedResponse<Organization>>('/organizations', {
       page: input.page,
       sort: `${input.sortField},${input.sortOrder}`,
     });
@@ -3639,7 +3639,7 @@ export class ToolHandler {
     const input = GetOrganizationMembersInputSchema.parse(args);
 
     // v2 API: page size is fixed at 50
-    const response = await helpScoutClient.get<PaginatedResponse<Customer>>(
+    const response = await getClient().get<PaginatedResponse<Customer>>(
       `/organizations/${input.organizationId}/customers`,
       { page: input.page }
     );
@@ -3665,7 +3665,7 @@ export class ToolHandler {
     const input = GetOrganizationConversationsInputSchema.parse(args);
 
     // v2 API: page size is fixed at 50
-    const response = await helpScoutClient.get<PaginatedResponse<Conversation>>(
+    const response = await getClient().get<PaginatedResponse<Conversation>>(
       `/organizations/${input.organizationId}/conversations`,
       { page: input.page }
     );

--- a/src/tools/writes.ts
+++ b/src/tools/writes.ts
@@ -6,10 +6,10 @@ import { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod/v4';
 import {
   HelpScoutWriteError,
-  WriteMethod,
-  WriteResponse,
-  helpScoutClient,
-} from '../utils/helpscout-client.js';
+  getClient,
+  type WriteMethod,
+  type WriteResponse,
+} from '../utils/api.js';
 import { createMcpToolError } from '../utils/mcp-errors.js';
 import { cache } from '../utils/cache.js';
 import { logger } from '../utils/logger.js';
@@ -167,13 +167,13 @@ function conversationPath(conversationId: string): string {
 async function sendPlanned(request: PlannedRequest): Promise<WriteResponse> {
   switch (request.method) {
     case 'POST':
-      return helpScoutClient.post(request.path, request.body);
+      return getClient().post(request.path, request.body);
     case 'PUT':
-      return helpScoutClient.put(request.path, request.body);
+      return getClient().put(request.path, request.body);
     case 'PATCH':
-      return helpScoutClient.patch(request.path, request.body);
+      return getClient().patch(request.path, request.body);
     case 'DELETE':
-      return helpScoutClient.delete(request.path);
+      return getClient().delete(request.path);
   }
 }
 
@@ -203,7 +203,7 @@ function statusOf(error: unknown): number | undefined {
 /** Read the conversation fresh: a merge computed from a cached copy would drop concurrent edits. */
 async function readConversation(conversationId: string): Promise<ConversationReadModel> {
   try {
-    return await helpScoutClient.get<ConversationReadModel>(
+    return await getClient().get<ConversationReadModel>(
       conversationPath(conversationId),
       undefined,
       { ttl: 0 },
@@ -506,7 +506,7 @@ export class WriteHandler {
       },
       perform: async (input) => {
         const customer = await resolveReplyCustomer(input);
-        const response = await helpScoutClient.post(
+        const response = await getClient().post(
           `${conversationPath(input.conversationId)}/reply`,
           buildReplyBody(input, true, customer),
         );
@@ -653,7 +653,7 @@ export class WriteHandler {
         });
         const merged = [...existing, ...added];
 
-        const response = await helpScoutClient.put(
+        const response = await getClient().put(
           `${conversationPath(conversationId)}/tags`,
           { tags: merged },
         );
@@ -697,7 +697,7 @@ export class WriteHandler {
         const remaining = existing.filter((tag) => !removeLower.has(tag.toLowerCase()));
         const removed = existing.filter((tag) => removeLower.has(tag.toLowerCase()));
 
-        const response = await helpScoutClient.put(
+        const response = await getClient().put(
           `${conversationPath(conversationId)}/tags`,
           { tags: remaining },
         );
@@ -763,7 +763,7 @@ export class WriteHandler {
         }
         const fields = Array.from(merged.values());
 
-        const response = await helpScoutClient.put(
+        const response = await getClient().put(
           `${conversationPath(conversationId)}/fields`,
           { fields },
         );
@@ -922,7 +922,7 @@ export class WriteHandler {
       },
       perform: async (input) => {
         const customer = await resolveReplyCustomer(input);
-        const response = await helpScoutClient.post(
+        const response = await getClient().post(
           `${conversationPath(input.conversationId)}/reply`,
           buildReplyBody(input, false, customer),
         );

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,137 @@
+/**
+ * Transport-neutral seam between the capability surface and the Help Scout
+ * HTTP client.
+ *
+ * Tool, write, and resource handlers resolve their client through
+ * `getClient()` instead of importing the axios-backed singleton, so a
+ * request-scoped client (per-user OAuth in a remote deployment) can be swapped
+ * in without touching any call site. The stdio server registers its single
+ * app-wide client as the process default; a remote entry point wraps each
+ * request in `withHelpScoutApi()` and the async context carries that user's
+ * client for everything the request touches, including nested awaits.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type WriteMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * Outcome of a non-idempotent request. Mailbox v2 answers most mutations with
+ * `204 No Content`, so the status and headers carry more than the body does:
+ * `Resource-Id` is the only place a newly created thread ID appears.
+ */
+export interface WriteResponse<T = unknown> {
+  status: number;
+  data: T;
+  headers: Record<string, string>;
+}
+
+/**
+ * Failure of a non-idempotent request, carrying the upstream status so a write
+ * handler can map it to model-correctable guidance.
+ *
+ * Writes deliberately do not reuse `transformError`: that path flattens 403 and
+ * 404 into prose without a status code, and its suggestions promise automatic
+ * retries that writes never perform.
+ */
+export class HelpScoutWriteError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | undefined,
+    readonly body: unknown,
+    readonly method: WriteMethod,
+    readonly path: string,
+    readonly requestId: string,
+  ) {
+    super(message);
+    this.name = 'HelpScoutWriteError';
+  }
+}
+
+export interface PaginatedResponse<T> {
+  _embedded: { [key: string]: T[] };
+  _links?: {
+    next?: { href: string };
+    prev?: { href: string };
+  };
+  page?: {
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    number: number;
+  };
+}
+
+export interface RawGetOptions {
+  responseType?: 'json' | 'text' | 'arraybuffer';
+  headers?: Record<string, string>;
+}
+
+/**
+ * The subset of an HTTP response that raw-format handlers consume. The axios
+ * client's responses satisfy this structurally; a fetch-backed client returns
+ * it directly.
+ */
+export interface RawResponse<T> {
+  status: number;
+  data: T;
+  headers: Record<string, unknown>;
+}
+
+export interface HelpScoutApi {
+  get<T>(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    cacheOptions?: { ttl?: number },
+  ): Promise<T>;
+  getAllPages<T>(
+    endpoint: string,
+    collectionKey: string,
+    params?: Record<string, unknown>,
+    maxItems?: number,
+  ): Promise<{ items: T[]; totalElements: number; pagesFetched: number; truncated: boolean }>;
+  getRaw<T>(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    options?: RawGetOptions,
+  ): Promise<RawResponse<T>>;
+  post<T = unknown>(endpoint: string, body?: unknown): Promise<WriteResponse<T>>;
+  put<T = unknown>(endpoint: string, body?: unknown): Promise<WriteResponse<T>>;
+  patch<T = unknown>(endpoint: string, body?: unknown): Promise<WriteResponse<T>>;
+  delete<T = unknown>(endpoint: string): Promise<WriteResponse<T>>;
+}
+
+const clientStorage = new AsyncLocalStorage<HelpScoutApi>();
+
+let defaultClient: HelpScoutApi | undefined;
+
+/**
+ * Register the process-wide fallback client. The stdio server calls this once
+ * at module load with its app-wide axios client, preserving today's behavior
+ * exactly. A multi-user deployment must NOT rely on the default: it would
+ * execute one user's request with another identity.
+ */
+export function setDefaultHelpScoutApi(client: HelpScoutApi): void {
+  defaultClient = client;
+}
+
+/**
+ * Run `fn` with `client` as the Help Scout client for the whole async call
+ * tree, overriding the process default.
+ */
+export function withHelpScoutApi<T>(client: HelpScoutApi, fn: () => T): T {
+  return clientStorage.run(client, fn);
+}
+
+/**
+ * Resolve the Help Scout client for the current request context: the
+ * async-local client when one is set, otherwise the process default.
+ */
+export function getClient(): HelpScoutApi {
+  const client = clientStorage.getStore() ?? defaultClient;
+  if (!client) {
+    throw new Error(
+      'No Help Scout client is configured. Register one with setDefaultHelpScoutApi() or wrap the request in withHelpScoutApi().',
+    );
+  }
+  return client;
+}

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -1,6 +1,15 @@
-import axios, { AxiosInstance, AxiosResponse, AxiosError, ResponseType } from 'axios';
+import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
+import {
+  HelpScoutWriteError,
+  setDefaultHelpScoutApi,
+  type HelpScoutApi,
+  type PaginatedResponse,
+  type RawGetOptions,
+  type WriteMethod,
+  type WriteResponse,
+} from './api.js';
 
 interface RequestMetadata {
   requestId: string;
@@ -12,11 +21,6 @@ interface RetryConfig {
   retryDelay: number;
   maxRetryDelay: number;
   retryCondition?: (error: AxiosError) => boolean;
-}
-
-interface RawGetOptions {
-  responseType?: ResponseType;
-  headers?: Record<string, string>;
 }
 
 declare module 'axios' {
@@ -52,56 +56,14 @@ const DEFAULT_POOL_CONFIG: ConnectionPoolConfig = {
   keepAliveMsecs: 1000,  // Keep-alive probe interval
 };
 
-export type WriteMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+// The transport-neutral write and pagination types now live in api.ts so the
+// tool surface can depend on them without depending on axios. Re-exported here
+// because this module was their home and existing importers still resolve them
+// from it.
+export { HelpScoutWriteError } from './api.js';
+export type { PaginatedResponse, RawGetOptions, WriteMethod, WriteResponse } from './api.js';
 
-/**
- * Outcome of a non-idempotent request. Mailbox v2 answers most mutations with
- * `204 No Content`, so the status and headers carry more than the body does:
- * `Resource-Id` is the only place a newly created thread ID appears.
- */
-export interface WriteResponse<T = unknown> {
-  status: number;
-  data: T;
-  headers: Record<string, string>;
-}
-
-/**
- * Failure of a non-idempotent request, carrying the upstream status so a write
- * handler can map it to model-correctable guidance.
- *
- * Writes deliberately do not reuse `transformError`: that path flattens 403 and
- * 404 into prose without a status code, and its suggestions promise automatic
- * retries that writes never perform.
- */
-export class HelpScoutWriteError extends Error {
-  constructor(
-    message: string,
-    readonly status: number | undefined,
-    readonly body: unknown,
-    readonly method: WriteMethod,
-    readonly path: string,
-    readonly requestId: string,
-  ) {
-    super(message);
-    this.name = 'HelpScoutWriteError';
-  }
-}
-
-export interface PaginatedResponse<T> {
-  _embedded: { [key: string]: T[] };
-  _links?: {
-    next?: { href: string };
-    prev?: { href: string };
-  };
-  page?: {
-    size: number;
-    totalElements: number;
-    totalPages: number;
-    number: number;
-  };
-}
-
-export class HelpScoutClient {
+export class HelpScoutClient implements HelpScoutApi {
   private client: AxiosInstance;
   private accessToken: string | null = null;
   private tokenExpiresAt: number = 0;
@@ -823,3 +785,8 @@ export class HelpScoutClient {
 
 // Create client instance with connection pool config from environment
 export const helpScoutClient = new HelpScoutClient(config.connectionPool);
+
+// The stdio server runs every request as this one app-wide client, so loading
+// this module is what makes getClient() resolve. A per-user deployment never
+// registers a default and scopes its clients with withHelpScoutApi() instead.
+setDefaultHelpScoutApi(helpScoutClient);

--- a/tests/test-all-tools-edge-cases.ts
+++ b/tests/test-all-tools-edge-cases.ts
@@ -8,6 +8,9 @@
  */
 
 import 'dotenv/config';
+// Load the axios client so it registers itself as the default behind
+// getClient(); the tool layer no longer imports it transitively.
+import '../src/utils/helpscout-client.js';
 import { ToolHandler } from '../src/tools/index.js';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 


### PR DESCRIPTION
## Summary

Introduces a transport-neutral `HelpScoutApi` interface and resolves the concrete client per request through an `AsyncLocalStorage` accessor (`getClient()`) instead of the module-level `helpScoutClient` singleton. Tool, write, and resource handlers (some 80 call sites) now depend only on the seam.

Stdio behavior is byte-identical: loading the client module registers the axios singleton as the process default, so every existing entry point resolves the same client it always used. What this enables is installing a request-scoped client with `withHelpScoutApi()`, which the planned remote deployment needs to run each session under its own user's credentials.

## Changes

- New `src/utils/api.ts`: the `HelpScoutApi` interface, the write/pagination types (moved here so the tool surface no longer depends on axios; the client module re-exports them for existing importers), and the async-local accessor trio (`getClient`, `withHelpScoutApi`, `setDefaultHelpScoutApi`).
- `HelpScoutClient` now `implements HelpScoutApi` and registers itself as the default at module load.
- `src/tools/index.ts`, `src/tools/writes.ts`, `src/resources/index.ts`: mechanical swap from the imported singleton to `getClient()`.
- Nock-driven suites import the client module explicitly (the handlers no longer load it transitively), including after each `jest.resetModules()` in the v1.6 suites.
- New `src/__tests__/api.test.ts` covering the seam contract: unconfigured refusal, default resolution, context carry across awaits, and isolation between concurrent contexts.

## Verification

- `npm run type-check`, `npm run lint`, `npm run build` clean
- Full jest: 528 passed; the two local failures are pre-existing environment issues (the documented local node shim in package-scripts, and a stale extension build artifact that a rebuild clears), both unrelated to this change and covered by CI
- The live dogfood against the real account runs in CI on the dev-to-main release PR, which is the behavioral gate for this change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->