### PR TITLE
feat(NAS-1492): real Help Scout Authorization Code leg with durable token rotation

### DIFF
--- a/src/__tests__/helpscout-fetch-client.test.ts
+++ b/src/__tests__/helpscout-fetch-client.test.ts
@@ -608,6 +608,24 @@ describe('HelpScoutFetchClient', () => {
       expect(error.code).toBe('UPSTREAM_ERROR');
     });
 
+    it.each([0, -1, Number.NaN])(
+      'refuses to persist a refresh response with a nonsensical lifetime (%p)',
+      async (expiresIn) => {
+        const { client, persistTokens } = makeHarness();
+        fetchMock.mockImplementation(async (input) => {
+          if ((input as string) === TOKEN_URL) {
+            return jsonResponse({ access_token: 'access-2', refresh_token: 'refresh-2', expires_in: expiresIn });
+          }
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        });
+
+        const error = (await client.get('/conversations/1').catch((e) => e)) as { code: string };
+
+        expect(persistTokens).not.toHaveBeenCalled();
+        expect(error.code).toBe('UPSTREAM_ERROR');
+      },
+    );
+
     it('retries a stale 401 with the current token instead of rotating again', async () => {
       const harness = makeHarness();
       let apiCalls = 0;

--- a/src/__tests__/worker-oauth-cookie.test.ts
+++ b/src/__tests__/worker-oauth-cookie.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit coverage for the worker's signed consent-cookie helpers. The module is
+ * dependency-free (WebCrypto + TextEncoder, all Node globals), so the
+ * security-critical signing logic is exercised here in CI while the full
+ * consent flow is exercised by the worker smoke suite.
+ */
+import {
+  CONSENT_COOKIE_NAME,
+  CONSENT_TTL_MS,
+  buildConsentClearCookie,
+  buildConsentSetCookie,
+  readCookie,
+  signConsentCookie,
+  verifyConsentCookie,
+  type ConsentTransaction,
+} from '../../worker/src/oauth-cookie.js';
+
+const SECRET = 'test-secret-key-for-consent-cookies';
+
+interface FakeAuthRequest {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+}
+
+function freshTxn(overrides: Partial<ConsentTransaction<FakeAuthRequest>> = {}): ConsentTransaction<FakeAuthRequest> {
+  return {
+    oauthReq: {
+      clientId: 'client-1',
+      redirectUri: 'https://example.com/callback',
+      state: 'client-state',
+    },
+    exp: Date.now() + CONSENT_TTL_MS,
+    ...overrides,
+  };
+}
+
+describe('consent cookie signing', () => {
+  it('round-trips a transaction, preserving client-supplied unicode', async () => {
+    const txn = freshTxn({
+      oauthReq: { clientId: 'client-✓-日本語', redirectUri: 'https://example.com/cb', state: 'état-✓' },
+      state: 'hs-state-1',
+    });
+
+    const cookie = await signConsentCookie(txn, SECRET);
+    const decoded = await verifyConsentCookie<FakeAuthRequest>(cookie, SECRET);
+
+    expect(decoded).toEqual(txn);
+  });
+
+  it('rejects a tampered body even when the signature is untouched', async () => {
+    const cookie = await signConsentCookie(freshTxn(), SECRET);
+    const [body, sig] = [cookie.slice(0, cookie.lastIndexOf('.')), cookie.slice(cookie.lastIndexOf('.') + 1)];
+    const other = await signConsentCookie(
+      freshTxn({ oauthReq: { clientId: 'attacker', redirectUri: 'https://attacker.example/cb', state: 'x' } }),
+      SECRET,
+    );
+    const otherBody = other.slice(0, other.lastIndexOf('.'));
+
+    expect(otherBody).not.toBe(body);
+    expect(await verifyConsentCookie(`${otherBody}.${sig}`, SECRET)).toBeNull();
+  });
+
+  it('rejects a valid body signed with a different secret', async () => {
+    const cookie = await signConsentCookie(freshTxn(), 'some-other-secret');
+
+    expect(await verifyConsentCookie(cookie, SECRET)).toBeNull();
+  });
+
+  it('rejects an expired transaction', async () => {
+    const cookie = await signConsentCookie(freshTxn({ exp: Date.now() - 1 }), SECRET);
+
+    expect(await verifyConsentCookie(cookie, SECRET)).toBeNull();
+  });
+
+  it.each([undefined, '', 'no-dot', '.leading-dot', 'not!base64.not!base64'])(
+    'rejects malformed cookie value %p without throwing',
+    async (value) => {
+      expect(await verifyConsentCookie(value as string | undefined, SECRET)).toBeNull();
+    },
+  );
+});
+
+describe('cookie header helpers', () => {
+  it('sets an HTTP-only, secure, lax cookie bounded by the consent TTL', () => {
+    const header = buildConsentSetCookie('abc');
+
+    expect(header).toContain(`${CONSENT_COOKIE_NAME}=abc`);
+    expect(header).toContain('HttpOnly');
+    expect(header).toContain('Secure');
+    expect(header).toContain('SameSite=Lax');
+    expect(header).toContain(`Max-Age=${Math.floor(CONSENT_TTL_MS / 1000)}`);
+  });
+
+  it('clears the cookie with a zero max-age', () => {
+    expect(buildConsentClearCookie()).toContain('Max-Age=0');
+  });
+
+  it('reads the named cookie out of a multi-cookie header', () => {
+    const request = new Request('https://example.com/', {
+      headers: { Cookie: `other=1; ${CONSENT_COOKIE_NAME}=the-value; another=2` },
+    });
+
+    expect(readCookie(request, CONSENT_COOKIE_NAME)).toBe('the-value');
+    expect(readCookie(request, 'missing')).toBeUndefined();
+    expect(readCookie(new Request('https://example.com/'), CONSENT_COOKIE_NAME)).toBeUndefined();
+  });
+});

--- a/src/worker/helpscout-fetch-client.ts
+++ b/src/worker/helpscout-fetch-client.ts
@@ -364,11 +364,12 @@ export class HelpScoutFetchClient implements HelpScoutApi {
     const expiresIn = data?.expires_in;
 
     // A 2xx with a malformed body must not overwrite usable grant state with
-    // undefined tokens and a NaN expiry.
+    // undefined tokens or a nonsensical expiry (zero or negative would persist
+    // an already-expired pair and rotate again on every request).
     if (
       typeof accessToken !== 'string' || accessToken === '' ||
       typeof refreshToken !== 'string' || refreshToken === '' ||
-      typeof expiresIn !== 'number' || !Number.isFinite(expiresIn)
+      typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0
     ) {
       logger.error('Token refresh returned a malformed response', { requestId });
       throw {

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -17,7 +17,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-const NODE_BIN = '/opt/homebrew/bin/node';
+const NODE_BIN = process.env.SMOKE_NODE_BIN || process.execPath;
 const WORKER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const WORKER_PORT = Number(process.env.WORKER_PORT || 8787);
 const BASE = `http://127.0.0.1:${WORKER_PORT}`;

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -46,7 +46,7 @@ const b64url = (buf) =>
 // State is mutated directly from the smoke process (same runtime) to exercise
 // the light-user path and to observe refresh-token rotation.
 function startMockHelpScout() {
-  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0 };
+  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0, issuedCodes: new Set() };
 
   const readBody = (req) =>
     new Promise((resolve) => {
@@ -63,6 +63,7 @@ function startMockHelpScout() {
     if (url.pathname === '/hs/authorize' && req.method === 'GET') {
       const clientState = url.searchParams.get('state') || '';
       const code = `hs-code-${crypto.randomBytes(6).toString('hex')}`;
+      state.issuedCodes.add(code);
       const loc = `${REDIRECT_URI}?code=${encodeURIComponent(code)}&state=${encodeURIComponent(clientState)}`;
       res.writeHead(302, { Location: loc });
       res.end();
@@ -83,6 +84,14 @@ function startMockHelpScout() {
         };
       };
       if (body.grant_type === 'authorization_code') {
+        // Codes are single-use, like the real Help Scout: a replayed callback
+        // must fail here, which is the worker's authoritative replay defense.
+        if (!state.issuedCodes.has(body.code)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid_grant' }));
+          return;
+        }
+        state.issuedCodes.delete(body.code);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(issue()));
         return;
@@ -480,10 +489,11 @@ async function runMode({ mock, enableWrites }) {
     const tampered = await fetch(tamperUrl, { redirect: 'manual', headers: { Cookie: `${CONSENT_COOKIE}=${captured.cookie}` } });
     check('tampered state at /callback is rejected', tampered.status === 400, `status ${tampered.status}`);
 
-    // Replay: the captured callback's state was already consumed by the happy
-    // path above, so replaying it must be rejected by the single-use marker.
+    // Replay: the captured callback's code was already spent by the happy path
+    // above, so replaying it must fail the (single-use) code exchange upstream
+    // and surface as a sign-in failure, never a completed grant.
     const replayed = await fetch(captured.callbackUrl, { redirect: 'manual', headers: { Cookie: `${CONSENT_COOKIE}=${captured.cookie}` } });
-    check('replayed state at /callback is rejected', replayed.status === 400, `status ${replayed.status}`);
+    check('replayed callback is rejected via the single-use code', replayed.status === 502, `status ${replayed.status}`);
   }
 
   // [8] light-user 403 -> seat-required page, no grant

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -1,13 +1,31 @@
-// T4 smoke test against a running `wrangler dev`. Verifies the OAuth shell end
-// to end with the stub upstream: discovery metadata, the 401 challenge, Dynamic
-// Client Registration, the full auth-code + PKCE flow, and initialize +
-// tools/list over Streamable HTTP advertising the three read tools.
+// End-to-end smoke for the Help Scout remote MCP worker.
 //
-// Usage: BASE=http://localhost:8787 node scripts/smoke.mjs
+// Self-contained: it starts a local mock Help Scout (authorize redirect, token
+// endpoint, users/me), spawns `wrangler dev` with the worker's HELPSCOUT_* vars
+// pointed at the mock, and drives the FULL per-user OAuth flow — consent →
+// approve → mock Help Scout → /callback → token exchange → /mcp initialize +
+// tools/list — for both write modes. No live Help Scout is reachable from
+// localhost (the redirect URL is fixed at app registration), so the mock stands
+// in for it.
+//
+// Usage: node scripts/smoke.mjs            (runs read-only and write modes)
+//        SMOKE_MODE=reads node scripts/smoke.mjs
+//        SMOKE_MODE=writes node scripts/smoke.mjs
 import crypto from 'node:crypto';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
-const BASE = (process.env.BASE || 'http://localhost:8787').replace(/\/$/, '');
+const NODE_BIN = '/opt/homebrew/bin/node';
+const WORKER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const WORKER_PORT = Number(process.env.WORKER_PORT || 8787);
+const BASE = `http://127.0.0.1:${WORKER_PORT}`;
 const REDIRECT_URI = `${BASE}/callback`;
+const READY_TIMEOUT_MS = 90_000;
+
+const MOCK_USER = { id: 987, firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.test', type: 'user' };
+const HS_EXPIRES_IN = 172800; // 48h, matching Help Scout
 
 let passed = 0;
 const failures = [];
@@ -24,19 +42,176 @@ function check(name, cond, detail = '') {
 const b64url = (buf) =>
   Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 
-// --- Streamable HTTP body decode (SSE or JSON) -----------------------------
+// --- Mock Help Scout --------------------------------------------------------
+// State is mutated directly from the smoke process (same runtime) to exercise
+// the light-user path and to observe refresh-token rotation.
+function startMockHelpScout() {
+  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0 };
+
+  const readBody = (req) =>
+    new Promise((resolve) => {
+      let data = '';
+      req.on('data', (c) => (data += c));
+      req.on('end', () => resolve(data));
+    });
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1`);
+
+    // Authorize: takes client_id + state, immediately redirects to the fixed
+    // worker callback carrying a code and echoing the state.
+    if (url.pathname === '/hs/authorize' && req.method === 'GET') {
+      const clientState = url.searchParams.get('state') || '';
+      const code = `hs-code-${crypto.randomBytes(6).toString('hex')}`;
+      const loc = `${REDIRECT_URI}?code=${encodeURIComponent(code)}&state=${encodeURIComponent(clientState)}`;
+      res.writeHead(302, { Location: loc });
+      res.end();
+      return;
+    }
+
+    // Token endpoint: authorization_code and refresh_token grants.
+    if (url.pathname === '/hs/token' && req.method === 'POST') {
+      const body = JSON.parse((await readBody(req)) || '{}');
+      const issue = () => {
+        state.accessCounter += 1;
+        state.currentRefreshToken = `hs-refresh-${state.accessCounter}`;
+        return {
+          access_token: `hs-access-${state.accessCounter}`,
+          refresh_token: state.currentRefreshToken,
+          token_type: 'bearer',
+          expires_in: HS_EXPIRES_IN,
+        };
+      };
+      if (body.grant_type === 'authorization_code') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(issue()));
+        return;
+      }
+      if (body.grant_type === 'refresh_token') {
+        // Rotating refresh: the presented token must be the current one.
+        if (body.refresh_token !== state.currentRefreshToken) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid_grant' }));
+          return;
+        }
+        state.refreshCount += 1;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(issue()));
+        return;
+      }
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unsupported_grant_type' }));
+      return;
+    }
+
+    // Identity. Light Users have no Mailbox API access: 403 even with a token.
+    if (url.pathname === '/hs/users/me' && req.method === 'GET') {
+      if (state.lightUser) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'forbidden' }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(MOCK_USER));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ url: `http://127.0.0.1:${port}`, state, close: () => new Promise((r) => server.close(r)) });
+    });
+  });
+}
+
+// --- wrangler dev lifecycle -------------------------------------------------
+function startWorker({ mockUrl, enableWrites }) {
+  const args = [
+    './node_modules/.bin/wrangler',
+    'dev',
+    '--port',
+    String(WORKER_PORT),
+    '--ip',
+    '127.0.0.1',
+    '--var',
+    `HELPSCOUT_AUTHORIZE_URL:${mockUrl}/hs/authorize`,
+    '--var',
+    `HELPSCOUT_TOKEN_URL:${mockUrl}/hs/token`,
+    '--var',
+    `HELPSCOUT_BASE_URL:${mockUrl}/hs/`,
+    '--var',
+    `HELPSCOUT_ENABLE_WRITES:${enableWrites ? 'true' : 'false'}`,
+  ];
+  const proc = spawn(NODE_BIN, args, {
+    cwd: WORKER_DIR,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, WRANGLER_SEND_METRICS: 'false' },
+  });
+  let log = '';
+  proc.stdout.on('data', (d) => (log += d));
+  proc.stderr.on('data', (d) => (log += d));
+
+  const close = () =>
+    new Promise((resolve) => {
+      if (proc.exitCode !== null) return resolve();
+      proc.once('exit', () => resolve());
+      try {
+        process.kill(-proc.pid, 'SIGTERM');
+      } catch {
+        try { proc.kill('SIGTERM'); } catch { /* already gone */ }
+      }
+      setTimeout(() => {
+        try { process.kill(-proc.pid, 'SIGKILL'); } catch { /* ignore */ }
+        resolve();
+      }, 5000).unref();
+    });
+
+  return { proc, close, getLog: () => log };
+}
+
+async function waitForReady(getLog) {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE}/.well-known/oauth-protected-resource`);
+      if (res.ok) return true;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 750));
+  }
+  throw new Error(`worker did not become ready within ${READY_TIMEOUT_MS}ms.\n--- wrangler output ---\n${getLog()}`);
+}
+
+// --- Cookie jar + Streamable HTTP helpers -----------------------------------
+const CONSENT_COOKIE = 'hs_mcp_txn';
+function setCookieValues(res) {
+  const raw = typeof res.headers.getSetCookie === 'function' ? res.headers.getSetCookie() : [];
+  const single = res.headers.get('set-cookie');
+  const all = raw.length ? raw : single ? [single] : [];
+  const jar = {};
+  for (const line of all) {
+    const first = line.split(';', 1)[0];
+    const eq = first.indexOf('=');
+    if (eq > 0) jar[first.slice(0, eq).trim()] = first.slice(eq + 1).trim();
+  }
+  return jar;
+}
+
 async function readRpc(res) {
   const ct = res.headers.get('content-type') || '';
   const text = await res.text();
   if (ct.includes('text/event-stream')) {
-    // Concatenate the JSON payloads of `data:` lines; return the last object.
     const objs = [];
     for (const line of text.split('\n')) {
       const t = line.trim();
       if (t.startsWith('data:')) {
         const payload = t.slice(5).trim();
         if (payload && payload !== '[DONE]') {
-          try { objs.push(JSON.parse(payload)); } catch { /* ignore keepalives */ }
+          try { objs.push(JSON.parse(payload)); } catch { /* keepalive */ }
         }
       }
     }
@@ -45,79 +220,104 @@ async function readRpc(res) {
   try { return JSON.parse(text); } catch { return { _raw: text }; }
 }
 
-async function main() {
-  console.log(`\nHelp Scout MCP worker smoke — ${BASE}\n`);
+// Drive one full consent + Help Scout flow. Returns the OUR-token pair plus the
+// authorization code, or an object describing where it stopped when a stage is
+// expected to fail (used by the tamper/replay/light-user checks).
+async function runFullFlow({ clientId, resource, stateOverride, lightUser, mock, capture }) {
+  const verifier = b64url(crypto.randomBytes(32));
+  const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+  const clientState = stateOverride ?? b64url(crypto.randomBytes(8));
 
-  // 1. Protected-resource metadata (RFC 9728)
-  console.log('[1] discovery metadata');
-  const prmRes = await fetch(`${BASE}/.well-known/oauth-protected-resource`);
-  check('protected-resource metadata is 200', prmRes.status === 200, `status ${prmRes.status}`);
-  const prm = await prmRes.json().catch(() => ({}));
-  check('protected-resource has resource', typeof prm.resource === 'string', JSON.stringify(prm.resource));
-  check(
-    'protected-resource has authorization_servers',
-    Array.isArray(prm.authorization_servers) && prm.authorization_servers.length > 0,
-  );
-  const resource = prm.resource;
+  // 1. GET /authorize -> consent page + signed cookie C1
+  const authGet = new URL(`${BASE}/authorize`);
+  authGet.searchParams.set('response_type', 'code');
+  authGet.searchParams.set('client_id', clientId);
+  authGet.searchParams.set('redirect_uri', REDIRECT_URI);
+  authGet.searchParams.set('code_challenge', challenge);
+  authGet.searchParams.set('code_challenge_method', 'S256');
+  authGet.searchParams.set('state', clientState);
+  if (resource) authGet.searchParams.set('resource', resource);
 
-  // Authorization-server metadata (RFC 8414)
-  const asRes = await fetch(`${BASE}/.well-known/oauth-authorization-server`);
-  check('authorization-server metadata is 200', asRes.status === 200, `status ${asRes.status}`);
-  const as = await asRes.json().catch(() => ({}));
-  check('AS metadata has issuer', typeof as.issuer === 'string');
-  check('AS metadata has authorization_endpoint', typeof as.authorization_endpoint === 'string');
-  check('AS metadata has token_endpoint', typeof as.token_endpoint === 'string');
-  check('AS metadata has registration_endpoint', typeof as.registration_endpoint === 'string');
-  check(
-    'AS metadata advertises S256 PKCE',
-    Array.isArray(as.code_challenge_methods_supported) &&
-      as.code_challenge_methods_supported.includes('S256'),
-    JSON.stringify(as.code_challenge_methods_supported),
-  );
+  const consent = await fetch(authGet, { headers: { Accept: 'text/html' }, redirect: 'manual' });
+  if (consent.status !== 200) throw new Error(`/authorize returned ${consent.status}`);
+  const c1 = setCookieValues(consent)[CONSENT_COOKIE];
+  if (!c1) throw new Error('consent page set no consent cookie');
 
-  const authorizeUrl = as.authorization_endpoint || `${BASE}/authorize`;
-  const tokenUrl = as.token_endpoint || `${BASE}/token`;
-  const registerUrl = as.registration_endpoint || `${BASE}/register`;
-
-  // 2. Unauthenticated /mcp -> 401 + WWW-Authenticate
-  console.log('[2] unauthenticated /mcp challenge');
-  const unauth = await fetch(`${BASE}/mcp`, {
+  // 2. POST /approve -> 302 to mock Help Scout authorize + cookie C2
+  const approveRes = await fetch(`${BASE}/approve`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    redirect: 'manual',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: `${CONSENT_COOKIE}=${c1}` },
+    body: new URLSearchParams({ approve: 'true' }).toString(),
   });
-  check('unauthenticated POST /mcp is 401', unauth.status === 401, `status ${unauth.status}`);
-  check(
-    'unauthenticated /mcp sends WWW-Authenticate',
-    typeof unauth.headers.get('www-authenticate') === 'string',
-    unauth.headers.get('www-authenticate') || '(missing)',
-  );
+  if (approveRes.status !== 302) throw new Error(`/approve did not redirect (status ${approveRes.status})`);
+  const hsAuthorize = approveRes.headers.get('location');
+  const c2 = setCookieValues(approveRes)[CONSENT_COOKIE] || c1;
 
-  // 3. Dynamic Client Registration
-  console.log('[3] dynamic client registration');
-  const regRes = await fetch(registerUrl, {
+  // 3. Follow to mock Help Scout authorize -> 302 back to /callback?code&state
+  const hsRes = await fetch(hsAuthorize, { redirect: 'manual' });
+  if (hsRes.status !== 302) throw new Error(`mock HS authorize did not redirect (status ${hsRes.status})`);
+  const callbackUrl = new URL(hsRes.headers.get('location'));
+
+  if (capture) capture({ callbackUrl, cookie: c2 });
+
+  // Optional light-user toggle: flip the mock so users/me 403s on this callback.
+  if (lightUser && mock) mock.state.lightUser = true;
+
+  // 4. GET /callback -> 302 back to the MCP client (or seat-required page)
+  const cbRes = await fetch(callbackUrl, {
+    redirect: 'manual',
+    headers: { Cookie: `${CONSENT_COOKIE}=${c2}` },
+  });
+
+  if (lightUser && mock) mock.state.lightUser = false;
+
+  if (cbRes.status !== 302) {
+    // Expected for the light-user path and tamper/replay cases.
+    const body = await cbRes.text();
+    return { stopped: 'callback', status: cbRes.status, body };
+  }
+
+  const clientRedirect = new URL(cbRes.headers.get('location'));
+  const ourCode = clientRedirect.searchParams.get('code');
+  if (!ourCode) throw new Error(`callback redirect carried no code: ${clientRedirect}`);
+
+  // 5. Exchange OUR code at /token
+  const form = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: ourCode,
+    redirect_uri: REDIRECT_URI,
+    client_id: clientId,
+    code_verifier: verifier,
+  });
+  if (resource) form.set('resource', resource);
+  const tokenRes = await fetch(`${BASE}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  });
+  const tokenBody = await tokenRes.json().catch(() => ({}));
+  if (!tokenRes.ok) throw new Error(`/token failed: ${tokenRes.status} ${JSON.stringify(tokenBody)}`);
+  return { accessToken: tokenBody.access_token, refreshToken: tokenBody.refresh_token, clientState };
+}
+
+async function registerClient(registerUrl, clientName) {
+  const res = await fetch(registerUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      client_name: 'T4 Smoke Client',
+      client_name: clientName,
       redirect_uris: [REDIRECT_URI],
       token_endpoint_auth_method: 'none',
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
     }),
   });
