### PR TITLE
feat: fetch-based Help Scout client for the Workers build (NAS-1490)

### DIFF
--- a/src/__tests__/helpscout-fetch-client.test.ts
+++ b/src/__tests__/helpscout-fetch-client.test.ts
@@ -3,6 +3,7 @@ import {
   HelpScoutFetchClient,
   RefreshMutex,
   ReauthRequiredError,
+  TokenPersistenceError,
   type FetchClientDeps,
   type UserTokenContext,
 } from '../worker/helpscout-fetch-client.js';
@@ -550,6 +551,96 @@ describe('HelpScoutFetchClient', () => {
       // must still get its post-refresh retry rather than running the loop out.
       await expect(promise).resolves.toEqual({ ok: true });
       expect(apiCalls).toBe(5);
+    });
+
+    it('does not repeat the exchange when persisting the rotated pair fails', async () => {
+      // Near expiry so the proactive refresh fires before the read.
+      const { client, persistTokens } = makeHarness({}, { expiresAt: Date.now() + 1000 });
+      persistTokens.mockRejectedValue(new Error('KV write failed'));
+      let tokenCalls = 0;
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          tokenCalls++;
+          return jsonResponse({ access_token: 'access-2', refresh_token: 'refresh-2', expires_in: 172800 });
+        }
+        return jsonResponse({ ok: true });
+      });
+
+      const error = (await client.get('/conversations/1').catch((e) => e)) as TokenPersistenceError;
+
+      // The old refresh token is already spent; a retry would exchange it
+      // again and manufacture an invalid_grant on top of a storage failure.
+      expect(error).toBeInstanceOf(TokenPersistenceError);
+      expect(error).not.toBeInstanceOf(ReauthRequiredError);
+      expect(tokenCalls).toBe(1);
+    });
+
+    it('does not tell the user to reconnect when the deployment credentials are rejected', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          return jsonResponse({ error: 'invalid_client' }, 401);
+        }
+        return jsonResponse({ error: 'unauthorized' }, 401);
+      });
+
+      const error = (await client.get('/conversations/1').catch((e) => e)) as { code: string; message: string };
+
+      // invalid_client is a bad deployment secret; reconnecting cannot fix it.
+      expect(error).not.toBeInstanceOf(ReauthRequiredError);
+      expect(error.code).toBe('UPSTREAM_ERROR');
+      expect(error.message).toContain('invalid_client');
+    });
+
+    it('refuses to persist a malformed token refresh response', async () => {
+      const { client, persistTokens } = makeHarness();
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          // 200 but missing refresh_token: persisting would corrupt the grant.
+          return jsonResponse({ access_token: 'access-2', expires_in: 172800 });
+        }
+        return jsonResponse({ error: 'unauthorized' }, 401);
+      });
+
+      const error = (await client.get('/conversations/1').catch((e) => e)) as { code: string };
+
+      expect(persistTokens).not.toHaveBeenCalled();
+      expect(error.code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('retries a stale 401 with the current token instead of rotating again', async () => {
+      const harness = makeHarness();
+      let apiCalls = 0;
+      let tokenCalls = 0;
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          tokenCalls++;
+          return jsonResponse({ access_token: 'access-3', refresh_token: 'refresh-3', expires_in: 172800 });
+        }
+        apiCalls++;
+        if (apiCalls === 1) {
+          // While this response was in flight, another session rotated the
+          // token: the 401 below was produced under access-1, not access-2.
+          await harness.deps.persistTokens({
+            accessToken: 'access-2',
+            refreshToken: 'refresh-2',
+            expiresAt: Date.now() + 3_600_000,
+          });
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        }
+        return jsonResponse({ ok: true });
+      });
+
+      await expect(harness.client.get('/conversations/1')).resolves.toEqual({ ok: true });
+
+      expect(tokenCalls).toBe(0);
+      expect(authHeader(1)).toBe('Bearer access-2');
+    });
+  });
+
+  describe('token URL validation', () => {
+    it('rejects a non-HTTPS token URL', () => {
+      expect(() => makeHarness({ tokenUrl: 'http://api.helpscout.net/v2/oauth2/token' })).toThrow(/HTTPS/);
     });
   });
 

--- a/src/__tests__/helpscout-fetch-client.test.ts
+++ b/src/__tests__/helpscout-fetch-client.test.ts
@@ -644,6 +644,51 @@ describe('HelpScoutFetchClient', () => {
     });
   });
 
+  describe('proactive refresh failure classification', () => {
+    it('propagates a classified token-endpoint outage once instead of retrying it per attempt', async () => {
+      const { client } = makeHarness({}, { expiresAt: Date.now() + 1000 });
+      let tokenCalls = 0;
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          tokenCalls++;
+          return jsonResponse({ error: 'server_error' }, 503);
+        }
+        return jsonResponse({ ok: true });
+      });
+
+      const error = (await client.get('/conversations/1').catch((e) => e)) as { code: string; message: string };
+
+      // The refresh path already classified this; the read retry loop must
+      // not flatten it into an unknown error or hammer the token endpoint.
+      expect(error.code).toBe('UPSTREAM_ERROR');
+      expect(error.message).toContain('503');
+      expect(tokenCalls).toBe(1);
+    });
+  });
+
+  describe('unknown expiry', () => {
+    it('forces a refresh before a write when the expiry is unknown', async () => {
+      // expiresAt 0 is the contract for "expiry unknown": refresh first.
+      const { client } = makeHarness({}, { expiresAt: 0 });
+      let tokenCalls = 0;
+      fetchMock.mockImplementation(async (input, init) => {
+        if ((input as string) === TOKEN_URL) {
+          tokenCalls++;
+          return jsonResponse({ access_token: 'access-2', refresh_token: 'refresh-2', expires_in: 172800 });
+        }
+        const auth = (init as { headers?: Record<string, string> })?.headers?.Authorization;
+        // The write must run under the freshly rotated token, never the stale one.
+        expect(auth).toBe('Bearer access-2');
+        return jsonResponse({ id: 99 }, 201, { 'resource-id': '99' });
+      });
+
+      const result = await client.post('/conversations/1/notes', { text: 'hi' });
+
+      expect(tokenCalls).toBe(1);
+      expect(result.status).toBe(201);
+    });
+  });
+
   describe('validateHttpsBaseUrl', () => {
     it('rejects a non-HTTPS base URL', () => {
       expect(() => makeHarness({ baseUrl: 'http://api.helpscout.net/v2/' })).toThrow(/HTTPS/);

--- a/src/__tests__/helpscout-fetch-client.test.ts
+++ b/src/__tests__/helpscout-fetch-client.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import {
+  HelpScoutFetchClient,
+  RefreshMutex,
+  ReauthRequiredError,
+  type FetchClientDeps,
+  type UserTokenContext,
+} from '../worker/helpscout-fetch-client.js';
+import { HelpScoutWriteError } from '../utils/api.js';
+
+// Keep the client's inline logging out of the test output.
+jest.mock('../utils/logger.js', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const BASE_URL = 'https://api.helpscout.net/v2/';
+const TOKEN_URL = 'https://api.helpscout.net/v2/oauth2/token';
+
+/** Build a fresh JSON Response on every call so bodies are never read twice. */
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+interface Harness {
+  deps: FetchClientDeps;
+  client: HelpScoutFetchClient;
+  persistTokens: jest.Mock<(tokens: UserTokenContext) => Promise<void>>;
+  getTokens: jest.Mock<() => UserTokenContext>;
+  current: () => UserTokenContext;
+}
+
+function makeHarness(overrides: Partial<FetchClientDeps> = {}, initial?: Partial<UserTokenContext>): Harness {
+  let tokens: UserTokenContext = {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    // Far from expiry so proactive refresh never fires unless a test asks for it.
+    expiresAt: Date.now() + 3_600_000,
+    ...initial,
+  };
+  const persistTokens = jest.fn<(t: UserTokenContext) => Promise<void>>(async (t) => {
+    tokens = t;
+  });
+  const getTokens = jest.fn<() => UserTokenContext>(() => tokens);
+
+  const deps: FetchClientDeps = {
+    baseUrl: BASE_URL,
+    tokenUrl: TOKEN_URL,
+    clientId: 'client-id',
+    clientSecret: 'client-secret',
+    getTokens,
+    persistTokens,
+    refreshMutex: new RefreshMutex(),
+    ...overrides,
+  };
+
+  return { deps, client: new HelpScoutFetchClient(deps), persistTokens, getTokens, current: () => tokens };
+}
+
+let fetchMock: jest.Mock<typeof fetch>;
+
+beforeEach(() => {
+  fetchMock = jest.fn<typeof fetch>();
+  (global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+type FetchInit = { method?: string; body?: unknown; headers?: Record<string, string> };
+
+function lastInit(callIndex: number): FetchInit {
+  return fetchMock.mock.calls[callIndex][1] as FetchInit;
+}
+
+function authHeader(callIndex: number): string | undefined {
+  return lastInit(callIndex).headers?.Authorization;
+}
+
+describe('HelpScoutFetchClient', () => {
+  describe('auth injection', () => {
+    it('sets the injected bearer token on every request', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(jsonResponse({ id: 1 }));
+
+      await client.get('/conversations/1');
+
+      expect(authHeader(0)).toBe('Bearer access-1');
+    });
+
+    it('never leaks tokens between two client instances', async () => {
+      const a = makeHarness({}, { accessToken: 'token-A' });
+      const b = makeHarness({}, { accessToken: 'token-B' });
+      fetchMock.mockImplementation(async () => jsonResponse({ ok: true }));
+
+      await a.client.get('/mailboxes');
+      await b.client.get('/mailboxes');
+
+      expect(authHeader(0)).toBe('Bearer token-A');
+      expect(authHeader(1)).toBe('Bearer token-B');
+    });
+  });
+
+  describe('get', () => {
+    it('parses a JSON body on the happy path', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(jsonResponse({ id: 42, subject: 'Hi' }));
+
+      const result = await client.get<{ id: number; subject: string }>('/conversations/42');
+
+      expect(result).toEqual({ id: 42, subject: 'Hi' });
+    });
+
+    it('does not cache: two identical gets issue two fetches', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async () => jsonResponse({ id: 1 }));
+
+      await client.get('/conversations/1', undefined, { ttl: 300 });
+      await client.get('/conversations/1', undefined, { ttl: 300 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('serializes query params onto the URL', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+      await client.get('/conversations', { page: 2, status: 'active' });
+
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.helpscout.net/v2/conversations?page=2&status=active');
+    });
+  });
+
+  describe('getAllPages', () => {
+    it('accumulates multiple pages and stops at totalPages', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async (input) => {
+        const url = new URL(input as string);
+        const page = url.searchParams.get('page');
+        if (page === '1') {
+          return jsonResponse({
+            _embedded: { conversations: [{ id: 1 }, { id: 2 }] },
+            page: { size: 2, totalElements: 3, totalPages: 2, number: 1 },
+          });
+        }
+        return jsonResponse({
+          _embedded: { conversations: [{ id: 3 }] },
+          page: { size: 2, totalElements: 3, totalPages: 2, number: 2 },
+        });
+      });
+
+      const result = await client.getAllPages<{ id: number }>('/conversations', 'conversations');
+
+      expect(result.items).toHaveLength(3);
+      expect(result.pagesFetched).toBe(2);
+      expect(result.totalElements).toBe(3);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('caps at maxItems and flags truncation', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async () =>
+        jsonResponse({
+          _embedded: { conversations: [{ id: 1 }, { id: 2 }] },
+          page: { size: 2, totalElements: 10, totalPages: 5, number: 1 },
+        }),
+      );
+
+      const result = await client.getAllPages<{ id: number }>('/conversations', 'conversations', {}, 1);
+
+      expect(result.items).toEqual([{ id: 1 }]);
+      expect(result.truncated).toBe(true);
+    });
+
+    it('stops after a single page when totalPages is 1', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async () =>
+        jsonResponse({
+          _embedded: { conversations: [{ id: 1 }] },
+          page: { size: 50, totalElements: 1, totalPages: 1, number: 1 },
+        }),
+      );
+
+      const result = await client.getAllPages('/conversations', 'conversations');
+
+      expect(result.pagesFetched).toBe(1);
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  describe('getRaw', () => {
+    it('returns text with lowercase headers and forwards Accept', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(
+        new Response('raw email source', {
+          status: 200,
+          headers: { 'Content-Type': 'message/rfc822' },
+        }),
+      );
+
+      const result = await client.getRaw<string>('/conversations/1/threads/2/original-source', undefined, {
+        responseType: 'text',
+        headers: { Accept: 'message/rfc822' },
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.data).toBe('raw email source');
+      expect(result.headers['content-type']).toBe('message/rfc822');
+      expect((lastInit(0).headers as Record<string, string>).Accept).toBe('message/rfc822');
+    });
+
+    it('returns an ArrayBuffer with the correct bytes for arraybuffer', async () => {
+      const { client } = makeHarness();
+      const bytes = new Uint8Array([1, 2, 3, 4]);
+      fetchMock.mockResolvedValue(
+        new Response(bytes, {
+          status: 200,
+          headers: { 'content-type': 'application/octet-stream' },
+        }),
+      );
+
+      const result = await client.getRaw<ArrayBuffer>('/conversations/1/attachments/2/file', undefined, {
+        responseType: 'arraybuffer',
+      });
+
+      expect(result.data).toBeInstanceOf(ArrayBuffer);
+      expect(Array.from(new Uint8Array(result.data))).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe('write verbs', () => {
+    it('returns a WriteResponse carrying status, data, and resource-id', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(
+        jsonResponse({ id: 555 }, 201, { 'Resource-Id': '555' }),
+      );
+
+      const result = await client.post('/conversations/1/threads', { text: 'hello' });
+
+      expect(result.status).toBe(201);
+      expect(result.data).toEqual({ id: 555 });
+      expect(result.headers['resource-id']).toBe('555');
+    });
+
+    it('maps a 204 empty body to null data', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(new Response(null, { status: 204, headers: { 'Resource-Id': '9' } }));
+
+      const result = await client.patch('/conversations/1', { subject: 'x' });
+
+      expect(result.status).toBe(204);
+      expect(result.data).toBeNull();
+      expect(result.headers['resource-id']).toBe('9');
+    });
+
+    it('sends a JSON body and content-type when a body is provided', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(new Response(null, { status: 201 }));
+
+      await client.post('/conversations', { subject: 'New' });
+
+      const init = lastInit(0);
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ subject: 'New' }));
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    });
+  });
+
+  describe('write no-retry contract', () => {
+    it.each([500, 429, 401])(
+      'issues exactly one fetch and throws HelpScoutWriteError on %s',
+      async (status) => {
+        const { client } = makeHarness();
+        fetchMock.mockResolvedValue(jsonResponse({ error: 'nope' }, status));
+
+        await expect(client.post('/conversations', { subject: 'x' })).rejects.toBeInstanceOf(
+          HelpScoutWriteError,
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const error = await client.post('/conversations', { subject: 'x' }).catch((e) => e);
+        expect(error).toBeInstanceOf(HelpScoutWriteError);
+        expect((error as HelpScoutWriteError).status).toBe(status);
+      },
+    );
+
+    it('surfaces a network throw on a write as HelpScoutWriteError', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockRejectedValue(new Error('connection reset'));
+
+      const error = await client.delete('/conversations/1').catch((e) => e);
+      expect(error).toBeInstanceOf(HelpScoutWriteError);
+      expect((error as HelpScoutWriteError).status).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('read retry', () => {
+    it('retries a 500 then succeeds', async () => {
+      jest.useFakeTimers();
+      const { client } = makeHarness();
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+
+      const promise = client.get('/conversations/1');
+      await jest.advanceTimersByTimeAsync(5000);
+
+      await expect(promise).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a network throw then succeeds', async () => {
+      jest.useFakeTimers();
+      const { client } = makeHarness();
+      fetchMock
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+
+      const promise = client.get('/conversations/1');
+      await jest.advanceTimersByTimeAsync(5000);
+
+      await expect(promise).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('waits the X-RateLimit-Retry-After window on a 429 then retries', async () => {
+      jest.useFakeTimers();
+      const { client } = makeHarness();
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ error: 'slow down' }, 429, { 'X-RateLimit-Retry-After': '2' }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+
+      const promise = client.get('/conversations/1');
+
+      // Not yet elapsed: still only the first attempt has run.
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1500);
+      await expect(promise).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws a transformed ApiError once retries are exhausted', async () => {
+      jest.useFakeTimers();
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(jsonResponse({ error: 'down' }, 500));
+
+      const promise = client.get('/conversations/1').catch((e) => e);
+      await jest.advanceTimersByTimeAsync(60000);
+
+      const error = (await promise) as { code: string };
+      expect(error.code).toBe('UPSTREAM_ERROR');
+      expect(fetchMock).toHaveBeenCalledTimes(4); // initial + 3 retries
+    });
+  });
+
+  describe('transformError mapping', () => {
+    // Exercise the pure mapping directly across the status table.
+    const map = (context: Record<string, unknown>) =>
+      (
+        makeHarness().client as unknown as {
+          transformError: (c: Record<string, unknown>) => { code: string; retryAfter?: number };
+        }
+      ).transformError({ requestId: 'r', headers: {}, ...context });
+
+    it.each([
+      [401, 'UNAUTHORIZED'],
+      [403, 'UNAUTHORIZED'],
+      [404, 'NOT_FOUND'],
+      [422, 'INVALID_INPUT'],
+      [429, 'RATE_LIMIT'],
+      [400, 'INVALID_INPUT'],
+      [500, 'UPSTREAM_ERROR'],
+      [503, 'UPSTREAM_ERROR'],
+    ])('maps status %s to %s', (status, code) => {
+      expect(map({ status }).code).toBe(code);
+    });
+
+    it('maps a timeout (ECONNABORTED) to UPSTREAM_ERROR', () => {
+      expect(map({ code: 'ECONNABORTED' }).code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('prefers X-RateLimit-Retry-After for the 429 retryAfter', () => {
+      const result = map({
+        status: 429,
+        headers: { 'x-ratelimit-retry-after': '30', 'retry-after': '120' },
+      });
+      expect(result.code).toBe('RATE_LIMIT');
+      expect(result.retryAfter).toBe(30);
+    });
+
+    it('maps a 404 end-to-end through get', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockResolvedValue(jsonResponse({ message: 'missing' }, 404));
+
+      const error = (await client.get('/conversations/nope').catch((e) => e)) as { code: string };
+      expect(error.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('token refresh with rotation', () => {
+    it('refreshes on a 401, retries with the new token, and persists the rotated pair once', async () => {
+      const harness = makeHarness();
+      const { client, persistTokens } = harness;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = input as string;
+        if (url === TOKEN_URL) {
+          return jsonResponse({
+            access_token: 'access-2',
+            refresh_token: 'refresh-2',
+            expires_in: 172800,
+          });
+        }
+        const auth = (init?.headers as Record<string, string>).Authorization;
+        if (auth === 'Bearer access-1') {
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        }
+        return jsonResponse({ ok: true });
+      });
+
+      const result = await client.get('/conversations/1');
+
+      expect(result).toEqual({ ok: true });
+      expect(persistTokens).toHaveBeenCalledTimes(1);
+      expect(persistTokens).toHaveBeenCalledWith({
+        accessToken: 'access-2',
+        refreshToken: 'refresh-2',
+        expiresAt: expect.any(Number),
+      });
+
+      // The token endpoint was called with the OLD refresh token, and the
+      // rotated pair is now what the client holds.
+      const tokenCall = fetchMock.mock.calls.find((c) => c[0] === TOKEN_URL);
+      expect(JSON.parse(tokenCall![1]!.body as string).refresh_token).toBe('refresh-1');
+      expect(harness.current().refreshToken).toBe('refresh-2');
+    });
+
+    it('refreshes exactly once for concurrent 401s (serialization)', async () => {
+      const { client } = makeHarness();
+      let refreshCalls = 0;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = input as string;
+        if (url === TOKEN_URL) {
+          refreshCalls++;
+          return jsonResponse({
+            access_token: 'access-2',
+            refresh_token: 'refresh-2',
+            expires_in: 172800,
+          });
+        }
+        const auth = (init?.headers as Record<string, string>).Authorization;
+        if (auth === 'Bearer access-1') {
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        }
+        return jsonResponse({ ok: true });
+      });
+
+      const results = await Promise.all([
+        client.get('/a'),
+        client.get('/b'),
+        client.get('/c'),
+        client.get('/d'),
+      ]);
+
+      expect(results).toEqual([{ ok: true }, { ok: true }, { ok: true }, { ok: true }]);
+      expect(refreshCalls).toBe(1);
+    });
+
+    it('proactively refreshes before a request when the token is near expiry', async () => {
+      const { client, persistTokens } = makeHarness({}, { expiresAt: Date.now() + 10_000 });
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          return jsonResponse({ access_token: 'access-2', refresh_token: 'refresh-2', expires_in: 172800 });
+        }
+        return jsonResponse({ ok: true });
+      });
+
+      await client.get('/conversations/1');
+
+      expect(persistTokens).toHaveBeenCalledTimes(1);
+      // The API request used the freshly rotated token.
+      const apiCall = fetchMock.mock.calls.find((c) => c[0] !== TOKEN_URL)!;
+      expect((apiCall[1]!.headers as Record<string, string>).Authorization).toBe('Bearer access-2');
+    });
+  });
+
+  describe('refresh failure', () => {
+    it('throws REAUTH_REQUIRED (not UNAUTHORIZED) on invalid_grant', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          return jsonResponse({ error: 'invalid_grant' }, 400);
+        }
+        return jsonResponse({ error: 'unauthorized' }, 401);
+      });
+
+      const error = (await client.get('/conversations/1').catch((e) => e)) as ReauthRequiredError;
+
+      expect(error).toBeInstanceOf(ReauthRequiredError);
+      expect(error.code).toBe('REAUTH_REQUIRED');
+    });
+
+    it('surfaces a temporary token-endpoint failure as an upstream error, not re-consent', async () => {
+      const { client } = makeHarness();
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          return jsonResponse({ error: 'server_error' }, 503);
+        }
+        return jsonResponse({ error: 'unauthorized' }, 401);
+      });
+
+      const error = (await client.get('/conversations/1').catch((e) => e)) as { code: string };
+
+      // A 503 from the token endpoint says nothing about the grant; telling
+      // the user to reconnect here would be wrong and destructive advice.
+      expect(error).not.toBeInstanceOf(ReauthRequiredError);
+      expect(error.code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('still retries after a refresh when the 401 lands on the final attempt', async () => {
+      jest.useFakeTimers();
+      const { client } = makeHarness();
+      let apiCalls = 0;
+      fetchMock.mockImplementation(async (input) => {
+        if ((input as string) === TOKEN_URL) {
+          return jsonResponse({ access_token: 'access-2', refresh_token: 'refresh-2', expires_in: 172800 });
+        }
+        apiCalls++;
+        if (apiCalls <= 3) return jsonResponse({ error: 'down' }, 500);
+        if (apiCalls === 4) return jsonResponse({ error: 'unauthorized' }, 401);
+        return jsonResponse({ ok: true }, 200);
+      });
+
+      const promise = client.get('/conversations/1');
+      await jest.advanceTimersByTimeAsync(60000);
+
+      // Three 5xx retries exhaust the budget; the 401 on the final attempt
+      // must still get its post-refresh retry rather than running the loop out.
+      await expect(promise).resolves.toEqual({ ok: true });
+      expect(apiCalls).toBe(5);
+    });
+  });
+
+  describe('validateHttpsBaseUrl', () => {
+    it('rejects a non-HTTPS base URL', () => {
+      expect(() => makeHarness({ baseUrl: 'http://api.helpscout.net/v2/' })).toThrow(/HTTPS/);
+    });
+
+    it('rejects a malformed base URL', () => {
+      expect(() => makeHarness({ baseUrl: 'not a url' })).toThrow(/Invalid Help Scout base URL/);
+    });
+  });
+});

--- a/src/worker/helpscout-fetch-client.ts
+++ b/src/worker/helpscout-fetch-client.ts
@@ -1,0 +1,804 @@
+/**
+ * fetch-based Help Scout client for the Cloudflare Workers build.
+ *
+ * This is a port of the axios-backed `HelpScoutClient`
+ * (`src/utils/helpscout-client.ts`) onto the platform `fetch`, implementing the
+ * same `HelpScoutApi` seam so every tool, write, and resource handler resolves
+ * it through `getClient()` unchanged. The two clients coexist: the stdio server
+ * keeps the axios client with its connection pool and shared cache; a per-user
+ * remote request constructs one of these and scopes it with `withHelpScoutApi()`.
+ *
+ * Two things fall away in the Workers runtime and are deliberately gone here:
+ * the http.Agent connection pool (Workers has no sockets) and the shared read
+ * cache (a process-wide cache would leak one user's data to the next). Two
+ * things are net-new: per-user OAuth token injection and a serialized
+ * refresh-with-rotation flow. Everything else is either a verbatim port of a
+ * pure helper or a mechanical axios -> fetch rewrite.
+ */
+import {
+  HelpScoutWriteError,
+  type HelpScoutApi,
+  type PaginatedResponse,
+  type RawGetOptions,
+  type RawResponse,
+  type WriteMethod,
+  type WriteResponse,
+} from '../utils/api.js';
+import { logger } from '../utils/logger.js';
+import { ApiError } from '../schema/types.js';
+
+/** Refresh proactively once the access token is within this window of expiry. */
+const REFRESH_BUFFER_MS = 60_000;
+
+/** Default request timeout, enforced with AbortSignal.timeout. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface RetryConfig {
+  retries: number;
+  retryDelay: number;
+  maxRetryDelay: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  retries: 3,
+  retryDelay: 1000, // 1 second
+  maxRetryDelay: 10000, // 10 seconds
+};
+
+/**
+ * The per-user OAuth pair the client reads for every request. `expiresAt`
+ * (epoch ms) drives proactive refresh; it is optional so a caller that only has
+ * the tokens still works, falling back to reactive refresh on a 401.
+ */
+export interface UserTokenContext {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt?: number;
+}
+
+/**
+ * Everything the client needs, injected per request. Tokens are read through
+ * `getTokens()` (not captured by value) so a mid-request rotation is picked up
+ * by the very next request; `persistTokens` writes the rotated pair back to
+ * wherever the caller stores grant state, keeping the client storage-agnostic.
+ */
+export interface FetchClientDeps {
+  baseUrl: string;
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  getTokens: () => UserTokenContext;
+  persistTokens: (tokens: UserTokenContext) => Promise<void>;
+  refreshMutex: RefreshMutex;
+  timeoutMs?: number;
+}
+
+/**
+ * Serializes token refresh for one user so concurrent 401s (or concurrent
+ * proactive refreshes) spend the rotating refresh token exactly once. The first
+ * caller starts the refresh and stores the promise; concurrent callers await
+ * the same one; the slot is cleared in `finally`, but only if it still points at
+ * that promise, so a refresh that starts after this one completes is never
+ * clobbered.
+ *
+ * This mirrors the axios client's `authenticationPromise` guard. It covers a
+ * single Durable Object instance; a user with two live sessions is two
+ * instances with two mutexes, and account-wide serialization (a per-user DO or
+ * a KV compare-and-swap) is the follow-up fix, not this layer's job.
+ */
+export class RefreshMutex {
+  private inFlight: Promise<UserTokenContext> | null = null;
+
+  run(operation: () => Promise<UserTokenContext>): Promise<UserTokenContext> {
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+    const promise = operation().finally(() => {
+      if (this.inFlight === promise) {
+        this.inFlight = null;
+      }
+    });
+    this.inFlight = promise;
+    return promise;
+  }
+}
+
+/**
+ * Refresh failed because the refresh token is spent or revoked (invalid_grant).
+ * Distinct from the generic UNAUTHORIZED prose because the only recovery is for
+ * the user to reconnect the connector, and the model should say exactly that
+ * rather than suggest checking credentials it cannot see.
+ */
+export class ReauthRequiredError extends Error {
+  readonly code = 'REAUTH_REQUIRED' as const;
+
+  constructor(
+    message: string,
+    readonly requestId: string,
+  ) {
+    super(message);
+    this.name = 'ReauthRequiredError';
+  }
+}
+
+/** The subset of a failed response `transformError` reasons about. */
+interface ErrorContext {
+  status?: number;
+  headers: Record<string, string>;
+  data?: unknown;
+  requestId: string;
+  /** Set to 'ECONNABORTED' for a timeout, mirroring the axios timeout code. */
+  code?: string;
+}
+
+/** Copy a fetch `Headers` into a plain object; fetch keys are already lowercase. */
+function headersToObject(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+export class HelpScoutFetchClient implements HelpScoutApi {
+  private readonly timeoutMs: number;
+  private readonly retryConfig: RetryConfig = DEFAULT_RETRY_CONFIG;
+
+  constructor(private readonly deps: FetchClientDeps) {
+    this.validateHttpsBaseUrl(deps.baseUrl);
+    this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  // --- Pure helpers, ported verbatim from the axios client -------------------
+
+  private async sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private validateHttpsBaseUrl(baseUrl: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(baseUrl);
+    } catch {
+      throw new Error(`Invalid Help Scout base URL: ${baseUrl}`);
+    }
+
+    if (parsed.protocol !== 'https:') {
+      throw new Error('HELPSCOUT_BASE_URL must use HTTPS to protect OAuth2 credentials');
+    }
+  }
+
+  private parseRetryAfterMs(value: unknown, fallbackMs = 60000): number {
+    const rawValue = Array.isArray(value) ? value[0] : value;
+
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue >= 0) {
+      return rawValue * 1000;
+    }
+
+    if (typeof rawValue === 'string') {
+      const trimmed = rawValue.trim();
+      const seconds = Number(trimmed);
+      if (Number.isFinite(seconds) && seconds >= 0) {
+        return seconds * 1000;
+      }
+
+      const retryAt = Date.parse(trimmed);
+      if (Number.isFinite(retryAt)) {
+        return Math.max(retryAt - Date.now(), 0);
+      }
+    }
+
+    return fallbackMs;
+  }
+
+  private calculateRetryDelay(attempt: number, baseDelay: number, maxDelay: number): number {
+    // Exponential backoff with jitter
+    const exponentialDelay = baseDelay * Math.pow(2, attempt);
+    const jitter = Math.random() * 0.1 * exponentialDelay; // 10% jitter
+    return Math.min(exponentialDelay + jitter, maxDelay);
+  }
+
+  // --- Request construction --------------------------------------------------
+
+  private newRequestId(): string {
+    return Math.random().toString(36).substring(7);
+  }
+
+  /**
+   * Join the base URL and endpoint the way axios joins baseURL + url: by
+   * concatenating trimmed paths, NOT via `new URL(endpoint, base)`, which would
+   * treat a leading-slash endpoint as absolute and drop the `/v2` prefix.
+   */
+  private buildUrl(endpoint: string, params?: Record<string, unknown>): string {
+    const base = this.deps.baseUrl.replace(/\/+$/, '');
+    const path = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+    const url = new URL(base + path);
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue;
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item === undefined || item === null) continue;
+            url.searchParams.append(key, String(item));
+          }
+        } else {
+          url.searchParams.append(key, String(value));
+        }
+      }
+    }
+
+    return url.toString();
+  }
+
+  /**
+   * Refresh proactively when the token is set to expire within the buffer,
+   * before ever issuing the request. This is what keeps writes usable: they
+   * never retry a 401, so they rely on almost never meeting an expired token.
+   */
+  private async maybeProactiveRefresh(): Promise<void> {
+    const tokens = this.deps.getTokens();
+    if (tokens.expiresAt === undefined) return;
+    if (Date.now() > tokens.expiresAt - REFRESH_BUFFER_MS) {
+      await this.refresh();
+    }
+  }
+
+  /**
+   * Exchange the current refresh token for a rotated pair, serialized through
+   * the injected mutex so concurrent callers refresh once. Persists the new pair
+   * before returning so the next `getTokens()` reads the rotated tokens.
+   */
+  private async refresh(): Promise<UserTokenContext> {
+    return this.deps.refreshMutex.run(() => this.performRefresh());
+  }
+
+  private async performRefresh(): Promise<UserTokenContext> {
+    const requestId = this.newRequestId();
+    const current = this.deps.getTokens();
+
+    let response: Response;
+    try {
+      response = await fetch(this.deps.tokenUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: current.refreshToken,
+          client_id: this.deps.clientId,
+          client_secret: this.deps.clientSecret,
+        }),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (error) {
+      // A network failure or timeout reaching the token endpoint says nothing
+      // about the grant. Surface it as a temporary upstream error; telling the
+      // user to reconnect over a blip would burn a working refresh token's
+      // grant for no reason.
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Token refresh request failed', { requestId, error: message });
+      throw this.transformError({
+        headers: {},
+        requestId,
+        code: this.isTimeout(error) ? 'ECONNABORTED' : undefined,
+      });
+    }
+
+    if (!response.ok) {
+      const body = await this.safeJson(response);
+      const oauthError =
+        typeof body === 'object' && body !== null
+          ? (body as Record<string, unknown>).error
+          : undefined;
+
+      logger.error('Token refresh rejected', { requestId, status: response.status, oauthError });
+
+      // A 400/401 (invalid_grant) means the refresh token is spent or the
+      // grant was revoked: no retry can recover it, only re-consent. Anything
+      // else (a 5xx from the token endpoint, a 429) is Help Scout misbehaving,
+      // not a dead grant, and must not tell the user to reconnect.
+      if (response.status === 400 || response.status === 401) {
+        throw new ReauthRequiredError(
+          'Your Help Scout session has expired or was revoked. Please reconnect the Help Scout connector to continue.',
+          requestId,
+        );
+      }
+      throw this.transformError({
+        status: response.status,
+        headers: headersToObject(response.headers),
+        data: body,
+        requestId,
+      });
+    }
+
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    };
+
+    const rotated: UserTokenContext = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    };
+
+    // Persist the rotated pair atomically (both tokens + expiry together) before
+    // any request uses it, so a crash never leaves a spent refresh token stored.
+    await this.deps.persistTokens(rotated);
+
+    logger.info('Refreshed Help Scout access token', { requestId });
+
+    return rotated;
+  }
+
+  /** Issue a single GET, injecting the current per-user bearer token. */
+  private async sendGet(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    headers?: Record<string, string>,
+  ): Promise<Response> {
+    await this.maybeProactiveRefresh();
+
+    const tokens = this.deps.getTokens();
+    return fetch(this.buildUrl(endpoint, params), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...headers,
+        Authorization: `Bearer ${tokens.accessToken}`,
+      },
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+  }
+
+  // --- Read path with retry --------------------------------------------------
+
+  /**
+   * Run a GET with the read retry policy: retry on a network throw, an
+   * AbortController timeout, a 5xx, or a 429; refresh-then-retry-once on a 401.
+   * Returns the raw `Response` so the caller decodes the body (JSON, text, or
+   * bytes). Non-retryable failures and exhausted retries throw a transformed
+   * `ApiError`.
+   */
+  private async executeWithRetry(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    headers?: Record<string, string>,
+  ): Promise<Response> {
+    const requestId = this.newRequestId();
+    let refreshedOn401 = false;
+    let lastError: ErrorContext | undefined;
+
+    for (let attempt = 0; attempt <= this.retryConfig.retries; attempt++) {
+      let response: Response;
+
+      try {
+        response = await this.sendGet(endpoint, params, headers);
+      } catch (error) {
+        // A refresh that failed with invalid_grant must surface as re-consent,
+        // not be swallowed as a retryable network blip.
+        if (error instanceof ReauthRequiredError) {
+          throw error;
+        }
+
+        const timedOut = this.isTimeout(error);
+        lastError = {
+          headers: {},
+          requestId,
+          code: timedOut ? 'ECONNABORTED' : undefined,
+        };
+
+        logger.warn('Request failed, retrying', {
+          attempt: attempt + 1,
+          totalAttempts: this.retryConfig.retries + 1,
+          requestId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+
+        if (attempt === this.retryConfig.retries) break;
+        await this.sleep(
+          this.calculateRetryDelay(attempt, this.retryConfig.retryDelay, this.retryConfig.maxRetryDelay),
+        );
+        continue;
+      }
+
+      if (response.ok) {
+        return response;
+      }
+
+      const status = response.status;
+
+      // Reactive refresh: a single 401 refreshes the token and retries once.
+      // A second 401 (token still rejected) is a real auth failure. The retry
+      // does not consume a read attempt: a 401 on the final attempt must still
+      // get the retry the refresh exists for, and the refreshedOn401 guard
+      // keeps this from looping.
+      if (status === 401 && !refreshedOn401) {
+        refreshedOn401 = true;
+        logger.warn('Authentication failed, refreshing token before retry', { attempt: attempt + 1, requestId });
+        await this.refresh(); // throws ReauthRequiredError on invalid_grant
+        attempt--;
+        continue;
+      }
+
+      const responseHeaders = headersToObject(response.headers);
+      lastError = {
+        status,
+        headers: responseHeaders,
+        data: await this.safeJson(response),
+        requestId,
+      };
+
+      if (attempt === this.retryConfig.retries) break;
+      if (!this.isRetryableStatus(status)) break;
+
+      if (status === 429) {
+        const delay = this.compute429Delay(responseHeaders, attempt);
+        logger.warn('Rate limit hit, waiting before retry', { attempt: attempt + 1, retryAfter: delay, requestId });
+        await this.sleep(delay);
+      } else {
+        const delay = this.calculateRetryDelay(
+          attempt,
+          this.retryConfig.retryDelay,
+          this.retryConfig.maxRetryDelay,
+        );
+        logger.warn('Request failed, retrying', {
+          attempt: attempt + 1,
+          totalAttempts: this.retryConfig.retries + 1,
+          delay,
+          status,
+          requestId,
+        });
+        await this.sleep(delay);
+      }
+    }
+
+    if (lastError) {
+      throw this.transformError(lastError);
+    }
+    throw new Error('Request failed without error details');
+  }
+
+  private isTimeout(error: unknown): boolean {
+    // AbortSignal.timeout aborts with a TimeoutError; a manual abort throws
+    // AbortError. Treat both as a retryable timeout for reads.
+    return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+  }
+
+  private isRetryableStatus(status: number): boolean {
+    return status === 429 || (status >= 500 && status < 600);
+  }
+
+  /**
+   * Adaptive 429 wait, in priority order: the account-scoped
+   * `X-RateLimit-Retry-After`, then the standard `Retry-After`, then exponential
+   * backoff. Never a hardcoded limit — the account bucket is shared and only the
+   * headers know the true window.
+   */
+  private compute429Delay(headers: Record<string, string>, attempt: number): number {
+    const rateLimitRetryAfter = headers['x-ratelimit-retry-after'];
+    if (rateLimitRetryAfter !== undefined) {
+      return this.parseRetryAfterMs(rateLimitRetryAfter);
+    }
+    const retryAfter = headers['retry-after'];
+    if (retryAfter !== undefined) {
+      return this.parseRetryAfterMs(retryAfter);
+    }
+    return this.calculateRetryDelay(attempt, this.retryConfig.retryDelay, this.retryConfig.maxRetryDelay);
+  }
+
+  private async safeJson(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  private transformError(context: ErrorContext): ApiError {
+    const { requestId, status, headers } = context;
+
+    logger.error('API request failed', { requestId, status });
+
+    if (status === 401) {
+      return {
+        code: 'UNAUTHORIZED',
+        message: 'Help Scout authentication failed. Your session may have expired.',
+        details: {
+          requestId,
+          suggestion: 'Reconnect the Help Scout connector to re-authorize access.',
+        },
+      };
+    }
+
+    if (status === 403) {
+      return {
+        code: 'UNAUTHORIZED',
+        message: 'Access forbidden. Insufficient permissions for this Help Scout resource.',
+        details: {
+          requestId,
+          suggestion: 'Check whether your Help Scout account has access to this mailbox or resource',
+        },
+      };
+    }
+
+    if (status === 404) {
+      return {
+        code: 'NOT_FOUND',
+        message: 'Help Scout resource not found. The requested conversation, mailbox, or thread does not exist.',
+        details: {
+          requestId,
+          suggestion: 'Verify the ID is correct and the resource exists',
+        },
+      };
+    }
+
+    if (status === 429) {
+      const headerValue = headers['x-ratelimit-retry-after'] ?? headers['retry-after'];
+      const retryAfter = Math.ceil(this.parseRetryAfterMs(headerValue) / 1000);
+      return {
+        code: 'RATE_LIMIT',
+        message: `Help Scout API rate limit exceeded. Please wait ${retryAfter} seconds before retrying.`,
+        retryAfter,
+        details: {
+          requestId,
+          suggestion: 'Reduce request frequency or implement request batching',
+        },
+      };
+    }
+
+    if (status === 422) {
+      const responseData = (context.data as Record<string, unknown>) || {};
+      return {
+        code: 'INVALID_INPUT',
+        message: `Help Scout API validation error: ${responseData.message || 'Invalid request data'}`,
+        details: {
+          requestId,
+          validationErrors: responseData.errors || responseData,
+          suggestion: 'Check the request parameters match Help Scout API requirements',
+        },
+      };
+    }
+
+    if (status && status >= 400 && status < 500) {
+      const responseData = (context.data as Record<string, unknown>) || {};
+      return {
+        code: 'INVALID_INPUT',
+        message: `Help Scout API client error: ${responseData.message || 'Invalid request'}`,
+        details: {
+          requestId,
+          statusCode: status,
+          apiResponse: responseData,
+        },
+      };
+    }
+
+    if (context.code === 'ECONNABORTED') {
+      return {
+        code: 'UPSTREAM_ERROR',
+        message: 'Help Scout API request timed out. The service may be experiencing high load.',
+        details: {
+          requestId,
+          errorCode: context.code,
+          suggestion: 'Request will be automatically retried with exponential backoff',
+        },
+      };
+    }
+
+    if (status && status >= 500) {
+      return {
+        code: 'UPSTREAM_ERROR',
+        message: `Help Scout API server error (${status}). The service is temporarily unavailable.`,
+        details: {
+          requestId,
+          statusCode: status,
+          suggestion: 'Request will be automatically retried with exponential backoff',
+        },
+      };
+    }
+
+    return {
+      code: 'UPSTREAM_ERROR',
+      message: 'Help Scout API error: Unknown upstream service error',
+      details: {
+        requestId,
+        errorCode: context.code,
+        suggestion: 'Check your network connection and Help Scout service status',
+      },
+    };
+  }
+
+  // --- HelpScoutApi: reads ---------------------------------------------------
+
+  async get<T>(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    // Accepted for interface parity with the axios client and ignored: the
+    // Workers build has no shared cache to read or write (a process-wide cache
+    // would leak one user's data to the next request).
+    _cacheOptions?: { ttl?: number },
+  ): Promise<T> {
+    const response = await this.executeWithRetry(endpoint, params);
+    return (await response.json()) as T;
+  }
+
+  /**
+   * Fetch successive pages of a v2 list endpoint and accumulate the embedded
+   * collection. The Mailbox v2 API has NO `size`/`pageSize` parameter — page
+   * size is fixed (25 for conversations/threads, 50 elsewhere) and any `size`
+   * is silently ignored — so callers that need more than one page must loop.
+   *
+   * Stops at `maxItems`, at the last page (`page.totalPages`), or when a page
+   * returns no items. Safe when the endpoint returns no `page` block (e.g. a
+   * cursor-based or bare-array response): `totalPages` defaults to 1, so only
+   * the first page is fetched and no over-fetch/infinite loop can occur.
+   */
+  async getAllPages<T>(
+    endpoint: string,
+    collectionKey: string,
+    params: Record<string, unknown> = {},
+    maxItems: number = Number.POSITIVE_INFINITY,
+  ): Promise<{ items: T[]; totalElements: number; pagesFetched: number; truncated: boolean }> {
+    const items: T[] = [];
+    let pageNum = typeof params.page === 'number' && params.page > 0 ? params.page : 1;
+    let totalElements = 0;
+    let totalPages = 1;
+    let pagesFetched = 0;
+
+    do {
+      const resp = await this.get<PaginatedResponse<T>>(endpoint, { ...params, page: pageNum });
+      pagesFetched++;
+      const batch = resp._embedded?.[collectionKey] ?? [];
+      items.push(...batch);
+      totalElements = resp.page?.totalElements ?? items.length;
+      totalPages = resp.page?.totalPages ?? 1;
+      if (batch.length === 0) break;
+      pageNum++;
+    } while (pageNum <= totalPages && items.length < maxItems);
+
+    const capped = Number.isFinite(maxItems) && items.length > maxItems;
+    return {
+      items: capped ? items.slice(0, maxItems) : items,
+      totalElements,
+      pagesFetched,
+      // truncated = there is more data than we are returning to the caller.
+      truncated: capped || totalElements > items.length,
+    };
+  }
+
+  async getRaw<T>(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    options: RawGetOptions = {},
+  ): Promise<RawResponse<T>> {
+    const response = await this.executeWithRetry(endpoint, params, options.headers);
+
+    let data: unknown;
+    switch (options.responseType) {
+      case 'text':
+        data = await response.text();
+        break;
+      case 'arraybuffer':
+        data = await response.arrayBuffer();
+        break;
+      case 'json':
+      default:
+        data = await response.json();
+        break;
+    }
+
+    return {
+      status: response.status,
+      data: data as T,
+      headers: headersToObject(response.headers),
+    };
+  }
+
+  // --- HelpScoutApi: writes --------------------------------------------------
+
+  /**
+   * Issue a non-idempotent request exactly once.
+   *
+   * This deliberately bypasses the read retry loop. Reads keep retrying 429 and
+   * 5xx because a repeated GET costs nothing; a repeated POST is a second
+   * customer email or a duplicate note, and a 5xx never proves the first attempt
+   * failed. Backoff is the caller's decision, because only the caller can read
+   * the target back and check whether the first attempt landed.
+   *
+   * A 401 surfaces as a HelpScoutWriteError rather than triggering a
+   * refresh-and-retry: proactive refresh (run before the write) is what keeps a
+   * write from meeting an expired token, so a 401 here is a genuine failure the
+   * caller must handle. Every failure carries the upstream status.
+   */
+  private async writeRequest<T>(
+    method: WriteMethod,
+    endpoint: string,
+    body?: unknown,
+  ): Promise<WriteResponse<T>> {
+    const requestId = this.newRequestId();
+
+    // Refresh before the write if the token is near expiry. A refresh failure
+    // (invalid_grant) surfaces as re-consent guidance and the write never fires,
+    // which is safe: nothing was sent.
+    await this.maybeProactiveRefresh();
+
+    let response: Response;
+    try {
+      const tokens = this.deps.getTokens();
+      response = await fetch(this.buildUrl(endpoint), {
+        method,
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${tokens.accessToken}`,
+          ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Write request failed', { requestId, method, endpoint, status: undefined });
+      throw new HelpScoutWriteError(message, undefined, undefined, method, endpoint, requestId);
+    }
+
+    if (!response.ok) {
+      const responseBody = await this.safeJson(response);
+      logger.error('Write request failed', { requestId, method, endpoint, status: response.status });
+      throw new HelpScoutWriteError(
+        `Request failed with status ${response.status}`,
+        response.status,
+        responseBody,
+        method,
+        endpoint,
+        requestId,
+      );
+    }
+
+    return {
+      status: response.status,
+      data: await this.parseWriteBody<T>(response),
+      headers: headersToObject(response.headers),
+    };
+  }
+
+  /**
+   * Decode a write response body. Mailbox v2 answers most mutations with
+   * `204 No Content` (and sometimes an empty 200/201); in that case the body is
+   * null and the created resource ID lives in the `Resource-Id` header instead.
+   */
+  private async parseWriteBody<T>(response: Response): Promise<T> {
+    if (response.status === 204) {
+      return null as T;
+    }
+    const text = await response.text();
+    if (text === '') {
+      return null as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return text as unknown as T;
+    }
+  }
+
+  /** Single-attempt POST. See writeRequest for why writes are never retried. */
+  async post<T = unknown>(endpoint: string, body?: unknown): Promise<WriteResponse<T>> {
+    return this.writeRequest<T>('POST', endpoint, body);
+  }
+
+  /** Single-attempt PUT. See writeRequest for why writes are never retried. */
+  async put<T = unknown>(endpoint: string, body?: unknown): Promise<WriteResponse<T>> {
+    return this.writeRequest<T>('PUT', endpoint, body);
+  }
+
+  /** Single-attempt PATCH. See writeRequest for why writes are never retried. */
+  async patch<T = unknown>(endpoint: string, body?: unknown): Promise<WriteResponse<T>> {
+    return this.writeRequest<T>('PATCH', endpoint, body);
+  }
+
+  /** Single-attempt DELETE. See writeRequest for why writes are never retried. */
+  async delete<T = unknown>(endpoint: string): Promise<WriteResponse<T>> {
+    return this.writeRequest<T>('DELETE', endpoint);
+  }
+}

--- a/src/worker/helpscout-fetch-client.ts
+++ b/src/worker/helpscout-fetch-client.ts
@@ -121,6 +121,24 @@ export class ReauthRequiredError extends Error {
   }
 }
 
+/**
+ * A refresh succeeded upstream but the rotated pair could not be saved. This
+ * must never be retried as if it were a transport blip: the old refresh token
+ * is already spent, so a second exchange with it would fail with invalid_grant
+ * and bury the real (storage) problem under wrong re-consent advice.
+ */
+export class TokenPersistenceError extends Error {
+  readonly code = 'TOKEN_PERSISTENCE_FAILED' as const;
+
+  constructor(
+    message: string,
+    readonly requestId: string,
+  ) {
+    super(message);
+    this.name = 'TokenPersistenceError';
+  }
+}
+
 /** The subset of a failed response `transformError` reasons about. */
 interface ErrorContext {
   status?: number;
@@ -146,6 +164,9 @@ export class HelpScoutFetchClient implements HelpScoutApi {
 
   constructor(private readonly deps: FetchClientDeps) {
     this.validateHttpsBaseUrl(deps.baseUrl);
+    // The token endpoint receives the refresh token and the client secret, so
+    // it gets the same HTTPS requirement as the API base.
+    this.validateHttpsUrl(deps.tokenUrl, 'Help Scout token URL');
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
@@ -165,6 +186,19 @@ export class HelpScoutFetchClient implements HelpScoutApi {
 
     if (parsed.protocol !== 'https:') {
       throw new Error('HELPSCOUT_BASE_URL must use HTTPS to protect OAuth2 credentials');
+    }
+  }
+
+  private validateHttpsUrl(url: string, label: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error(`Invalid ${label}: ${url}`);
+    }
+
+    if (parsed.protocol !== 'https:') {
+      throw new Error(`${label} must use HTTPS to protect OAuth2 credentials`);
     }
   }
 
@@ -293,15 +327,22 @@ export class HelpScoutFetchClient implements HelpScoutApi {
 
       logger.error('Token refresh rejected', { requestId, status: response.status, oauthError });
 
-      // A 400/401 (invalid_grant) means the refresh token is spent or the
-      // grant was revoked: no retry can recover it, only re-consent. Anything
-      // else (a 5xx from the token endpoint, a 429) is Help Scout misbehaving,
-      // not a dead grant, and must not tell the user to reconnect.
-      if (response.status === 400 || response.status === 401) {
+      // Only invalid_grant means the refresh token is spent or the grant was
+      // revoked, which re-consent can fix. Everything else (invalid_client is
+      // a bad deployment secret, a 5xx is Help Scout misbehaving) is not the
+      // user's session, and telling them to reconnect would be wrong advice.
+      if ((response.status === 400 || response.status === 401) && oauthError === 'invalid_grant') {
         throw new ReauthRequiredError(
           'Your Help Scout session has expired or was revoked. Please reconnect the Help Scout connector to continue.',
           requestId,
         );
+      }
+      if (response.status === 400 || response.status === 401) {
+        throw {
+          code: 'UPSTREAM_ERROR',
+          message: `Help Scout rejected the token refresh (${typeof oauthError === 'string' ? oauthError : `status ${response.status}`}). This points at the deployment's OAuth configuration, not your session.`,
+          details: { requestId, suggestion: 'Check the deployment client ID and secret against the Help Scout app.' },
+        } as ApiError;
       }
       throw this.transformError({
         status: response.status,
@@ -311,37 +352,69 @@ export class HelpScoutFetchClient implements HelpScoutApi {
       });
     }
 
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-    };
+    const data = (await this.safeJson(response)) as
+      | { access_token?: unknown; refresh_token?: unknown; expires_in?: unknown }
+      | undefined;
+
+    const accessToken = data?.access_token;
+    const refreshToken = data?.refresh_token;
+    const expiresIn = data?.expires_in;
+
+    // A 2xx with a malformed body must not overwrite usable grant state with
+    // undefined tokens and a NaN expiry.
+    if (
+      typeof accessToken !== 'string' || accessToken === '' ||
+      typeof refreshToken !== 'string' || refreshToken === '' ||
+      typeof expiresIn !== 'number' || !Number.isFinite(expiresIn)
+    ) {
+      logger.error('Token refresh returned a malformed response', { requestId });
+      throw {
+        code: 'UPSTREAM_ERROR',
+        message: 'Help Scout returned a malformed token refresh response.',
+        details: { requestId, suggestion: 'Retry later; if it persists, check Help Scout status.' },
+      } as ApiError;
+    }
 
     const rotated: UserTokenContext = {
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      expiresAt: Date.now() + data.expires_in * 1000,
+      accessToken,
+      refreshToken,
+      expiresAt: Date.now() + expiresIn * 1000,
     };
 
     // Persist the rotated pair atomically (both tokens + expiry together) before
     // any request uses it, so a crash never leaves a spent refresh token stored.
-    await this.deps.persistTokens(rotated);
+    // A persistence failure is NOT retryable: the exchange already consumed the
+    // old refresh token, and repeating it would fail with invalid_grant.
+    try {
+      await this.deps.persistTokens(rotated);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Refreshed tokens could not be persisted', { requestId, error: message });
+      throw new TokenPersistenceError(
+        'Help Scout issued new session tokens but they could not be saved. Retry shortly; if this persists the connection may need to be re-authorized.',
+        requestId,
+      );
+    }
 
     logger.info('Refreshed Help Scout access token', { requestId });
 
     return rotated;
   }
 
-  /** Issue a single GET, injecting the current per-user bearer token. */
+  /**
+   * Issue a single GET, injecting the current per-user bearer token. Returns
+   * the token it sent alongside the response so the retry loop can tell a 401
+   * produced by a since-rotated token from one produced by the current token.
+   */
   private async sendGet(
     endpoint: string,
     params?: Record<string, unknown>,
     headers?: Record<string, string>,
-  ): Promise<Response> {
+  ): Promise<{ response: Response; accessTokenUsed: string }> {
     await this.maybeProactiveRefresh();
 
     const tokens = this.deps.getTokens();
-    return fetch(this.buildUrl(endpoint, params), {
+    const response = await fetch(this.buildUrl(endpoint, params), {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -350,6 +423,7 @@ export class HelpScoutFetchClient implements HelpScoutApi {
       },
       signal: AbortSignal.timeout(this.timeoutMs),
     });
+    return { response, accessTokenUsed: tokens.accessToken };
   }
 
   // --- Read path with retry --------------------------------------------------
@@ -368,17 +442,20 @@ export class HelpScoutFetchClient implements HelpScoutApi {
   ): Promise<Response> {
     const requestId = this.newRequestId();
     let refreshedOn401 = false;
+    let staleTokenRetryDone = false;
     let lastError: ErrorContext | undefined;
 
     for (let attempt = 0; attempt <= this.retryConfig.retries; attempt++) {
       let response: Response;
+      let accessTokenUsed: string;
 
       try {
-        response = await this.sendGet(endpoint, params, headers);
+        ({ response, accessTokenUsed } = await this.sendGet(endpoint, params, headers));
       } catch (error) {
         // A refresh that failed with invalid_grant must surface as re-consent,
-        // not be swallowed as a retryable network blip.
-        if (error instanceof ReauthRequiredError) {
+        // and a spent-then-unsaved rotation must not be repeated; neither is a
+        // retryable network blip.
+        if (error instanceof ReauthRequiredError || error instanceof TokenPersistenceError) {
           throw error;
         }
 
@@ -408,6 +485,17 @@ export class HelpScoutFetchClient implements HelpScoutApi {
       }
 
       const status = response.status;
+
+      // A 401 produced under a token that has since rotated (another caller
+      // refreshed while this response was in flight) is stale: retry with the
+      // current token instead of spending another refresh on a token that was
+      // never rejected.
+      if (status === 401 && !staleTokenRetryDone && this.deps.getTokens().accessToken !== accessTokenUsed) {
+        staleTokenRetryDone = true;
+        logger.warn('Stale 401 under a rotated token, retrying with the current token', { attempt: attempt + 1, requestId });
+        attempt--;
+        continue;
+      }
 
       // Reactive refresh: a single 401 refreshes the token and retries once.
       // A second 401 (token still rejected) is a real auth failure. The retry

--- a/src/worker/helpscout-fetch-client.ts
+++ b/src/worker/helpscout-fetch-client.ts
@@ -47,13 +47,17 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 
 /**
  * The per-user OAuth pair the client reads for every request. `expiresAt`
- * (epoch ms) drives proactive refresh; it is optional so a caller that only has
- * the tokens still works, falling back to reactive refresh on a 401.
+ * (epoch ms) drives proactive refresh, which is what keeps writes usable:
+ * writes never retry a 401, so they depend on never meeting an expired token.
+ * A caller that does not know the expiry must pass 0, which forces a refresh
+ * before first use and self-heals (the refresh response carries the real
+ * expiry). It is deliberately not optional: an absent expiry would silently
+ * disable proactive refresh and strand every write once the token expires.
  */
 export interface UserTokenContext {
   accessToken: string;
   refreshToken: string;
-  expiresAt?: number;
+  expiresAt: number;
 }
 
 /**
@@ -272,7 +276,6 @@ export class HelpScoutFetchClient implements HelpScoutApi {
    */
   private async maybeProactiveRefresh(): Promise<void> {
     const tokens = this.deps.getTokens();
-    if (tokens.expiresAt === undefined) return;
     if (Date.now() > tokens.expiresAt - REFRESH_BUFFER_MS) {
       await this.refresh();
     }
@@ -411,8 +414,6 @@ export class HelpScoutFetchClient implements HelpScoutApi {
     params?: Record<string, unknown>,
     headers?: Record<string, string>,
   ): Promise<{ response: Response; accessTokenUsed: string }> {
-    await this.maybeProactiveRefresh();
-
     const tokens = this.deps.getTokens();
     const response = await fetch(this.buildUrl(endpoint, params), {
       method: 'GET',
@@ -448,6 +449,12 @@ export class HelpScoutFetchClient implements HelpScoutApi {
     for (let attempt = 0; attempt <= this.retryConfig.retries; attempt++) {
       let response: Response;
       let accessTokenUsed: string;
+
+      // Outside the transport try/catch, like the reactive refresh below: a
+      // refresh failure arrives already classified (re-consent, persistence,
+      // rate limit, upstream) and must propagate as-is, not be flattened into
+      // a retryable network blip that hammers the token endpoint per attempt.
+      await this.maybeProactiveRefresh();
 
       try {
         ({ response, accessTokenUsed } = await this.sendGet(endpoint, params, headers));


### PR DESCRIPTION
## Summary

T3 of the remote-OAuth track: a fetch-based client (`src/worker/helpscout-fetch-client.ts`) implementing the `HelpScoutApi` seam from T1, for the Cloudflare Workers deployment where each session runs on its own user's OAuth tokens. Purely additive: the stdio axios client and every existing behavior are untouched (`src/utils/helpscout-client.ts` is byte-identical).

Blueprint: `docs/plans/2026-07-30-t3-fetch-client-blueprint.md`.

## What it carries over from the axios client

- The read retry loop (network throw, timeout, 5xx, 429), with the same exponential-backoff-plus-jitter math
- Adaptive 429 waits keyed off `X-RateLimit-Retry-After`, then `Retry-After`, then backoff; never a hardcoded limit
- `transformError` with the same status-to-ApiError mapping
- `getAllPages` pagination and the raw text/arraybuffer read path (headers arrive lowercase from fetch, matching what the tool layer already reads)
- The write contract exactly: single attempt, never retried, failures carry the upstream status and the `resource-id` header is preserved

## What is new

- Per-request construction with injected deps; no module-level token state, so two users' clients cannot bleed into each other
- Proactive token refresh inside a 60s expiry buffer, plus a reactive refresh-then-retry-once on a read 401; the retry does not consume a read attempt
- Refresh-with-rotation serialized through a per-user mutex: concurrent 401s spend the rotating refresh token exactly once, and the rotated pair is persisted atomically before use
- Refresh failure classification: 400/401 from the token endpoint means a dead grant and raises `ReauthRequiredError` with reconnect guidance; a network failure or 5xx surfaces as a temporary upstream error instead, so users are never told to re-consent over a blip

## What is deliberately absent

- No shared response cache: a process-wide cache in a multi-user runtime would serve one user's data to another. The `cacheOptions` parameter is accepted for interface parity and ignored.
- No connection pool (Workers has no sockets), no wrangler config, no worker entry point; those are T4.

## Verification

- `npm run type-check`, `npm run lint` clean
- 40 unit tests over an injected fetch mock: auth injection and cross-instance isolation, no-cache proof, pagination, raw text/arraybuffer, write no-retry (exactly one fetch on 500/429/401), read retry with fake timers, transformError table, refresh rotation and single-flight serialization, invalid_grant vs transient-failure classification, and the final-attempt-401 retry
- No new dependencies

## For the next milestones

- `persistTokens` is an injected callback; T5 must wire it to the real grant-props update or refresh write-back silently no-ops (flagged on NAS-1492)
- The refresh mutex covers one Durable Object instance; account-wide serialization across sessions is the T4 decision (flagged on NAS-1491)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->