-  check('DCR is 200/201', regRes.status === 200 || regRes.status === 201, `status ${regRes.status}`);
-  const reg = await regRes.json().catch(() => ({}));
-  check('DCR returned client_id', typeof reg.client_id === 'string', JSON.stringify(reg.client_id));
-  const clientId = reg.client_id;
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, clientId: body.client_id };
+}
 
-  // 4. Auth-code + PKCE flow (stub consent auto-approve)
-  console.log('[4] authorization-code + PKCE flow');
-  const token = await runAuthFlow({ authorizeUrl, tokenUrl, clientId, resource });
-  check('token exchange returned an access_token', typeof token === 'string' && token.length > 0);
-
-  // 5. initialize + tools/list over Streamable HTTP
-  console.log('[5] MCP initialize + tools/list');
+async function mcpInitialize(token) {
   const initRes = await fetch(`${BASE}/mcp`, {
     method: 'POST',
     headers: {
@@ -129,104 +329,219 @@ async function main() {
       jsonrpc: '2.0',
       id: 1,
       method: 'initialize',
-      params: {
-        protocolVersion: '2025-06-18',
-        capabilities: {},
-        clientInfo: { name: 'smoke', version: '0.0.0' },
-      },
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0.0.0' } },
     }),
   });
-  check('authenticated initialize is 200', initRes.status === 200, `status ${initRes.status}`);
   const sessionId = initRes.headers.get('mcp-session-id') || initRes.headers.get('Mcp-Session-Id');
   const initBody = await readRpc(initRes);
   const protocolVersion = initBody?.result?.protocolVersion || '2025-06-18';
-  check('initialize returned serverInfo', Boolean(initBody?.result?.serverInfo), JSON.stringify(initBody?.result));
-
-  const mcpHeaders = {
+  const headers = {
     Authorization: `Bearer ${token}`,
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
     'MCP-Protocol-Version': protocolVersion,
   };
-  if (sessionId) mcpHeaders['Mcp-Session-Id'] = sessionId;
-
-  // notifications/initialized (fire-and-forget)
+  if (sessionId) headers['Mcp-Session-Id'] = sessionId;
   await fetch(`${BASE}/mcp`, {
     method: 'POST',
-    headers: mcpHeaders,
+    headers,
     body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
   }).catch(() => {});
+  return { status: initRes.status, initBody, headers };
+}
 
-  const listRes = await fetch(`${BASE}/mcp`, {
+async function toolsList(headers) {
+  const res = await fetch(`${BASE}/mcp`, {
     method: 'POST',
-    headers: mcpHeaders,
+    headers,
     body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
   });
-  check('tools/list is 200', listRes.status === 200, `status ${listRes.status}`);
-  const listBody = await readRpc(listRes);
-  const tools = (listBody?.result?.tools || []).map((t) => t.name);
-  console.log(`       advertised tools: ${tools.join(', ') || '(none)'}`);
+  const body = await readRpc(res);
+  return { status: res.status, tools: (body?.result?.tools || []).map((t) => t.name) };
+}
+
+// --- One full mode (writes off / on) ----------------------------------------
+async function runMode({ mock, enableWrites }) {
+  const label = enableWrites ? 'writes enabled' : 'read-only';
+  console.log(`\n=== mode: ${label} (${BASE}) ===\n`);
+
+  // [1] discovery metadata
+  console.log('[1] discovery metadata');
+  const prmRes = await fetch(`${BASE}/.well-known/oauth-protected-resource`);
+  check('protected-resource metadata is 200', prmRes.status === 200, `status ${prmRes.status}`);
+  const prm = await prmRes.json().catch(() => ({}));
+  check('protected-resource has resource', typeof prm.resource === 'string');
+  check('protected-resource has authorization_servers', Array.isArray(prm.authorization_servers) && prm.authorization_servers.length > 0);
+  const resource = prm.resource;
+
+  const asRes = await fetch(`${BASE}/.well-known/oauth-authorization-server`);
+  check('authorization-server metadata is 200', asRes.status === 200, `status ${asRes.status}`);
+  const as = await asRes.json().catch(() => ({}));
+  check('AS metadata has authorization_endpoint', typeof as.authorization_endpoint === 'string');
+  check('AS metadata has token_endpoint', typeof as.token_endpoint === 'string');
+  check('AS metadata has registration_endpoint', typeof as.registration_endpoint === 'string');
+  check(
+    'AS metadata advertises S256 PKCE',
+    Array.isArray(as.code_challenge_methods_supported) && as.code_challenge_methods_supported.includes('S256'),
+  );
+  const registerUrl = as.registration_endpoint || `${BASE}/register`;
+
+  // [2] unauthenticated /mcp -> 401 + WWW-Authenticate
+  console.log('[2] unauthenticated /mcp challenge');
+  const unauth = await fetch(`${BASE}/mcp`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+  });
+  check('unauthenticated POST /mcp is 401', unauth.status === 401, `status ${unauth.status}`);
+  check('unauthenticated /mcp sends WWW-Authenticate', typeof unauth.headers.get('www-authenticate') === 'string');
+
+  // [3] DCR
+  console.log('[3] dynamic client registration');
+  const reg = await registerClient(registerUrl, 'Smoke Client');
+  check('DCR is 200/201', reg.status === 200 || reg.status === 201, `status ${reg.status}`);
+  check('DCR returned client_id', typeof reg.clientId === 'string');
+
+  // [4] full Help Scout auth-code flow through the mock
+  console.log('[4] full per-user Help Scout auth-code flow');
+  const flow = await runFullFlow({ clientId: reg.clientId, resource, mock });
+  check('OUR token issued after full Help Scout flow', typeof flow.accessToken === 'string' && flow.accessToken.length > 0);
+  check('OUR refresh token issued', typeof flow.refreshToken === 'string' && flow.refreshToken.length > 0);
+
+  // [5] initialize + tools/list; assert the grant carries the mock user identity
+  console.log('[5] MCP initialize + tools/list');
+  const init = await mcpInitialize(flow.accessToken);
+  check('authenticated initialize is 200', init.status === 200, `status ${init.status}`);
+  check('initialize returned serverInfo', Boolean(init.initBody?.result?.serverInfo));
+  const instructions = init.initBody?.result?.instructions || '';
+  check('grant carries the mock user identity (instructions name the user)', instructions.includes(MOCK_USER.email), instructions);
+
+  const list = await toolsList(init.headers);
+  check('tools/list is 200', list.status === 200, `status ${list.status}`);
+  console.log(`       advertised tools: ${list.tools.join(', ') || '(none)'}`);
   for (const name of ['search_help_scout', 'describe_help_scout', 'read_help_scout']) {
-    check(`advertises ${name}`, tools.includes(name));
+    check(`advertises ${name}`, list.tools.includes(name));
   }
-  if (process.env.EXPECT_WRITES === '1') {
-    check('write_help_scout advertised while writes enabled', tools.includes('write_help_scout'));
+  if (enableWrites) {
+    check('write_help_scout advertised while writes enabled', list.tools.includes('write_help_scout'));
   } else {
-    check('write_help_scout hidden while writes disabled', !tools.includes('write_help_scout'));
+    check('write_help_scout hidden while writes disabled', !list.tools.includes('write_help_scout'));
   }
 
-  // 6. Consent-surface robustness: client-supplied unicode must not break the
-  // consent page (the AuthRequest round-trip is TextEncoder-based, not bare
-  // btoa), and a malformed round-trip blob must be a 400, not a 500.
-  console.log('[6] consent-surface robustness');
-  const uniReg = await fetch(registerUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      client_name: 'T4 Smoke ✓ 日本語 Client',
-      redirect_uris: [REDIRECT_URI],
-      token_endpoint_auth_method: 'none',
-      grant_types: ['authorization_code', 'refresh_token'],
-      response_types: ['code'],
-    }),
+  // [6] durable refresh rotation via tokenExchangeCallback
+  console.log('[6] durable refresh-token rotation');
+  const beforeRefreshes = mock.state.refreshCount;
+  const refreshForm = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: flow.refreshToken,
+    client_id: reg.clientId,
   });
-  const uniClientId = (await uniReg.json().catch(() => ({}))).client_id;
-  check('DCR accepts a unicode client name', typeof uniClientId === 'string');
-  if (uniClientId) {
-    const uniToken = await runAuthFlow({
-      authorizeUrl,
-      tokenUrl,
-      clientId: uniClientId,
-      resource,
-      stateOverride: 'smoke-✓-state-日本語',
-    });
-    check('auth flow survives unicode client name and state', typeof uniToken === 'string' && uniToken.length > 0);
-  }
-  const badApprove = await fetch(`${BASE}/approve`, {
+  const refreshRes = await fetch(`${BASE}/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ oauth_req: '!!not-valid-base64!!', approve: 'true' }).toString(),
+    body: refreshForm.toString(),
   });
-  check('malformed oauth_req is a 400, not a 500', badApprove.status === 400, `status ${badApprove.status}`);
+  const refreshBody = await refreshRes.json().catch(() => ({}));
+  check('OUR token refresh succeeds', refreshRes.ok && typeof refreshBody.access_token === 'string', `status ${refreshRes.status}`);
+  check('refresh rotated the Help Scout token upstream', mock.state.refreshCount === beforeRefreshes + 1, `count ${mock.state.refreshCount}`);
+  if (refreshBody.access_token) {
+    const reinit = await mcpInitialize(refreshBody.access_token);
+    check('initialize still works after refresh (identity preserved)', reinit.status === 200 && (reinit.initBody?.result?.instructions || '').includes(MOCK_USER.email));
+  }
 
-  // 7. RFC 8707 resource binding on token exchange (soft — reference oracle #2)
-  console.log('[7] resource-mismatch on token exchange (soft)');
+  // [7] consent-surface robustness: unicode, missing cookie, tamper, replay
+  console.log('[7] consent-surface robustness');
+  const uni = await registerClient(registerUrl, 'Smoke ✓ 日本語 Client');
+  check('DCR accepts a unicode client name', typeof uni.clientId === 'string');
+  if (uni.clientId) {
+    const uniFlow = await runFullFlow({ clientId: uni.clientId, resource, stateOverride: 'smoke-✓-state-日本語', mock });
+    check('flow survives unicode client name and state', typeof uniFlow.accessToken === 'string' && uniFlow.accessToken.length > 0);
+  }
+
+  const noCookie = await fetch(`${BASE}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ approve: 'true' }).toString(),
+  });
+  check('missing/invalid consent cookie is a 400, not a 500', noCookie.status === 400, `status ${noCookie.status}`);
+
+  // Tampered state: complete through the callback URL but with a state that does
+  // not match the cookie's bound state.
+  console.log('       tamper + replay');
+  let captured;
+  await runFullFlow({ clientId: reg.clientId, resource, mock, capture: (c) => (captured = c) })
+    .catch(() => {}); // the happy path completes; we reuse the captured callback for replay below
+  if (!captured) {
+    check('tamper/replay probe reached the callback stage', false, 'flow did not reach the Help Scout callback');
+  } else {
+    // Build a callback with a mismatched state query param.
+    const tamperUrl = new URL(captured.callbackUrl);
+    tamperUrl.searchParams.set('state', 'not-the-bound-state');
+    const tampered = await fetch(tamperUrl, { redirect: 'manual', headers: { Cookie: `${CONSENT_COOKIE}=${captured.cookie}` } });
+    check('tampered state at /callback is rejected', tampered.status === 400, `status ${tampered.status}`);
+
+    // Replay: the captured callback's state was already consumed by the happy
+    // path above, so replaying it must be rejected by the single-use marker.
+    const replayed = await fetch(captured.callbackUrl, { redirect: 'manual', headers: { Cookie: `${CONSENT_COOKIE}=${captured.cookie}` } });
+    check('replayed state at /callback is rejected', replayed.status === 400, `status ${replayed.status}`);
+  }
+
+  // [8] light-user 403 -> seat-required page, no grant
+  console.log('[8] light-user seat-required path');
+  const lightFlow = await runFullFlow({ clientId: reg.clientId, resource, mock, lightUser: true });
+  check('light user hits the callback error path', lightFlow.stopped === 'callback' && lightFlow.status === 403, `status ${lightFlow.status}`);
+  check('light-user page explains a full seat is required', /seat|Light User|full Help Scout/i.test(lightFlow.body || ''));
+
+  // [9] RFC 8707 resource binding on token exchange (soft)
+  console.log('[9] resource-mismatch on token exchange (soft)');
   try {
-    const mismatch = await runAuthFlow({
-      authorizeUrl,
-      tokenUrl,
-      clientId,
-      resource,
-      tokenResourceOverride: `${resource}/mismatch`,
-      expectTokenError: true,
-    });
-    if (mismatch.error) {
-      check('token exchange rejects a mismatched resource', true, `${mismatch.status} ${mismatch.error}`);
-    } else {
-      console.log('  soft: workers-oauth-provider did not reject a mismatched resource at /token (documented, not a T4 gate)');
-    }
+    // Re-drive to a fresh OUR code, then exchange with a mismatched resource.
+    const verifier = b64url(crypto.randomBytes(32));
+    const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+    const st = b64url(crypto.randomBytes(8));
+    const a = new URL(`${BASE}/authorize`);
+    a.searchParams.set('response_type', 'code');
+    a.searchParams.set('client_id', reg.clientId);
+    a.searchParams.set('redirect_uri', REDIRECT_URI);
+    a.searchParams.set('code_challenge', challenge);
+    a.searchParams.set('code_challenge_method', 'S256');
+    a.searchParams.set('state', st);
+    if (resource) a.searchParams.set('resource', resource);
+    const consent = await fetch(a, { headers: { Accept: 'text/html' }, redirect: 'manual' });
+    const c1 = setCookieValues(consent)[CONSENT_COOKIE];
+    const appr = await fetch(`${BASE}/approve`, { method: 'POST', redirect: 'manual', headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: `${CONSENT_COOKIE}=${c1}` }, body: 'approve=true' });
+    const c2 = setCookieValues(appr)[CONSENT_COOKIE] || c1;
+    const hs = await fetch(appr.headers.get('location'), { redirect: 'manual' });
+    const cb = await fetch(hs.headers.get('location'), { redirect: 'manual', headers: { Cookie: `${CONSENT_COOKIE}=${c2}` } });
+    const ourCode = new URL(cb.headers.get('location')).searchParams.get('code');
+    const form = new URLSearchParams({ grant_type: 'authorization_code', code: ourCode, redirect_uri: REDIRECT_URI, client_id: reg.clientId, code_verifier: verifier, resource: `${resource}/mismatch` });
+    const tr = await fetch(`${BASE}/token`, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: form.toString() });
+    if (!tr.ok) check('token exchange rejects a mismatched resource', true, `status ${tr.status}`);
+    else console.log('  soft: workers-oauth-provider did not reject a mismatched resource at /token (documented, not a gate)');
   } catch (e) {
     console.log(`  soft: resource-mismatch probe inconclusive — ${e.message}`);
+  }
+}
+
+async function main() {
+  const only = process.env.SMOKE_MODE; // 'reads' | 'writes' | undefined (both)
+  const modes = only === 'reads' ? [false] : only === 'writes' ? [true] : [false, true];
+
+  const mock = await startMockHelpScout();
+  console.log(`mock Help Scout on ${mock.url}`);
+
+  try {
+    for (const enableWrites of modes) {
+      const worker = startWorker({ mockUrl: mock.url, enableWrites });
+      try {
+        await waitForReady(worker.getLog);
+        await runMode({ mock, enableWrites });
+      } finally {
+        await worker.close();
+      }
+    }
+  } finally {
+    await mock.close();
   }
 
   console.log(`\n${passed} checks passed, ${failures.length} failed.`);
@@ -234,63 +549,6 @@ async function main() {
     console.log('Failures:\n  - ' + failures.join('\n  - '));
     process.exit(1);
   }
-}
-
-// Drive one auth-code + PKCE flow. Returns the access token string, or when
-// expectTokenError is set, an object describing the /token response.
-async function runAuthFlow({ authorizeUrl, tokenUrl, clientId, resource, tokenResourceOverride, expectTokenError, stateOverride }) {
-  const verifier = b64url(crypto.randomBytes(32));
-  const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
-  const state = stateOverride ?? b64url(crypto.randomBytes(8));
-
-  const authGet = new URL(authorizeUrl);
-  authGet.searchParams.set('response_type', 'code');
-  authGet.searchParams.set('client_id', clientId);
-  authGet.searchParams.set('redirect_uri', REDIRECT_URI);
-  authGet.searchParams.set('code_challenge', challenge);
-  authGet.searchParams.set('code_challenge_method', 'S256');
-  authGet.searchParams.set('state', state);
-  if (resource) authGet.searchParams.set('resource', resource);
-
-  const consent = await fetch(authGet, { headers: { Accept: 'text/html' } });
-  if (consent.status !== 200) throw new Error(`/authorize returned ${consent.status}`);
-  const html = await consent.text();
-  const m = html.match(/name="oauth_req" value="([^"]*)"/);
-  if (!m) throw new Error('consent page missing oauth_req field');
-
-  const approveRes = await fetch(`${BASE}/approve`, {
-    method: 'POST',
-    redirect: 'manual',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ oauth_req: m[1], approve: 'true' }).toString(),
-  });
-  const location = approveRes.headers.get('location');
-  if (!location) throw new Error(`/approve did not redirect (status ${approveRes.status})`);
-  const code = new URL(location).searchParams.get('code');
-  if (!code) throw new Error(`redirect carried no code: ${location}`);
-
-  const form = new URLSearchParams({
-    grant_type: 'authorization_code',
-    code,
-    redirect_uri: REDIRECT_URI,
-    client_id: clientId,
-    code_verifier: verifier,
-  });
-  if (tokenResourceOverride) form.set('resource', tokenResourceOverride);
-  else if (resource) form.set('resource', resource);
-
-  const tokenRes = await fetch(tokenUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: form.toString(),
-  });
-  const body = await tokenRes.json().catch(() => ({}));
-
-  if (expectTokenError) {
-    return { status: tokenRes.status, error: tokenRes.ok ? null : (body.error || `status ${tokenRes.status}`), body };
-  }
-  if (!tokenRes.ok) throw new Error(`/token failed: ${tokenRes.status} ${JSON.stringify(body)}`);
-  return body.access_token;
 }
 
 main().catch((e) => {

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -3,7 +3,7 @@
  * the real Help Scout Authorization Code client (Leg B, upstream).
  *
  * Flow: GET /authorize renders a signed-cookie consent gate; POST /approve
- * redirects the browser to Help Scout's authorize URL bound to a single-use
+ * redirects the browser to Help Scout's authorize URL bound to a cookie-signed
  * `state`; GET /callback validates that state, exchanges the code for a per-user
  * Help Scout token pair, reads the user's identity, and completes the MCP
  * authorization with those real tokens in the encrypted grant props.
@@ -28,11 +28,6 @@ import {
   type ConsentTransaction,
 } from './oauth-cookie.js';
 
-/** KV key prefix for the single-use consent-state marker (namespaced away from library keys). */
-const STATE_MARKER_PREFIX = 'hsmcp_txn:';
-/** Marker TTL matches the cookie TTL. KV enforces a 60s floor; 600 is safe. */
-const STATE_MARKER_TTL_S = Math.floor(CONSENT_TTL_MS / 1000);
-
 /** HTML-escape untrusted values before echoing them into a page. */
 function esc(value: unknown): string {
   return String(value ?? '').replace(
@@ -46,7 +41,7 @@ function firstResource(resource: AuthRequest['resource']): string {
   return resource ?? '';
 }
 
-/** A random, URL-safe nonce used as the Help Scout `state` and single-use key. */
+/** A random, URL-safe nonce used as the Help Scout `state`. */
 function newState(): string {
   const bytes = new Uint8Array(24);
   crypto.getRandomValues(bytes);
@@ -149,11 +144,11 @@ async function renderConsent(request: Request, env: Env): Promise<Response> {
 }
 
 /**
- * POST /approve — mint the single-use state, then redirect to Help Scout.
+ * POST /approve — mint the state nonce, then redirect to Help Scout.
  *
  * Rebuilds the AuthRequest from the signed cookie (a missing or tampered cookie
- * is a 400), re-validates the client binding, records the state as single-use in
- * KV, and re-signs the cookie with the state bound in. The browser is sent to
+ * is a 400), re-validates the client binding, and re-signs the cookie with the
+ * freshly minted state bound in. The browser is sent to
  * Help Scout's authorize URL carrying only our client id and that state.
  */
 async function handleApprove(request: Request, env: Env): Promise<Response> {
@@ -202,11 +197,9 @@ async function handleApprove(request: Request, env: Env): Promise<Response> {
     );
   }
 
+  // The state binds the Help Scout redirect to this browser's signed cookie;
+  // single-use enforcement rides on the authorization code (see /callback).
   const state = newState();
-  // Mark the state single-use before sending the browser upstream. Consumed
-  // (get-then-delete) at /callback so a replayed callback finds nothing.
-  await env.OAUTH_KV.put(`${STATE_MARKER_PREFIX}${state}`, '1', { expirationTtl: STATE_MARKER_TTL_S });
-
   const boundTxn: ConsentTransaction<AuthRequest> = { oauthReq: txn.oauthReq, state, exp: Date.now() + CONSENT_TTL_MS };
   const cookie = await signConsentCookie(boundTxn, env.COOKIE_ENCRYPTION_KEY ?? '');
 
@@ -236,8 +229,7 @@ interface HelpScoutUser {
 /**
  * GET /callback — the Help Scout redirect target.
  *
- * Validates the state against both the signed cookie and the single-use KV
- * marker, exchanges the code for a per-user token pair, reads the user's
+ * Validates the state against the signed cookie, exchanges the code for a per-user token pair, reads the user's
  * identity (403 => a Light User without Mailbox access, shown a seat-required
  * page and NO grant), then completes the MCP authorization with the real tokens.
  */
@@ -260,19 +252,14 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     );
   }
 
-  // Consume the single-use marker. A replayed callback (state already spent, or
-  // expired) finds nothing and is rejected before any code is exchanged.
-  const markerKey = `${STATE_MARKER_PREFIX}${state}`;
-  const marker = await env.OAUTH_KV.get(markerKey);
-  if (marker === null) {
-    return htmlResponse(
-      page('Authorize Help Scout', 'This sign-in link was already used', '<p>This Help Scout sign-in link has expired or was already used. Reconnect the connector to start again.</p>'),
-      400,
-      { 'Set-Cookie': buildConsentClearCookie() },
-    );
-  }
-  await env.OAUTH_KV.delete(markerKey);
-
+  // Replay protection deliberately does NOT use a KV marker here. KV only
+  // guarantees read-after-write from the writing location, so a marker written
+  // at /approve can be invisible to a legitimate /callback that lands in a
+  // different colo (mobile handoff, egress rotation mid-login) — a valid
+  // sign-in would be rejected. The authorization code itself is single-use at
+  // Help Scout, so a replayed callback fails the exchange below; that is the
+  // authoritative defense, and the signed cookie's state binding above is the
+  // CSRF boundary.
   const client = await validateClientBinding(env, txn.oauthReq);
   if (!client) {
     return htmlResponse(

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -136,7 +136,7 @@ async function renderConsent(request: Request, env: Env): Promise<Response> {
     );
   }
 
-  const txn: ConsentTransaction = { oauthReq, exp: Date.now() + CONSENT_TTL_MS };
+  const txn: ConsentTransaction<AuthRequest> = { oauthReq, exp: Date.now() + CONSENT_TTL_MS };
   const cookie = await signConsentCookie(txn, env.COOKIE_ENCRYPTION_KEY ?? '');
   const clientLabel = client.clientName ? esc(client.clientName) : esc(oauthReq.clientId);
 
@@ -158,7 +158,7 @@ async function renderConsent(request: Request, env: Env): Promise<Response> {
  */
 async function handleApprove(request: Request, env: Env): Promise<Response> {
   const cookieValue = readCookie(request, CONSENT_COOKIE_NAME);
-  const txn = await verifyConsentCookie(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
+  const txn = await verifyConsentCookie<AuthRequest>(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
   if (!txn) {
     return htmlResponse(
       page('Authorize Help Scout', 'Session expired', '<p>This authorization session is missing or expired. Reconnect the connector to try again.</p>'),
@@ -179,7 +179,7 @@ async function handleApprove(request: Request, env: Env): Promise<Response> {
   // (get-then-delete) at /callback so a replayed callback finds nothing.
   await env.OAUTH_KV.put(`${STATE_MARKER_PREFIX}${state}`, '1', { expirationTtl: STATE_MARKER_TTL_S });
 
-  const boundTxn: ConsentTransaction = { oauthReq: txn.oauthReq, state, exp: Date.now() + CONSENT_TTL_MS };
+  const boundTxn: ConsentTransaction<AuthRequest> = { oauthReq: txn.oauthReq, state, exp: Date.now() + CONSENT_TTL_MS };
   const cookie = await signConsentCookie(boundTxn, env.COOKIE_ENCRYPTION_KEY ?? '');
 
   const authorizeUrl = new URL(env.HELPSCOUT_AUTHORIZE_URL);
@@ -219,7 +219,7 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
   const state = url.searchParams.get('state');
 
   const cookieValue = readCookie(request, CONSENT_COOKIE_NAME);
-  const txn = await verifyConsentCookie(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
+  const txn = await verifyConsentCookie<AuthRequest>(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
 
   // The cookie must verify, carry the same state Help Scout echoed back, and the
   // request must actually carry a code and state. Any mismatch is a hard reject:

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -61,6 +61,25 @@ function joinUrl(base: string, path: string): string {
 }
 
 /**
+ * Codes, client secrets, and fresh bearer tokens flow to these URLs, so they
+ * must be https — the same invariant the fetch client enforces — with a
+ * loopback exception so the smoke harness can stand in a mock upstream.
+ */
+function isSecureUpstreamUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol === 'https:') return true;
+  return (
+    url.protocol === 'http:' &&
+    (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')
+  );
+}
+
+/**
  * Both binding checks the NAS-1492 review makes mandatory: the clientId must
  * still resolve to a registered client AND the redirect URI must be one that
  * client registered. Run at approve AND callback so a crafted request cannot
@@ -80,7 +99,14 @@ async function validateClientBinding(
 function htmlResponse(body: string, status: number, extraHeaders: Record<string, string> = {}): Response {
   return new Response(body, {
     status,
-    headers: { 'Content-Type': 'text/html; charset=utf-8', ...extraHeaders },
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      // The consent surface carries an approval control; refuse all framing so
+      // it cannot be overlaid in a clickjacking frame.
+      'X-Frame-Options': 'DENY',
+      'Content-Security-Policy': "frame-ancestors 'none'",
+      ...extraHeaders,
+    },
   });
 }
 
@@ -228,6 +254,16 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     );
   }
 
+  // Refuse to send the code, client secret, or a fresh bearer token anywhere
+  // that is not https (loopback excepted for the mock-upstream harness).
+  if (!isSecureUpstreamUrl(env.HELPSCOUT_TOKEN_URL) || !isSecureUpstreamUrl(env.HELPSCOUT_BASE_URL)) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Deployment misconfigured', '<p>This server is configured with a non-https Help Scout URL. Ask whoever operates it to fix HELPSCOUT_TOKEN_URL / HELPSCOUT_BASE_URL.</p>'),
+      500,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+
   // --- Exchange the code for a per-user Help Scout token pair, server-side. ---
   let tokenData: HelpScoutTokenResponse;
   try {
@@ -267,8 +303,17 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
       { 'Set-Cookie': buildConsentClearCookie() },
     );
   }
+  // A missing lifetime is tolerated (0 = unknown = refresh before first use); a
+  // present-but-nonsensical one is a malformed response we refuse to persist.
   const expiresIn = tokenData.expires_in;
-  const expiresAt = typeof expiresIn === 'number' && Number.isFinite(expiresIn) ? Date.now() + expiresIn * 1000 : 0;
+  if (expiresIn !== undefined && (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0)) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Help Scout sign-in failed', '<p>Help Scout returned an unexpected response. Reconnect the connector and try again.</p>'),
+      502,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+  const expiresAt = typeof expiresIn === 'number' ? Date.now() + expiresIn * 1000 : 0;
 
   // --- Identity. A 403 here means a Light User (no Mailbox API access). ---
   let user: HelpScoutUser;
@@ -305,7 +350,16 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     );
   }
 
-  const userId = typeof user.id === 'number' ? user.id : Number(user.id) || 0;
+  // The grant is keyed by this identity, so a malformed users/me response must
+  // reject the authorization rather than collapse onto a shared user id.
+  const userId = typeof user.id === 'number' ? user.id : Number(user.id);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Could not read your Help Scout profile', '<p>Help Scout returned a profile without a usable identity. Try again in a moment.</p>'),
+      502,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
   const email = typeof user.email === 'string' ? user.email : '';
   const name =
     [user.firstName, user.lastName]

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -1,55 +1,39 @@
 /**
- * The OAuth shell's defaultHandler: the downstream (Leg A) consent surface.
+ * The OAuth shell's defaultHandler: the consent surface (Leg A, downstream) plus
+ * the real Help Scout Authorization Code client (Leg B, upstream).
  *
- * T4 SCOPE — STUB UPSTREAM. This renders a minimal consent page and, on
- * approval, completes the authorization with STUB Help Scout props. The real
- * Help Scout Authorization Code leg (Leg B) is T5: on approval T5 will instead
- * redirect the user to `HELPSCOUT_AUTHORIZE_URL`, handle the `/callback`, and
- * exchange the code for a real token pair before calling completeAuthorization.
+ * Flow: GET /authorize renders a signed-cookie consent gate; POST /approve
+ * redirects the browser to Help Scout's authorize URL bound to a single-use
+ * `state`; GET /callback validates that state, exchanges the code for a per-user
+ * Help Scout token pair, reads the user's identity, and completes the MCP
+ * authorization with those real tokens in the encrypted grant props.
  *
- * The structure is deliberately shaped for that swap: `renderConsent` is the
- * only place a redirect-to-Help-Scout is introduced, and `handleApprove` is the
- * only place `completeAuthorization` is called. T5 replaces the STUB_PROPS block
- * in `handleApprove` (and the plaintext `oauth_req` round-trip below with a
- * signed, CSRF-protected cookie) without touching the OAuth shell wiring.
+ * SETUP CAVEAT (load-bearing): the Help Scout app's Redirection URL is fixed at
+ * registration and must be the deployed worker's `https://.../callback`. An app
+ * born with an `http://` redirect is permanently broken for the authorize flow
+ * (Help Scout silently bounces it and editing the URL later does not heal it),
+ * so the worker must be reachable over https and the app registered with the
+ * https callback from the start.
  */
-import type { AuthRequest, OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+import type { AuthRequest, ClientInfo } from '@cloudflare/workers-oauth-provider';
 import type { Env } from './mcp-agent.js';
+import {
+  CONSENT_TTL_MS,
+  CONSENT_COOKIE_NAME,
+  buildConsentClearCookie,
+  buildConsentSetCookie,
+  readCookie,
+  signConsentCookie,
+  verifyConsentCookie,
+  type ConsentTransaction,
+} from './oauth-cookie.js';
 
-/**
- * The stub grant the T4 consent flow issues. Shape matches HelpScoutProps.
- * `expiresAt: 0` marks the (stub) token expiry as unknown, which the fetch
- * client treats as "refresh before first use". T5 replaces this whole object
- * with the real per-user token pair and identity from the Help Scout callback.
- */
-const STUB_PROPS = {
-  accessToken: 'stub',
-  refreshToken: 'stub',
-  expiresAt: 0,
-  userId: 0,
-  name: 'Stub',
-  email: 'stub@example.invalid',
-} as const;
+/** KV key prefix for the single-use consent-state marker (namespaced away from library keys). */
+const STATE_MARKER_PREFIX = 'hsmcp_txn:';
+/** Marker TTL matches the cookie TTL. KV enforces a 60s floor; 600 is safe. */
+const STATE_MARKER_TTL_S = Math.floor(CONSENT_TTL_MS / 1000);
 
-/**
- * Base64 round-trip for the pending AuthRequest. Goes through TextEncoder /
- * TextDecoder because the request carries client-supplied text (state, scope,
- * client names) and bare btoa/atob throw on any code point above U+00FF.
- */
-function encodeAuthRequest(oauthReq: AuthRequest): string {
-  const bytes = new TextEncoder().encode(JSON.stringify(oauthReq));
-  let binary = '';
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary);
-}
-
-function decodeAuthRequest(encoded: string): AuthRequest {
-  const binary = atob(encoded);
-  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-  return JSON.parse(new TextDecoder().decode(bytes)) as AuthRequest;
-}
-
-/** HTML-escape untrusted values before echoing them into the consent page. */
+/** HTML-escape untrusted values before echoing them into a page. */
 function esc(value: unknown): string {
   return String(value ?? '').replace(
     /[&<>"']/g,
@@ -62,99 +46,314 @@ function firstResource(resource: AuthRequest['resource']): string {
   return resource ?? '';
 }
 
+/** A random, URL-safe nonce used as the Help Scout `state` and single-use key. */
+function newState(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Join base URL + path the way the fetch client does, tolerating a trailing slash on the base. */
+function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}
+
 /**
- * Render the MCP consent gate. The form posts to `/approve`.
+ * Both binding checks the NAS-1492 review makes mandatory: the clientId must
+ * still resolve to a registered client AND the redirect URI must be one that
+ * client registered. Run at approve AND callback so a crafted request cannot
+ * complete a grant for an arbitrary client/redirect pair. Returns the client on
+ * success, or null when either check fails.
+ */
+async function validateClientBinding(
+  env: Env,
+  oauthReq: AuthRequest,
+): Promise<ClientInfo | null> {
+  const client = await env.OAUTH_PROVIDER.lookupClient(oauthReq.clientId);
+  if (!client) return null;
+  if (!client.redirectUris?.includes(oauthReq.redirectUri)) return null;
+  return client;
+}
+
+function htmlResponse(body: string, status: number, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/html; charset=utf-8', ...extraHeaders },
+  });
+}
+
+function page(title: string, heading: string, bodyHtml: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${esc(title)}</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#f6f3ee;color:#1f2528;display:grid;place-items:center;min-height:100vh;margin:0}
+.card{background:#fffdfa;border:1px solid #d8d1c7;border-radius:12px;padding:28px;width:360px;box-shadow:0 18px 45px rgba(55,47,38,.1)}
+h1{font-size:18px;margin:0 0 8px}p{color:#667174;font-size:13px;margin:0 0 16px;line-height:1.5}
+button{width:100%;padding:10px;background:#5b8cff;color:#fff;border:0;border-radius:8px;font-size:14px;cursor:pointer}</style></head>
+<body><div class="card"><h1>${esc(heading)}</h1>${bodyHtml}</div></body></html>`;
+}
+
+/**
+ * GET /authorize — render the MCP consent gate.
  *
- * The whole parsed AuthRequest is round-tripped as a single base64 hidden field
- * so `completeAuthorization` gets it back byte-for-byte (PKCE challenge and
- * RFC 8707 resource included). The individual hidden inputs below it mirror the
- * production reference's shape (client_id, redirect_uri, code_challenge, state,
- * scope, resource) and are display/parity only — `oauth_req` is load-bearing.
- *
- * T5 REPLACES this plaintext round-trip with a signed, short-lived cookie bound
- * to the pending authorization (the confused-deputy defense the MCP spec makes
- * a MUST for proxy servers), and adds the redirect to Help Scout.
+ * Validates the client binding, then stores the whole parsed AuthRequest in a
+ * signed HTTP-only cookie (no plaintext round-trip) and shows an explicit
+ * approve button. The form posts to /approve.
  */
 async function renderConsent(request: Request, env: Env): Promise<Response> {
   const oauthReq = await env.OAUTH_PROVIDER.parseAuthRequest(request);
-  const client = await env.OAUTH_PROVIDER.lookupClient(oauthReq.clientId);
+  const client = await validateClientBinding(env, oauthReq);
   if (!client) {
-    return new Response('Unknown OAuth client.', { status: 400 });
+    return htmlResponse(
+      page('Authorize Help Scout', 'Unknown client', '<p>This connection request could not be verified. Reconnect the connector and try again.</p>'),
+      400,
+    );
   }
 
-  const encoded = encodeAuthRequest(oauthReq);
+  const txn: ConsentTransaction = { oauthReq, exp: Date.now() + CONSENT_TTL_MS };
+  const cookie = await signConsentCookie(txn, env.COOKIE_ENCRYPTION_KEY ?? '');
   const clientLabel = client.clientName ? esc(client.clientName) : esc(oauthReq.clientId);
-  const hidden = (name: string, value: unknown): string =>
-    `<input type="hidden" name="${name}" value="${esc(value)}">`;
 
-  const page = `<!doctype html><html><head><meta charset="utf-8"><title>Authorize Help Scout MCP</title>
-<style>body{font-family:-apple-system,system-ui,sans-serif;background:#f6f3ee;color:#1f2528;display:grid;place-items:center;min-height:100vh;margin:0}
-form{background:#fffdfa;border:1px solid #d8d1c7;border-radius:12px;padding:28px;width:340px;box-shadow:0 18px 45px rgba(55,47,38,.1)}
-h1{font-size:18px;margin:0 0 4px}p{color:#667174;font-size:13px;margin:0 0 18px}
-button{width:100%;padding:10px;background:#5b8cff;color:#fff;border:0;border-radius:8px;font-size:14px;cursor:pointer}</style></head>
-<body><form method="POST" action="/approve">
-<h1>Authorize Help Scout MCP</h1>
-<p>Connect <strong>${clientLabel}</strong> to Help Scout as your user. (T4 stub: no real Help Scout login yet.)</p>
-${hidden('oauth_req', encoded)}
-${hidden('client_id', oauthReq.clientId)}
-${hidden('redirect_uri', oauthReq.redirectUri)}
-${hidden('code_challenge', oauthReq.codeChallenge)}
-${hidden('state', oauthReq.state)}
-${hidden('scope', oauthReq.scope.join(' '))}
-${hidden('resource', firstResource(oauthReq.resource))}
-<button type="submit" name="approve" value="true">Authorize</button>
-</form></body></html>`;
+  const body = `<p>Connect <strong>${clientLabel}</strong> to Help Scout. You will sign in to Help Scout, and this connection will act with your own Help Scout access.</p>
+<form method="POST" action="/approve"><button type="submit" name="approve" value="true">Continue to Help Scout</button></form>`;
 
-  return new Response(page, {
-    status: 200,
-    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  return htmlResponse(page('Authorize Help Scout', 'Authorize Help Scout', body), 200, {
+    'Set-Cookie': buildConsentSetCookie(cookie),
   });
 }
 
 /**
- * Handle the consent submit: reconstruct the AuthRequest and complete the grant
- * with STUB props. T5 replaces STUB_PROPS with the real Help Scout token pair
- * obtained from the callback, and validates the signed consent cookie here.
+ * POST /approve — mint the single-use state, then redirect to Help Scout.
+ *
+ * Rebuilds the AuthRequest from the signed cookie (a missing or tampered cookie
+ * is a 400), re-validates the client binding, records the state as single-use in
+ * KV, and re-signs the cookie with the state bound in. The browser is sent to
+ * Help Scout's authorize URL carrying only our client id and that state.
  */
 async function handleApprove(request: Request, env: Env): Promise<Response> {
-  const form = await request.formData();
-  const encoded = form.get('oauth_req');
-  if (typeof encoded !== 'string' || encoded === '') {
-    return new Response('Missing authorization request.', { status: 400 });
+  const cookieValue = readCookie(request, CONSENT_COOKIE_NAME);
+  const txn = await verifyConsentCookie(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
+  if (!txn) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Session expired', '<p>This authorization session is missing or expired. Reconnect the connector to try again.</p>'),
+      400,
+    );
   }
 
-  let oauthReq: AuthRequest;
-  try {
-    oauthReq = decodeAuthRequest(encoded);
-  } catch {
-    return new Response('Malformed authorization request.', { status: 400 });
+  const client = await validateClientBinding(env, txn.oauthReq);
+  if (!client) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Unknown client', '<p>This connection request could not be verified.</p>'),
+      400,
+    );
   }
 
-  const { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
-    request: oauthReq,
-    userId: String(STUB_PROPS.userId),
-    metadata: { label: STUB_PROPS.name },
-    scope: oauthReq.scope,
-    props: { ...STUB_PROPS },
+  const state = newState();
+  // Mark the state single-use before sending the browser upstream. Consumed
+  // (get-then-delete) at /callback so a replayed callback finds nothing.
+  await env.OAUTH_KV.put(`${STATE_MARKER_PREFIX}${state}`, '1', { expirationTtl: STATE_MARKER_TTL_S });
+
+  const boundTxn: ConsentTransaction = { oauthReq: txn.oauthReq, state, exp: Date.now() + CONSENT_TTL_MS };
+  const cookie = await signConsentCookie(boundTxn, env.COOKIE_ENCRYPTION_KEY ?? '');
+
+  const authorizeUrl = new URL(env.HELPSCOUT_AUTHORIZE_URL);
+  authorizeUrl.searchParams.set('client_id', env.HELPSCOUT_CLIENT_ID);
+  authorizeUrl.searchParams.set('state', state);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: authorizeUrl.toString(), 'Set-Cookie': buildConsentSetCookie(cookie) },
   });
+}
 
-  return new Response(null, { status: 302, headers: { Location: redirectTo } });
+interface HelpScoutTokenResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
+}
+
+interface HelpScoutUser {
+  id?: unknown;
+  firstName?: unknown;
+  lastName?: unknown;
+  email?: unknown;
 }
 
 /**
- * The defaultHandler the OAuth shell delegates to for everything it does not
- * handle itself (metadata, /token, /register, and the protected /mcp route are
- * the library's; /authorize and /approve are ours).
+ * GET /callback — the Help Scout redirect target.
+ *
+ * Validates the state against both the signed cookie and the single-use KV
+ * marker, exchanges the code for a per-user token pair, reads the user's
+ * identity (403 => a Light User without Mailbox access, shown a seat-required
+ * page and NO grant), then completes the MCP authorization with the real tokens.
+ */
+async function handleCallback(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  const cookieValue = readCookie(request, CONSENT_COOKIE_NAME);
+  const txn = await verifyConsentCookie(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
+
+  // The cookie must verify, carry the same state Help Scout echoed back, and the
+  // request must actually carry a code and state. Any mismatch is a hard reject:
+  // this is the confused-deputy / CSRF boundary.
+  if (!txn || !state || !code || txn.state !== state) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Could not verify this sign-in', '<p>The Help Scout sign-in could not be verified. Reconnect the connector and try again.</p>'),
+      400,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+
+  // Consume the single-use marker. A replayed callback (state already spent, or
+  // expired) finds nothing and is rejected before any code is exchanged.
+  const markerKey = `${STATE_MARKER_PREFIX}${state}`;
+  const marker = await env.OAUTH_KV.get(markerKey);
+  if (marker === null) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'This sign-in link was already used', '<p>This Help Scout sign-in link has expired or was already used. Reconnect the connector to start again.</p>'),
+      400,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+  await env.OAUTH_KV.delete(markerKey);
+
+  const client = await validateClientBinding(env, txn.oauthReq);
+  if (!client) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Unknown client', '<p>This connection request could not be verified.</p>'),
+      400,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+
+  // --- Exchange the code for a per-user Help Scout token pair, server-side. ---
+  let tokenData: HelpScoutTokenResponse;
+  try {
+    const tokenRes = await fetch(env.HELPSCOUT_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        client_id: env.HELPSCOUT_CLIENT_ID,
+        client_secret: env.HELPSCOUT_CLIENT_SECRET,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!tokenRes.ok) {
+      return htmlResponse(
+        page('Authorize Help Scout', 'Help Scout sign-in failed', '<p>Help Scout could not complete the sign-in. Reconnect the connector and try again. If this persists, the deployment credentials may need attention.</p>'),
+        502,
+        { 'Set-Cookie': buildConsentClearCookie() },
+      );
+    }
+    tokenData = (await tokenRes.json()) as HelpScoutTokenResponse;
+  } catch {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Help Scout is unreachable', '<p>Could not reach Help Scout to complete the sign-in. Try again in a moment.</p>'),
+      502,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+
+  const accessToken = tokenData.access_token;
+  const refreshToken = tokenData.refresh_token;
+  if (typeof accessToken !== 'string' || accessToken === '' || typeof refreshToken !== 'string' || refreshToken === '') {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Help Scout sign-in failed', '<p>Help Scout returned an unexpected response. Reconnect the connector and try again.</p>'),
+      502,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+  const expiresIn = tokenData.expires_in;
+  const expiresAt = typeof expiresIn === 'number' && Number.isFinite(expiresIn) ? Date.now() + expiresIn * 1000 : 0;
+
+  // --- Identity. A 403 here means a Light User (no Mailbox API access). ---
+  let user: HelpScoutUser;
+  try {
+    const meRes = await fetch(joinUrl(env.HELPSCOUT_BASE_URL, 'users/me'), {
+      method: 'GET',
+      headers: { Accept: 'application/json', Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (meRes.status === 403) {
+      return htmlResponse(
+        page(
+          'Help Scout access required',
+          'A full Help Scout User seat is required',
+          '<p>Your Help Scout account is a Light User, which cannot access the Mailbox API. Ask a Help Scout administrator to grant you a full User seat, then reconnect the connector.</p>',
+        ),
+        403,
+        { 'Set-Cookie': buildConsentClearCookie() },
+      );
+    }
+    if (!meRes.ok) {
+      return htmlResponse(
+        page('Authorize Help Scout', 'Could not read your Help Scout profile', '<p>Help Scout accepted the sign-in but the profile lookup failed. Try again in a moment.</p>'),
+        502,
+        { 'Set-Cookie': buildConsentClearCookie() },
+      );
+    }
+    user = (await meRes.json()) as HelpScoutUser;
+  } catch {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Help Scout is unreachable', '<p>Could not reach Help Scout to read your profile. Try again in a moment.</p>'),
+      502,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+
+  const userId = typeof user.id === 'number' ? user.id : Number(user.id) || 0;
+  const email = typeof user.email === 'string' ? user.email : '';
+  const name =
+    [user.firstName, user.lastName]
+      .filter((part): part is string => typeof part === 'string' && part.length > 0)
+      .join(' ') ||
+    email ||
+    `Help Scout user ${userId}`;
+
+  const { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
+    request: txn.oauthReq,
+    userId: String(userId),
+    metadata: { label: name },
+    scope: txn.oauthReq.scope,
+    props: { accessToken, refreshToken, expiresAt, userId, name, email },
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: redirectTo, 'Set-Cookie': buildConsentClearCookie() },
+  });
+}
+
+/**
+ * The defaultHandler the OAuth shell delegates to. Metadata, /token, and
+ * /register are the library's; /authorize, /approve, and /callback are ours.
  */
 export const helpScoutHandler: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+
+    // Refuse to run the consent flow with a missing signing key: an empty-key
+    // HMAC would still "verify", silently weakening the confused-deputy
+    // boundary instead of surfacing the deployment mistake.
+    if (!env.COOKIE_ENCRYPTION_KEY) {
+      return htmlResponse(
+        page('Authorize Help Scout', 'Deployment misconfigured', '<p>This server is missing its COOKIE_ENCRYPTION_KEY secret. Ask whoever operates it to set one with <code>wrangler secret put COOKIE_ENCRYPTION_KEY</code>.</p>'),
+        500,
+      );
+    }
 
     if (url.pathname === '/authorize' && request.method === 'GET') {
       return renderConsent(request, env);
     }
     if (url.pathname === '/approve' && request.method === 'POST') {
       return handleApprove(request, env);
+    }
+    if (url.pathname === '/callback' && request.method === 'GET') {
+      return handleCallback(request, env);
     }
 
     return new Response('Not found', { status: 404 });

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -157,12 +157,40 @@ async function renderConsent(request: Request, env: Env): Promise<Response> {
  * Help Scout's authorize URL carrying only our client id and that state.
  */
 async function handleApprove(request: Request, env: Env): Promise<Response> {
+  // Defense in depth on top of the SameSite=Lax cookie: a cross-origin POST
+  // must not be able to advance the consent flow even if a cookie somehow rides
+  // along, and the submit must carry the explicit approval field the consent
+  // form posts.
+  const origin = request.headers.get('Origin');
+  if (origin && origin !== new URL(request.url).origin) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Could not verify this request', '<p>This approval did not come from the consent page. Reconnect the connector to try again.</p>'),
+      403,
+    );
+  }
+  const form = await request.formData().catch(() => null);
+  if (form?.get('approve') !== 'true') {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Could not verify this request', '<p>This approval did not come from the consent page. Reconnect the connector to try again.</p>'),
+      400,
+    );
+  }
+
   const cookieValue = readCookie(request, CONSENT_COOKIE_NAME);
   const txn = await verifyConsentCookie<AuthRequest>(cookieValue, env.COOKIE_ENCRYPTION_KEY ?? '');
   if (!txn) {
     return htmlResponse(
       page('Authorize Help Scout', 'Session expired', '<p>This authorization session is missing or expired. Reconnect the connector to try again.</p>'),
       400,
+    );
+  }
+
+  // The browser is about to be sent to this URL; hold it to the same https
+  // bar as the other upstream endpoints (loopback excepted for the mock).
+  if (!isSecureUpstreamUrl(env.HELPSCOUT_AUTHORIZE_URL)) {
+    return htmlResponse(
+      page('Authorize Help Scout', 'Deployment misconfigured', '<p>This server is configured with a non-https Help Scout URL. Ask whoever operates it to fix HELPSCOUT_AUTHORIZE_URL.</p>'),
+      500,
     );
   }
 

--- a/worker/src/helpscout-oauth.ts
+++ b/worker/src/helpscout-oauth.ts
@@ -100,12 +100,18 @@ async function refreshHelpScoutTokens(props: HelpScoutProps): Promise<HelpScoutP
   if (typeof accessToken !== 'string' || accessToken === '' || typeof refreshToken !== 'string' || refreshToken === '') {
     throw new OAuthError('temporarily_unavailable', { description: 'Help Scout returned a malformed token refresh response.' });
   }
+  // A missing lifetime is tolerated (0 = unknown); a present-but-nonsensical
+  // one would persist an already-expired or never-expiring pair, so treat it as
+  // a malformed response instead.
+  if (expiresIn !== undefined && (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0)) {
+    throw new OAuthError('temporarily_unavailable', { description: 'Help Scout returned a malformed token refresh response.' });
+  }
 
   return {
     ...props,
     accessToken,
     refreshToken,
-    expiresAt: typeof expiresIn === 'number' && Number.isFinite(expiresIn) ? Date.now() + expiresIn * 1000 : 0,
+    expiresAt: typeof expiresIn === 'number' ? Date.now() + expiresIn * 1000 : 0,
   };
 }
 

--- a/worker/src/helpscout-oauth.ts
+++ b/worker/src/helpscout-oauth.ts
@@ -1,0 +1,141 @@
+/**
+ * Durable Help Scout token rotation via the OAuth shell's tokenExchangeCallback.
+ *
+ * This is the sanctioned, cross-instance-durable persistence hook. The provider
+ * invokes the callback on every token exchange it performs for OUR token and,
+ * on a refresh exchange, persists whatever `newProps` we return into the grant
+ * record in KV (re-encrypted) — a write no Durable Object can make, because the
+ * grant's encryption key is wrapped by the refresh token the /token endpoint
+ * holds. See the blueprint (docs/plans/2026-07-31-t5-helpscout-leg-blueprint.md)
+ * for the full evidence trail with library file/line citations.
+ *
+ * Strategy:
+ *   - authorization_code exchange: align OUR access-token TTL to the Help Scout
+ *     token so OUR token expires ~5 minutes BEFORE the Help Scout one. That
+ *     makes the MCP client's refresh of OUR token the primary rotation trigger,
+ *     ahead of the tool path's own proactive-refresh window.
+ *   - refresh_token exchange (the MCP client refreshing OUR token): refresh the
+ *     Help Scout pair upstream and return it as newProps so the rotation is
+ *     persisted durably; re-align the TTL to the fresh Help Scout expiry. On a
+ *     spent/revoked Help Scout refresh token, throw OAuthError('invalid_grant')
+ *     so the client re-runs authorization (re-consent) instead of a 500.
+ *
+ * Credentials arrive through process.env: the callback is a module-scope closure
+ * the provider calls with no `env` param, and process.env is populated from
+ * vars/secrets under nodejs_compat at the configured compatibility date.
+ */
+import {
+  OAuthError,
+  type TokenExchangeCallbackOptions,
+  type TokenExchangeCallbackResult,
+} from '@cloudflare/workers-oauth-provider';
+import type { HelpScoutProps } from './mcp-agent.js';
+
+/** OUR token expires this far before the Help Scout token, ahead of the fetch client's 60s proactive window. */
+const REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+/**
+ * OUR access-token lifetime, in seconds, aligned to the Help Scout token expiry
+ * minus the skew. Returns undefined when the Help Scout expiry is unknown (0),
+ * so the provider keeps its default TTL. Floored at 60s (the provider's minimum).
+ */
+function alignedAccessTokenTtl(expiresAt: number): number | undefined {
+  if (!expiresAt) return undefined;
+  const seconds = Math.floor((expiresAt - Date.now() - REFRESH_SKEW_MS) / 1000);
+  return Math.max(60, seconds);
+}
+
+interface HelpScoutTokenResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Exchange the stored Help Scout refresh token for a rotated pair. Throws
+ * OAuthError so the failure surfaces as a standard /token error (re-consent for
+ * a spent grant, a retryable error otherwise) rather than a generic 500.
+ */
+async function refreshHelpScoutTokens(props: HelpScoutProps): Promise<HelpScoutProps> {
+  const clientId = process.env.HELPSCOUT_CLIENT_ID;
+  const clientSecret = process.env.HELPSCOUT_CLIENT_SECRET;
+  const tokenUrl = process.env.HELPSCOUT_TOKEN_URL;
+  if (!clientId || !clientSecret || !tokenUrl) {
+    // No credentials to refresh with: leave the grant untouched rather than
+    // spend the refresh token. The tool-path fallback + re-consent still cover
+    // an expired Help Scout token.
+    return props;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: props.refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    throw new OAuthError('temporarily_unavailable', { description: 'Help Scout was unreachable during token refresh.' });
+  }
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as HelpScoutTokenResponse;
+    if ((response.status === 400 || response.status === 401) && body.error === 'invalid_grant') {
+      throw new OAuthError('invalid_grant', { description: 'The Help Scout session has expired or was revoked. Reconnect the connector.' });
+    }
+    throw new OAuthError('temporarily_unavailable', { description: `Help Scout rejected the token refresh (status ${response.status}).` });
+  }
+
+  const data = (await response.json().catch(() => ({}))) as HelpScoutTokenResponse;
+  const accessToken = data.access_token;
+  const refreshToken = data.refresh_token;
+  const expiresIn = data.expires_in;
+  if (typeof accessToken !== 'string' || accessToken === '' || typeof refreshToken !== 'string' || refreshToken === '') {
+    throw new OAuthError('temporarily_unavailable', { description: 'Help Scout returned a malformed token refresh response.' });
+  }
+
+  return {
+    ...props,
+    accessToken,
+    refreshToken,
+    expiresAt: typeof expiresIn === 'number' && Number.isFinite(expiresIn) ? Date.now() + expiresIn * 1000 : 0,
+  };
+}
+
+/**
+ * The tokenExchangeCallback wired into the OAuthProvider. Kept side-effect-light:
+ * it only touches Help Scout on a refresh exchange, and returns the result the
+ * provider persists.
+ */
+export async function helpScoutTokenExchangeCallback(
+  options: TokenExchangeCallbackOptions,
+): Promise<TokenExchangeCallbackResult | void> {
+  const props = options.props as HelpScoutProps | undefined;
+  if (!props) return;
+
+  if (options.grantType === 'authorization_code') {
+    const accessTokenTTL = alignedAccessTokenTtl(props.expiresAt);
+    return accessTokenTTL ? { accessTokenTTL } : undefined;
+  }
+
+  if (options.grantType === 'refresh_token') {
+    const rotated = await refreshHelpScoutTokens(props);
+    const accessTokenTTL = alignedAccessTokenTtl(rotated.expiresAt);
+    // Only claim a props change when the pair actually rotated (refresh may be a
+    // no-op when credentials are absent), so the provider skips a needless write.
+    const rotatedPair = rotated.accessToken !== props.accessToken || rotated.refreshToken !== props.refreshToken;
+    return {
+      ...(rotatedPair ? { newProps: rotated } : {}),
+      ...(accessTokenTTL ? { accessTokenTTL } : {}),
+    };
+  }
+
+  return;
+}

--- a/worker/src/helpscout-oauth.ts
+++ b/worker/src/helpscout-oauth.ts
@@ -42,7 +42,12 @@ const REFRESH_SKEW_MS = 5 * 60 * 1000;
 function alignedAccessTokenTtl(expiresAt: number): number | undefined {
   if (!expiresAt) return undefined;
   const seconds = Math.floor((expiresAt - Date.now() - REFRESH_SKEW_MS) / 1000);
-  return Math.max(60, seconds);
+  // An expiry at or inside the skew window means we have nothing meaningful to
+  // align to (typically a stale pair that could not be rotated). Fall back to
+  // the provider's default TTL rather than clamping to a floor that would push
+  // the client into a tight refresh loop.
+  if (seconds < 60) return undefined;
+  return seconds;
 }
 
 interface HelpScoutTokenResponse {
@@ -133,10 +138,12 @@ export async function helpScoutTokenExchangeCallback(
 
   if (options.grantType === 'refresh_token') {
     const rotated = await refreshHelpScoutTokens(props);
-    const accessTokenTTL = alignedAccessTokenTtl(rotated.expiresAt);
     // Only claim a props change when the pair actually rotated (refresh may be a
     // no-op when credentials are absent), so the provider skips a needless write.
+    // A no-op also keeps the provider's default TTL: aligning to the stale
+    // expiry of a pair we could not rotate would hand out ever-shorter tokens.
     const rotatedPair = rotated.accessToken !== props.accessToken || rotated.refreshToken !== props.refreshToken;
+    const accessTokenTTL = rotatedPair ? alignedAccessTokenTtl(rotated.expiresAt) : undefined;
     return {
       ...(rotatedPair ? { newProps: rotated } : {}),
       ...(accessTokenTTL ? { accessTokenTTL } : {}),

--- a/worker/src/helpscout-oauth.ts
+++ b/worker/src/helpscout-oauth.ts
@@ -69,7 +69,12 @@ async function refreshHelpScoutTokens(props: HelpScoutProps): Promise<HelpScoutP
   if (!clientId || !clientSecret || !tokenUrl) {
     // No credentials to refresh with: leave the grant untouched rather than
     // spend the refresh token. The tool-path fallback + re-consent still cover
-    // an expired Help Scout token.
+    // an expired Help Scout token. Loud on purpose: without this line, a
+    // deployment whose env stopped populating (e.g. a compat-date change)
+    // would look healthy while silently never rotating, then break days later.
+    console.error(
+      'Help Scout token rotation skipped: HELPSCOUT_CLIENT_ID / HELPSCOUT_CLIENT_SECRET / HELPSCOUT_TOKEN_URL are not visible to the token-exchange callback. Check the deployment secrets and compatibility date.',
+    );
     return props;
   }
 
@@ -138,14 +143,19 @@ export async function helpScoutTokenExchangeCallback(
 
   if (options.grantType === 'refresh_token') {
     const rotated = await refreshHelpScoutTokens(props);
-    // Only claim a props change when the pair actually rotated (refresh may be a
-    // no-op when credentials are absent), so the provider skips a needless write.
-    // A no-op also keeps the provider's default TTL: aligning to the stale
-    // expiry of a pair we could not rotate would hand out ever-shorter tokens.
-    const rotatedPair = rotated.accessToken !== props.accessToken || rotated.refreshToken !== props.refreshToken;
-    const accessTokenTTL = rotatedPair ? alignedAccessTokenTtl(rotated.expiresAt) : undefined;
+    // Only claim a props change when something actually changed (refresh is a
+    // no-op when credentials are absent), so the provider skips a needless
+    // write and keeps its default TTL — aligning to the stale expiry of a pair
+    // we could not rotate would hand out ever-shorter tokens. The expiry is
+    // part of the comparison: an upstream that returns the same token strings
+    // with a fresh lifetime must still have that lifetime persisted.
+    const changed =
+      rotated.accessToken !== props.accessToken ||
+      rotated.refreshToken !== props.refreshToken ||
+      rotated.expiresAt !== props.expiresAt;
+    const accessTokenTTL = changed ? alignedAccessTokenTtl(rotated.expiresAt) : undefined;
     return {
-      ...(rotatedPair ? { newProps: rotated } : {}),
+      ...(changed ? { newProps: rotated } : {}),
       ...(accessTokenTTL ? { accessTokenTTL } : {}),
     };
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -10,13 +10,16 @@
  *
  * Two handlers do the work:
  *   - apiHandler: the McpAgent (Durable Object) serving the gateway at /mcp.
- *   - defaultHandler: our consent surface at /authorize + /approve (T4 stub;
- *     T5 turns it into the real Help Scout Authorization Code client).
+ *   - defaultHandler: our consent surface at /authorize + /approve + /callback,
+ *     the real Help Scout Authorization Code client (help-scout-handler.ts).
+ *   - tokenExchangeCallback: durable Help Scout refresh-token rotation on the
+ *     client's refresh of OUR token (helpscout-oauth.ts).
  */
 import { OAuthProvider } from '@cloudflare/workers-oauth-provider';
 
 import { HelpScoutMCP } from './mcp-agent.js';
 import { helpScoutHandler } from './help-scout-handler.js';
+import { helpScoutTokenExchangeCallback } from './helpscout-oauth.js';
 import type { Env } from './mcp-agent.js';
 
 // The Durable Object class must be exported for the wrangler migration binding.
@@ -38,8 +41,16 @@ export default new OAuthProvider<Env>({
   tokenEndpoint: '/token',
   clientRegistrationEndpoint: '/register',
 
-  // TTL of the token WE issue to the MCP client (independent of the Help Scout
-  // token). 30 days with library-managed refresh rotation, matching the
-  // production reference server's contract.
+  // Fallback TTL of the token WE issue to the MCP client, used only when the
+  // Help Scout token expiry is unknown. Normally the tokenExchangeCallback below
+  // overrides this per grant, aligning OUR token to expire ~5 minutes before the
+  // Help Scout access token so the client's refresh of OUR token is the primary,
+  // durable Help Scout rotation trigger.
   accessTokenTTL: 2592000,
+
+  // The sanctioned durable-rotation hook. On the client's refresh of OUR token,
+  // this refreshes the Help Scout pair upstream and returns newProps, which the
+  // provider persists into the encrypted grant record in KV (survives Durable
+  // Object eviction and reaches every session). See helpscout-oauth.ts.
+  tokenExchangeCallback: helpScoutTokenExchangeCallback,
 });

--- a/worker/src/mcp-agent.ts
+++ b/worker/src/mcp-agent.ts
@@ -40,9 +40,8 @@ const SERVER_VERSION = '2.1.0';
  * The per-user grant, decrypted by workers-oauth-provider and re-injected as
  * `this.props` on every authorized `/mcp` request. The first three fields are
  * the Help Scout token pair the fetch client reads; the rest identify the user.
- *
- * For T4 the OAuth leg is stubbed (see help-scout-handler.ts), so these arrive
- * as stub values; T5 fills them with a real Help Scout Authorization Code login.
+ * These are filled by the real Help Scout Authorization Code login in
+ * help-scout-handler.ts and rotated durably via helpscout-oauth.ts.
  */
 export interface HelpScoutProps extends Record<string, unknown> {
   accessToken: string;
@@ -100,6 +99,15 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
   private gateway!: GatewayHandler;
 
   async init(): Promise<void> {
+    // Rebuild the server with instructions that name the connected user, read
+    // from the grant props. This is the confirmation that the grant carried a
+    // real per-user identity through the Help Scout leg, surfaced to the client
+    // in the initialize response without any Help Scout call.
+    this.server = new Server(
+      { name: SERVER_NAME, version: SERVER_VERSION },
+      { capabilities: { tools: {} }, instructions: this.buildInstructions() },
+    );
+
     // Same registry the stdio server builds, gated by the deployment's write
     // env vars. Passed explicitly rather than read from process.env so the
     // advertised surface is deterministic under workerd (where process.env
@@ -124,6 +132,18 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
       const client = this.buildClient();
       return withHelpScoutApi(client, () => this.gateway.callTool(request));
     });
+  }
+
+  /**
+   * A one-line description of the connected Help Scout user, surfaced as the MCP
+   * server instructions so the client can show who the session acts as. Reads
+   * only the grant props; falls back cleanly if a session somehow lacks them.
+   */
+  private buildInstructions(): string {
+    const base = 'Help Scout MCP gateway. Search, describe, and read (and, when enabled, write) Help Scout data.';
+    const props = this.props;
+    if (!props || !props.email) return base;
+    return `${base} Connected to Help Scout as ${props.name} <${props.email}>.`;
   }
 
   /** The grant props must be present on an authorized request; guard for TS and clarity. */
@@ -152,21 +172,21 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
         };
       },
       persistTokens: async (tokens: UserTokenContext): Promise<void> => {
-        // T5 SEAM — in-memory only. Update the live props so the next
-        // getTokens() and every later request on THIS instance reads the
-        // rotated pair. It does NOT re-encrypt the OAuth grant props that
-        // workers-oauth-provider re-injects on the next cold request, so a
-        // rotation does not yet survive instance eviction or a second session.
-        // Making rotation durable across instances is T5's job (open question
-        // on NAS-1491: whether mutating props persists). `this.updateProps(...)`
-        // would additionally write to DO storage and is the hook to build on.
+        // In-session safety net for a Help Scout token that expires mid-session.
+        // updateProps writes both this.props and DO storage, so the rest of this
+        // instance's requests read the rotated pair. This is NOT the durable
+        // path: on a cold wake, onStart re-injects the access token's props
+        // snapshot over DO storage, so a rotation here does not reach the grant
+        // or other instances. Durable, cross-instance rotation is the OAuth
+        // shell's tokenExchangeCallback (see helpscout-oauth.ts); OUR token TTL
+        // is aligned so that path fires ahead of this one in normal operation.
         const current = this.requireProps();
-        this.props = {
+        await this.updateProps({
           ...current,
           accessToken: tokens.accessToken,
           refreshToken: tokens.refreshToken,
           expiresAt: tokens.expiresAt,
-        };
+        });
       },
       refreshMutex: this.refreshMutex,
     });

--- a/worker/src/mcp-agent.ts
+++ b/worker/src/mcp-agent.ts
@@ -81,10 +81,12 @@ export interface Env {
 }
 
 export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
-  server = new Server(
-    { name: SERVER_NAME, version: SERVER_VERSION },
-    { capabilities: { tools: {} } },
-  );
+  // Constructed once, in init(): the instructions read the grant props, which
+  // are only injected by the time init() runs. A field initializer here would
+  // create a second Server the base class might capture; McpAgent connects the
+  // transport only after init() resolves, so this single construction site is
+  // the safe pattern.
+  server!: Server;
 
   /**
    * Serializes Help Scout token refresh for THIS Durable Object instance so
@@ -99,7 +101,7 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
   private gateway!: GatewayHandler;
 
   async init(): Promise<void> {
-    // Rebuild the server with instructions that name the connected user, read
+    // Build the server with instructions that name the connected user, read
     // from the grant props. This is the confirmation that the grant carried a
     // real per-user identity through the Help Scout leg, surfaced to the client
     // in the initialize response without any Help Scout call.

--- a/worker/src/oauth-cookie.ts
+++ b/worker/src/oauth-cookie.ts
@@ -14,8 +14,6 @@
  * (state, scope, client-chosen redirect) and bare btoa throws on any code point
  * above U+00FF.
  */
-import type { AuthRequest } from '@cloudflare/workers-oauth-provider';
-
 /** The cookie name for the pending consent transaction. */
 export const CONSENT_COOKIE_NAME = 'hs_mcp_txn';
 
@@ -24,12 +22,13 @@ export const CONSENT_TTL_MS = 10 * 60 * 1000;
 
 /**
  * The signed transaction. `oauthReq` is the whole parsed MCP authorization
- * request (its integrity is what the signature protects); `state` is the random
- * nonce we hand Help Scout and expect echoed back (absent until /approve mints
- * it); `exp` is the epoch-ms expiry.
+ * request (its integrity is what the signature protects; generic so this module
+ * carries no dependency on the provider's types and stays testable from the
+ * root suite); `state` is the random nonce we hand Help Scout and expect echoed
+ * back (absent until /approve mints it); `exp` is the epoch-ms expiry.
  */
-export interface ConsentTransaction {
-  oauthReq: AuthRequest;
+export interface ConsentTransaction<T = unknown> {
+  oauthReq: T;
   state?: string;
   exp: number;
 }
@@ -51,7 +50,10 @@ function base64UrlDecode(value: string): Uint8Array {
   return Uint8Array.from(binary, (c) => c.charCodeAt(0));
 }
 
-async function importHmacKey(secret: string): Promise<CryptoKey> {
+// Return type inferred from WebCrypto: the ambient CryptoKey name differs
+// between the workers and Node type libs, and this module must type-check
+// under both (the root suite unit-tests it).
+async function importHmacKey(secret: string) {
   return crypto.subtle.importKey(
     'raw',
     encoder.encode(secret),
@@ -65,8 +67,8 @@ async function importHmacKey(secret: string): Promise<CryptoKey> {
  * Sign a consent transaction into a cookie value: `body.signature`, where body
  * is base64url(JSON) and signature is base64url(HMAC-SHA256(body)).
  */
-export async function signConsentCookie(
-  txn: ConsentTransaction,
+export async function signConsentCookie<T>(
+  txn: ConsentTransaction<T>,
   secret: string,
 ): Promise<string> {
   const body = base64UrlEncode(encoder.encode(JSON.stringify(txn)));
@@ -80,10 +82,10 @@ export async function signConsentCookie(
  * is missing, malformed, has a bad signature, or is expired, so callers treat
  * every failure the same way: reject the request.
  */
-export async function verifyConsentCookie(
+export async function verifyConsentCookie<T = unknown>(
   value: string | undefined,
   secret: string,
-): Promise<ConsentTransaction | null> {
+): Promise<ConsentTransaction<T> | null> {
   if (!value) return null;
   const dot = value.lastIndexOf('.');
   if (dot <= 0) return null;
@@ -91,7 +93,7 @@ export async function verifyConsentCookie(
   const body = value.slice(0, dot);
   const providedSig = value.slice(dot + 1);
 
-  let key: CryptoKey;
+  let key: Awaited<ReturnType<typeof importHmacKey>>;
   let providedSigBytes: Uint8Array;
   try {
     key = await importHmacKey(secret);
@@ -107,7 +109,7 @@ export async function verifyConsentCookie(
   if (!ok) return null;
 
   try {
-    const txn = JSON.parse(decoder.decode(base64UrlDecode(body))) as ConsentTransaction;
+    const txn = JSON.parse(decoder.decode(base64UrlDecode(body))) as ConsentTransaction<T>;
     if (typeof txn.exp !== 'number' || Date.now() > txn.exp) return null;
     return txn;
   } catch {

--- a/worker/src/oauth-cookie.ts
+++ b/worker/src/oauth-cookie.ts
@@ -1,0 +1,139 @@
+/**
+ * Signed-cookie helpers for the Help Scout consent transaction.
+ *
+ * The consent flow carries the pending MCP authorization request across three
+ * requests (/authorize -> /approve -> /callback) that Help Scout redirects
+ * between. Instead of a plaintext round-trip, the transaction rides in an
+ * HTTP-only cookie whose integrity is guaranteed by an HMAC-SHA256 signature
+ * (WebCrypto) keyed by COOKIE_ENCRYPTION_KEY. This, together with re-validating
+ * the client and redirect URI at approve/callback time, is the confused-deputy
+ * defense the MCP spec makes a MUST for a proxy server with a static upstream
+ * client id.
+ *
+ * All encoding is TextEncoder-based: the payload holds client-supplied text
+ * (state, scope, client-chosen redirect) and bare btoa throws on any code point
+ * above U+00FF.
+ */
+import type { AuthRequest } from '@cloudflare/workers-oauth-provider';
+
+/** The cookie name for the pending consent transaction. */
+export const CONSENT_COOKIE_NAME = 'hs_mcp_txn';
+
+/** Consent transactions live 10 minutes: long enough to log in, short enough to bound replay. */
+export const CONSENT_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * The signed transaction. `oauthReq` is the whole parsed MCP authorization
+ * request (its integrity is what the signature protects); `state` is the random
+ * nonce we hand Help Scout and expect echoed back (absent until /approve mints
+ * it); `exp` is the epoch-ms expiry.
+ */
+export interface ConsentTransaction {
+  oauthReq: AuthRequest;
+  state?: string;
+  exp: number;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** URL-safe base64 of raw bytes (no padding). */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Inverse of base64UrlEncode. Throws on malformed input (callers treat that as a rejected cookie). */
+function base64UrlDecode(value: string): Uint8Array {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  );
+}
+
+/**
+ * Sign a consent transaction into a cookie value: `body.signature`, where body
+ * is base64url(JSON) and signature is base64url(HMAC-SHA256(body)).
+ */
+export async function signConsentCookie(
+  txn: ConsentTransaction,
+  secret: string,
+): Promise<string> {
+  const body = base64UrlEncode(encoder.encode(JSON.stringify(txn)));
+  const key = await importHmacKey(secret);
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+  return `${body}.${base64UrlEncode(new Uint8Array(sig))}`;
+}
+
+/**
+ * Verify and decode a cookie value. Returns null (never throws) when the value
+ * is missing, malformed, has a bad signature, or is expired, so callers treat
+ * every failure the same way: reject the request.
+ */
+export async function verifyConsentCookie(
+  value: string | undefined,
+  secret: string,
+): Promise<ConsentTransaction | null> {
+  if (!value) return null;
+  const dot = value.lastIndexOf('.');
+  if (dot <= 0) return null;
+
+  const body = value.slice(0, dot);
+  const providedSig = value.slice(dot + 1);
+
+  let key: CryptoKey;
+  let providedSigBytes: Uint8Array;
+  try {
+    key = await importHmacKey(secret);
+    providedSigBytes = base64UrlDecode(providedSig);
+  } catch {
+    return null;
+  }
+
+  // crypto.subtle.verify is constant-time over the signature comparison.
+  const ok = await crypto.subtle
+    .verify('HMAC', key, providedSigBytes, encoder.encode(body))
+    .catch(() => false);
+  if (!ok) return null;
+
+  try {
+    const txn = JSON.parse(decoder.decode(base64UrlDecode(body))) as ConsentTransaction;
+    if (typeof txn.exp !== 'number' || Date.now() > txn.exp) return null;
+    return txn;
+  } catch {
+    return null;
+  }
+}
+
+/** Build the Set-Cookie header for a signed transaction. */
+export function buildConsentSetCookie(value: string): string {
+  const maxAge = Math.floor(CONSENT_TTL_MS / 1000);
+  return `${CONSENT_COOKIE_NAME}=${value}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`;
+}
+
+/** Build the Set-Cookie header that clears the consent cookie. */
+export function buildConsentClearCookie(): string {
+  return `${CONSENT_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`;
+}
+
+/** Read one cookie value out of a request's Cookie header. */
+export function readCookie(request: Request, name: string): string | undefined {
+  const header = request.headers.get('Cookie');
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return undefined;
+}

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -32,12 +32,20 @@
 
   // Non-secret configuration. Secrets (HELPSCOUT_CLIENT_ID, HELPSCOUT_CLIENT_SECRET,
   // COOKIE_ENCRYPTION_KEY) are set with `wrangler secret put` and never live here.
-  // Optional: `wrangler secret put HELPSCOUT_DOCS_API_KEY` enables the Docs API
-  // operations; without it they are still advertised but fail at call time with
-  // a credentials-missing error.
+  // COOKIE_ENCRYPTION_KEY signs the consent-transaction cookie (the confused-deputy
+  // defense) — set it to a long random string. Optional: `wrangler secret put
+  // HELPSCOUT_DOCS_API_KEY` enables the Docs API operations; without it they are
+  // still advertised but fail at call time with a credentials-missing error.
+  //
+  // SETUP CAVEAT: the Help Scout app's Redirection URL is fixed at registration
+  // and MUST be this deployed worker's `https://<worker>/callback`. An app born
+  // with an `http://` redirect is permanently broken for the authorize flow
+  // (Help Scout silently bounces it; editing the URL later does not heal it), so
+  // register the https callback from the start.
   "vars": {
     "HELPSCOUT_BASE_URL": "https://api.helpscout.net/v2/",
     "HELPSCOUT_TOKEN_URL": "https://api.helpscout.net/v2/oauth2/token",
+    // Takes only client_id and state (no redirect_uri, no scope, no PKCE).
     "HELPSCOUT_AUTHORIZE_URL": "https://secure.helpscout.net/authentication/authorizeClientApplication",
     // Opt-in write surface. Both default off; flip to "true" to enable.
     "HELPSCOUT_ENABLE_WRITES": "false",


### PR DESCRIPTION
## What

Replaces the T4 stub consent surface with the real upstream Help Scout OAuth client, completing the per-user login path end to end:

- **Consent flow**: `GET /authorize` validates the client binding (clientId via lookup AND redirectUri against the client's registered URIs) and stores the pending MCP authorization in an HMAC-signed HTTP-only cookie (WebCrypto, TextEncoder-based; no plaintext round-trip). `POST /approve` mints a single-use `state` (KV marker) and redirects to Help Scout. `GET /callback` validates state against both the cookie and the marker, re-validates the client binding, exchanges the code server-side, reads the user's identity, and completes the authorization with the real token pair in the encrypted grant props.
- **Durable rotation**: the provider's `tokenExchangeCallback` is the persistence hook — the only path that can rewrite the encrypted grant record (evidence trail with library file/line citations in `docs/plans/2026-07-31-t5-helpscout-leg-blueprint.md` on the branch machine; `docs/plans/` is gitignored). Our access-token TTL is aligned to expire ~5 minutes before the Help Scout token so the client's refresh of our token refreshes the Help Scout pair upstream and persists it durably. The in-agent `persistTokens` path stays as an in-session safety net via `updateProps`, clearly marked non-durable.
- **Guardrails**: the consent flow refuses to run without `COOKIE_ENCRYPTION_KEY` (no empty-key HMAC); non-https upstream URLs are rejected before any secret leaves the worker (loopback excepted for the mock harness); consent pages send `X-Frame-Options: DENY` and `frame-ancestors 'none'`; a users/me response without a positive integer id rejects the authorization instead of collapsing onto user 0; a present-but-nonsensical `expires_in` is treated as malformed in all three places that persist token lifetimes. A Light User's 403 on the identity lookup gets a page explaining a full seat is required, and no grant.

## Verification

- Root type-check / lint clean; fetch-client suite 50/50 (new lifetime-validation regressions); full jest 576 passing (single known local-`.env` environmental case, absent in CI); worker `tsc --noEmit` clean.
- `worker/scripts/smoke.mjs` is now a self-contained orchestrator: it stands up a mock Help Scout (authorize redirect, token endpoint, users/me), points `wrangler dev` at it, and drives the full flow in both write modes. **66/66 checks**: discovery, 401 challenge, DCR, full auth-code + PKCE, grant carries the mock user's identity (surfaced via initialize `instructions`), durable refresh rotates the upstream pair and preserves identity, unicode client/state, missing-cookie 400, tampered state rejected, replayed state rejected, light-user seat-required page, RFC 8707 resource-mismatch rejection.

## Known residuals (tracked, not gaps)

- The tool-path in-memory refresh and the durable callback share no cross-instance lock (the DO cannot write grant props). The TTL skew makes the durable path fire first in normal operation; the residual races degrade to a clean re-consent, never silent loss or wrong-user action. Account-wide serialization is tracked for T6/T7 on NAS-1493/NAS-1494.
- The single-use state marker is get-then-delete (non-atomic at the KV edge); Help Scout's single-use code is the backstop.
- The durable refresh callback reads deployment credentials from `process.env` (module-scope closure, no `env` param); a compat-date regression would disable rotation without breaking anything else. Flagged for a live check in T7.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
