### PR TITLE
docs(NAS-1504): install decision guide, self-host positioning, setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ Built by a Help Scout customer who wanted to give his support team superpowers. 
 
 ## Quick Start
 
+### Which install should I use?
+
+| Install | Best for | Works in | Auth model | Writes act as | Setup effort |
+|---------|----------|----------|------------|---------------|--------------|
+| **Desktop Extension (`.mcpb`)** | One person on the Claude desktop app | Claude Desktop (Chat and Cowork) | One shared App ID and Secret you enter once | The app owner (shared credential) | One-click |
+| **`npx` / config file** | Developers, CLI and editor clients | Claude Code, Cursor, VS Code, Goose, any local MCP client | One shared App ID and Secret in env | The app owner (shared credential) | One command or a small config block |
+| **Docker** | Containerized or server-side runs | Any host that runs the container | One shared App ID and Secret in env | The app owner (shared credential) | One `docker run` |
+| **Remote worker (self-hosted)** | A whole team, and anyone on claude.ai web or mobile | claude.ai (web and mobile apps), Claude Desktop, any remote-MCP client | Each person signs in with their own Help Scout login | Each signed-in user, with their own Help Scout permissions | One-time Cloudflare deploy, then one URL per person |
+
+Two things the table cannot say loudly enough:
+
+- **claude.ai on the web and the mobile apps can only use the remote worker.** The other three installs run a local stdio process on one machine, which the web and mobile clients cannot reach. If you want Help Scout in claude.ai or on your phone, the remote worker is the only path.
+- **Only the remote worker gives per-user identity.** With the local installs (extension, npx, Docker) everyone shares one App ID and Secret, and every read and write acts as the app's owner. With the remote worker each person signs in as themselves and acts with their own Help Scout permissions, so reads and writes are attributed to the actual user and revoke with their account.
+
 ### Claude Desktop & Claude Cowork (Recommended)
 
 **One-click install** using [Desktop Extensions](https://www.anthropic.com/engineering/desktop-extensions). One install covers both Chat and Cowork sessions in the Claude desktop app.
@@ -86,8 +100,10 @@ docker run -e HELPSCOUT_APP_ID="your-app-id" \
 
 For a team, you can host one instance instead of giving everyone the same App ID and Secret. Deploy the Cloudflare Worker in [`worker/`](worker/) and each person connects one URL and signs in with their own Help Scout login, acting with their own permissions. No shared credentials, nothing to install per machine.
 
+This is the recommended path for teams that would rather not hand out shared API credentials, and for organizations with role-based access control or compliance-style requirements (for example teams operating under SOC 2 or ISO 27001 controls). The worker gives you per-user attribution, access that revokes with each person's Help Scout account, and a deployment that runs on your own infrastructure. That does not make the software certified or compliant on its own, but it supports the control requirements those organizations have to meet.
+
 1. `cd worker && npm install`
-2. Create a KV namespace, register a Help Scout app with an `https` callback, set three secrets, and `wrangler deploy`
+2. Run `npm run setup` (creates the KV namespace and writes your deploy config), then register a Help Scout app with an `https` callback, set three secrets, and `wrangler deploy`
 3. Add `https://<your-worker>/mcp` as a custom connector in claude.ai or Claude Desktop
 
 This needs a Cloudflare account (the free tier works) and a full Help Scout User seat; Light User seats cannot use it. Writes are opt-in per deployment, off by default. Full runbook, including the token behavior and the redirect-URL trap to avoid: [Self-hosting the remote server](guides/remote-self-host.md).

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For a team, you can host one instance instead of giving everyone the same App ID
 This is the recommended path for teams that would rather not hand out shared API credentials, and for organizations with role-based access control or compliance-style requirements (for example teams operating under SOC 2 or ISO 27001 controls). The worker gives you per-user attribution, access that revokes with each person's Help Scout account, and a deployment that runs on your own infrastructure. That does not make the software certified or compliant on its own, but it supports the control requirements those organizations have to meet.
 
 1. `cd worker && npm install`
-2. Run `npm run setup` (creates the KV namespace and writes your deploy config), then register a Help Scout app with an `https` callback, set three secrets, and `wrangler deploy`
+2. Run `npm run setup` (creates the KV namespace and writes your deploy config), deploy once to learn your worker URL, then register a Help Scout app with the `https://<your-worker>/callback` redirect, set three secrets, and deploy again
 3. Add `https://<your-worker>/mcp` as a custom connector in claude.ai or Claude Desktop
 
 This needs a Cloudflare account (the free tier works) and a full Help Scout User seat; Light User seats cannot use it. Writes are opt-in per deployment, off by default. Full runbook, including the token behavior and the redirect-URL trap to avoid: [Self-hosting the remote server](guides/remote-self-host.md).

--- a/guides/remote-self-host.md
+++ b/guides/remote-self-host.md
@@ -10,6 +10,14 @@ This is different from the [Desktop Extension](cowork-setup.md) and the npx/Dock
 installs, where each person runs their own copy with a single shared App ID and
 Secret. The remote worker is one deployment your whole team connects to.
 
+It is also the recommended path for teams that would rather not hand out shared API
+credentials, and for organizations with role-based access control or compliance-style
+requirements (for example teams operating under SOC 2 or ISO 27001 controls).
+Per-user attribution, access that revokes with each person's Help Scout account, and
+running on your own infrastructure are the point here. This does not make the software
+certified or compliant on its own; it is built to support the control requirements
+those organizations have to meet.
+
 It is a v1 remote deployment. Read the [seat requirement](#who-can-use-it) and the
 [token behavior](#how-tokens-and-sessions-behave) before rolling it out to a team.
 
@@ -60,6 +68,25 @@ This opens a browser and authorizes `wrangler` against your Cloudflare account.
 The OAuth provider stores hashed client secrets and the AES-GCM-encrypted per-user
 grants (which hold each user's Help Scout tokens) in a Workers KV namespace.
 
+The quickest path is the setup wizard, which does this step and the next one for
+you. From the `worker/` directory:
+
+```bash
+npm run setup
+```
+
+It checks that `wrangler` is logged in (and tells you to run `npx wrangler login`
+if not), creates the `OAUTH_KV` namespace, and writes `wrangler.deploy.jsonc` with
+the namespace id filled in. It prompts for an optional Cloudflare `account_id` and
+an optional custom worker name, then prints the remaining steps. It refuses to
+overwrite an existing `wrangler.deploy.jsonc` unless you pass `--force`, so it will
+not clobber a live deployment's config. If you already created a namespace, pass its
+id with `--kv-id <id>` to skip creation. When the wizard finishes, skip to step 5.
+
+To do it by hand instead, run the two steps below.
+
+**Manual alternative.** Create the namespace:
+
 ```bash
 npx wrangler kv namespace create OAUTH_KV
 ```
@@ -67,6 +94,9 @@ npx wrangler kv namespace create OAUTH_KV
 Copy the `id` it prints. You will paste it into your config in the next step.
 
 ### 4. Make a deploy config
+
+The wizard in step 3 writes this file for you. Do this step by hand only if you
+skipped the wizard.
 
 `wrangler.jsonc` is a tracked template with placeholders. Rather than edit the
 template in place, copy it to `wrangler.deploy.jsonc` (already gitignored) and fill
@@ -266,6 +296,21 @@ reconnect; other users are unaffected.
 
 ## Operating notes
 
+- **Upgrading a deployment.** Pull the new code and re-deploy with your existing
+  config:
+
+  ```bash
+  git pull
+  npm install   # only if package-lock.json changed
+  npx wrangler deploy --config wrangler.deploy.jsonc
+  ```
+
+  Your secrets and the `OAUTH_KV` namespace survive a re-deploy, so connected users
+  stay connected and no one has to sign in again. `wrangler.deploy.jsonc` is not
+  touched by `git pull` (it is gitignored), so your KV id and account id carry over.
+  If you want a check before shipping an update, run the smoke suite first (`npm run
+  smoke`); it drives the whole OAuth flow against a local mock without touching Help
+  Scout or your live deployment.
 - Live logs: `npm run tail` (wraps `wrangler tail`) streams request logs from the
   deployed worker.
 - The three advertised tools are a gateway over the read operations; Claude finds

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
+    "setup": "node scripts/setup.mjs",
     "deploy": "wrangler deploy --config wrangler.deploy.jsonc",
     "tail": "wrangler tail --config wrangler.deploy.jsonc",
     "type-check": "tsc --noEmit",

--- a/worker/scripts/setup.mjs
+++ b/worker/scripts/setup.mjs
@@ -1,0 +1,284 @@
+// Setup wizard for the Help Scout remote MCP worker.
+//
+// Collapses steps 3 and 4 of guides/remote-self-host.md: it confirms wrangler is
+// logged in, creates (or reuses) the OAUTH_KV namespace, and writes a
+// wrangler.deploy.jsonc with the KV id, an optional account_id, and an optional
+// custom worker name filled in. It then prints the remaining guide steps (deploy,
+// register the Help Scout app, set the secrets, connect a client) so you can pick
+// up where it leaves off.
+//
+// Idempotent: it refuses to overwrite an existing wrangler.deploy.jsonc unless you
+// pass --force, so it never clobbers a live deployment's config.
+//
+// Usage:
+//   npm run setup
+//   npm run setup -- --force            overwrite an existing wrangler.deploy.jsonc
+//   npm run setup -- --kv-id <id>       reuse an existing OAUTH_KV namespace
+//   npm run setup -- --name <name>      set the worker name (subdomain)
+//   npm run setup -- --account-id <id>  set the Cloudflare account_id
+//   npm run setup -- --yes              non-interactive: accept defaults, skip prompts
+//   npm run setup -- --dry-run          print the plan and resulting config, write nothing
+//   npm run setup -- --skip-auth-check  skip the `wrangler whoami` preflight
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const NODE_BIN = process.execPath;
+const WORKER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const WRANGLER_BIN = './node_modules/.bin/wrangler';
+const TEMPLATE = path.join(WORKER_DIR, 'wrangler.jsonc');
+const DEPLOY = path.join(WORKER_DIR, 'wrangler.deploy.jsonc');
+const DEFAULT_NAME = 'helpscout-mcp-oauth';
+
+// --- args -------------------------------------------------------------------
+function parseArgs(argv) {
+  const opts = { force: false, yes: false, dryRun: false, skipAuthCheck: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--force') opts.force = true;
+    else if (a === '--yes' || a === '-y') opts.yes = true;
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--skip-auth-check') opts.skipAuthCheck = true;
+    else if (a === '--kv-id') opts.kvId = argv[++i];
+    else if (a === '--account-id') opts.accountId = argv[++i];
+    else if (a === '--name') opts.name = argv[++i];
+    else if (a === '--help' || a === '-h') opts.help = true;
+    else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Help Scout remote worker setup wizard
+
+Confirms wrangler auth, creates or reuses the OAUTH_KV namespace, and writes
+wrangler.deploy.jsonc. Run from the worker/ directory (npm run setup).
+
+Options:
+  --force            overwrite an existing wrangler.deploy.jsonc
+  --kv-id <id>       reuse an existing OAUTH_KV namespace instead of creating one
+  --name <name>      worker name (becomes the workers.dev subdomain)
+  --account-id <id>  Cloudflare account_id (skip if your account has one context)
+  --yes, -y          non-interactive: accept defaults, skip optional prompts
+  --dry-run          print the plan and resulting config, write nothing
+  --skip-auth-check  skip the \`wrangler whoami\` preflight
+  --help, -h         show this help
+`);
+}
+
+// --- wrangler helpers -------------------------------------------------------
+function runWrangler(args) {
+  return spawnSync(NODE_BIN, [WRANGLER_BIN, ...args], {
+    cwd: WORKER_DIR,
+    encoding: 'utf8',
+    env: { ...process.env, WRANGLER_SEND_METRICS: 'false' },
+  });
+}
+
+function checkAuth() {
+  const res = runWrangler(['whoami']);
+  const out = `${res.stdout || ''}${res.stderr || ''}`;
+  // wrangler exits non-zero and/or prints a login hint when not authenticated.
+  const loggedOut = res.status !== 0 || /not authenticated|log ?in|not logged in/i.test(out);
+  return { ok: !loggedOut, output: out.trim() };
+}
+
+// Parse the KV namespace id out of `wrangler kv namespace create` output. Wrangler
+// prints a config snippet (TOML `id = "..."` or JSON `"id": "..."`); a namespace id
+// is a 32-char hex string. Try the structured forms first, then fall back.
+function parseKvId(output) {
+  const structured =
+    output.match(/"id"\s*:\s*"([0-9a-fA-F]{32})"/) || output.match(/\bid\s*=\s*"([0-9a-fA-F]{32})"/);
+  if (structured) return structured[1];
+  const bare = output.match(/\b([0-9a-fA-F]{32})\b/);
+  return bare ? bare[1] : null;
+}
+
+function createKvNamespace() {
+  console.log('Creating the OAUTH_KV namespace with wrangler...');
+  const res = runWrangler(['kv', 'namespace', 'create', 'OAUTH_KV']);
+  const out = `${res.stdout || ''}${res.stderr || ''}`;
+  if (res.status !== 0) {
+    console.error('wrangler kv namespace create failed:\n' + out.trim());
+    process.exit(1);
+  }
+  const id = parseKvId(out);
+  if (!id) {
+    console.error(
+      'Could not read the namespace id from wrangler output. Create it manually with\n' +
+        '  npx wrangler kv namespace create OAUTH_KV\n' +
+        'then re-run with --kv-id <id>. Raw output:\n' +
+        out.trim(),
+    );
+    process.exit(1);
+  }
+  console.log(`  namespace id: ${id}`);
+  return id;
+}
+
+// --- config rendering -------------------------------------------------------
+// Text-level edits on the JSONC template so its comments survive. The default
+// values in the template are the anchors we replace, so each match is unique.
+function renderDeployConfig(template, { kvId, accountId, name }) {
+  let out = template;
+
+  out = out.replace('<REPLACE_WITH_KV_ID>', kvId);
+
+  if (name && name !== DEFAULT_NAME) {
+    if (!out.includes(`"name": "${DEFAULT_NAME}"`)) {
+      throw new Error(`template no longer contains the expected default name "${DEFAULT_NAME}"`);
+    }
+    out = out.replace(`"name": "${DEFAULT_NAME}"`, `"name": "${name}"`);
+  }
+
+  if (accountId) {
+    const mainLine = '  "main": "src/index.ts",';
+    if (!out.includes(mainLine)) {
+      throw new Error('template no longer contains the expected "main" line for account_id insertion');
+    }
+    out = out.replace(mainLine, `  "account_id": "${accountId}",\n${mainLine}`);
+  }
+
+  return out;
+}
+
+// --- prompts ----------------------------------------------------------------
+async function prompt(rl, question, fallback = '') {
+  const answer = (await rl.question(question)).trim();
+  return answer || fallback;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+
+  if (!fs.existsSync(TEMPLATE)) {
+    console.error(`Cannot find the template at ${TEMPLATE}. Run this from the worker package (npm run setup).`);
+    process.exit(1);
+  }
+
+  // Refuse to clobber an existing deploy config unless forced. Checked first so
+  // the guard is fast and needs no network.
+  if (fs.existsSync(DEPLOY) && !opts.force && !opts.dryRun) {
+    console.error(
+      `${path.basename(DEPLOY)} already exists. This is your live deployment config.\n` +
+        'Refusing to overwrite it. Re-run with --force if you really mean to replace it,\n' +
+        'or edit the file directly. Nothing was changed.',
+    );
+    process.exit(1);
+  }
+
+  // Preflight: wrangler must be logged in (skippable, and soft under --dry-run).
+  if (!opts.skipAuthCheck) {
+    const auth = checkAuth();
+    if (!auth.ok) {
+      const msg =
+        'wrangler is not logged in to Cloudflare. Run\n  npx wrangler login\nthen re-run this wizard.';
+      if (opts.dryRun) {
+        console.log(`[dry-run] ${msg}`);
+      } else {
+        console.error(msg);
+        process.exit(1);
+      }
+    } else if (auth.output) {
+      console.log('wrangler is logged in.');
+    }
+  }
+
+  const rl = opts.yes ? null : readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    // KV namespace.
+    let kvId = opts.kvId;
+    if (!kvId) {
+      let create = true;
+      if (rl) {
+        const existing = await prompt(
+          rl,
+          'Reuse an existing OAUTH_KV namespace id? Paste it, or press enter to create one: ',
+        );
+        if (existing) {
+          kvId = existing;
+          create = false;
+        }
+      }
+      if (create) kvId = opts.dryRun ? (opts.kvId || 'DRY_RUN_KV_ID') : createKvNamespace();
+    }
+
+    // account_id (optional).
+    let accountId = opts.accountId;
+    if (accountId === undefined && rl) {
+      accountId =
+        (await prompt(
+          rl,
+          'Cloudflare account_id (optional; press enter to skip if your account has one context): ',
+        )) || undefined;
+    }
+
+    // Worker name (optional).
+    let name = opts.name;
+    if (name === undefined && rl) {
+      name = await prompt(rl, `Worker name [${DEFAULT_NAME}]: `, DEFAULT_NAME);
+    }
+    if (!name) name = DEFAULT_NAME;
+
+    const template = fs.readFileSync(TEMPLATE, 'utf8');
+    const rendered = renderDeployConfig(template, { kvId, accountId, name });
+
+    if (opts.dryRun) {
+      console.log('\n[dry-run] would write ' + DEPLOY + ' with:');
+      console.log(`  kv id:      ${kvId}`);
+      console.log(`  account_id: ${accountId || '(omitted)'}`);
+      console.log(`  name:       ${name}`);
+      console.log('\n--- wrangler.deploy.jsonc (not written) ---\n');
+      console.log(rendered);
+      return;
+    }
+
+    fs.writeFileSync(DEPLOY, rendered);
+    console.log(`\nWrote ${path.relative(WORKER_DIR, DEPLOY)} (gitignored).`);
+    console.log(`  kv id:      ${kvId}`);
+    console.log(`  account_id: ${accountId || '(omitted; single-account context assumed)'}`);
+    console.log(`  name:       ${name}`);
+
+    // Next steps, numbered to match guides/remote-self-host.md.
+    const workerRef = name === DEFAULT_NAME ? '<name>' : name;
+    console.log(`
+Steps 3 and 4 are done. Next, following the runbook:
+
+  5. First deploy (to learn your URL):
+       npx wrangler deploy --config wrangler.deploy.jsonc
+     It prints https://${workerRef}.<your-subdomain>.workers.dev. Write it down.
+
+  6. Register the Help Scout app AFTER the deploy. In Help Scout, My Apps >
+     Create App, set the Redirection URL to https://<worker-url>/callback.
+     It MUST be https from the start; an http:// redirect is permanently broken.
+     Copy the App ID and App Secret.
+
+  7. Set the three secrets, then re-deploy:
+       npx wrangler secret put HELPSCOUT_CLIENT_ID     --config wrangler.deploy.jsonc
+       npx wrangler secret put HELPSCOUT_CLIENT_SECRET  --config wrangler.deploy.jsonc
+       npx wrangler secret put COOKIE_ENCRYPTION_KEY    --config wrangler.deploy.jsonc
+       npx wrangler deploy --config wrangler.deploy.jsonc
+
+  8. Connect a client to https://<worker-url>/mcp and sign in.
+
+Full runbook, including the token behavior and write toggles:
+  ../guides/remote-self-host.md
+`);
+  } finally {
+    if (rl) rl.close();
+  }
+}
+
+main().catch((e) => {
+  console.error('\nsetup crashed:', e);
+  process.exit(1);
+});

--- a/worker/scripts/setup.mjs
+++ b/worker/scripts/setup.mjs
@@ -41,9 +41,9 @@ function parseArgs(argv) {
     else if (a === '--yes' || a === '-y') opts.yes = true;
     else if (a === '--dry-run') opts.dryRun = true;
     else if (a === '--skip-auth-check') opts.skipAuthCheck = true;
-    else if (a === '--kv-id') opts.kvId = argv[++i];
-    else if (a === '--account-id') opts.accountId = argv[++i];
-    else if (a === '--name') opts.name = argv[++i];
+    else if (a === '--kv-id') opts.kvId = takeValue(argv, ++i, a);
+    else if (a === '--account-id') opts.accountId = takeValue(argv, ++i, a);
+    else if (a === '--name') opts.name = takeValue(argv, ++i, a);
     else if (a === '--help' || a === '-h') opts.help = true;
     else {
       console.error(`Unknown argument: ${a}`);
@@ -51,6 +51,17 @@ function parseArgs(argv) {
     }
   }
   return opts;
+}
+
+// A flag that expects a value must actually get one; swallowing the next flag
+// would silently create namespaces or write configs with names like "--force".
+function takeValue(argv, i, flag) {
+  const value = argv[i];
+  if (value === undefined || value.startsWith('--')) {
+    console.error(`${flag} expects a value`);
+    process.exit(2);
+  }
+  return value;
 }
 
 function printHelp() {
@@ -83,8 +94,13 @@ function runWrangler(args) {
 function checkAuth() {
   const res = runWrangler(['whoami']);
   const out = `${res.stdout || ''}${res.stderr || ''}`;
-  // wrangler exits non-zero and/or prints a login hint when not authenticated.
-  const loggedOut = res.status !== 0 || /not authenticated|log ?in|not logged in/i.test(out);
+  // A signed-in `wrangler whoami` exits zero and says "You are logged in";
+  // signed-out runs exit non-zero and/or say "not authenticated". Matching a
+  // bare "login" would misread signed-in output that merely mentions logging in.
+  const loggedOut =
+    res.status !== 0 ||
+    /not authenticated|not logged in/i.test(out) ||
+    !/logged in/i.test(out);
   return { ok: !loggedOut, output: out.trim() };
 }
 
@@ -127,6 +143,9 @@ function createKvNamespace() {
 function renderDeployConfig(template, { kvId, accountId, name }) {
   let out = template;
 
+  if (!out.includes('<REPLACE_WITH_KV_ID>')) {
+    throw new Error('template no longer contains the <REPLACE_WITH_KV_ID> placeholder');
+  }
   out = out.replace('<REPLACE_WITH_KV_ID>', kvId);
 
   if (name && name !== DEFAULT_NAME) {


### PR DESCRIPTION
## What

The stabilization half of NAS-1504, ahead of the access-management feature work:

- **README decision table** ("Which install should I use?") across the four install paths, with two facts stated plainly below it: claude.ai web and mobile can only use the remote worker (the local stdio installs cannot reach them), and only the remote worker gives per-user identity and attribution, since the local installs share one App ID/Secret and act as the app owner.
- **Positioning**: the self-hosted worker is framed as the recommended path for teams avoiding shared credentials and for organizations under RBAC/compliance-style requirements (SOC 2 / ISO 27001 named as examples), carefully worded to support control requirements without claiming the software is certified or compliant.
- **Upgrade path** section in the runbook (git pull, npm install if the lockfile changed, wrangler deploy; secrets and KV survive; smoke before deploying).
- **Setup wizard**: `npm run setup` in worker/ collapses the KV-create and deploy-config steps: checks wrangler auth, creates OAUTH_KV (or takes `--kv-id`), writes wrangler.deploy.jsonc with the id and optional account_id/name, prints the remaining guide steps. Refuses to overwrite an existing deploy config without `--force`; supports `--dry-run` and `--yes`. Guide steps 3-4 lead with it, manual path kept.

## Verification

- Wizard behaviors exercised directly: no-clobber refusal against a real deploy config (file hash unchanged), second-run refusal, create path in a scratch dir (valid JSONC, DO binding name untouched), `--force`, `--dry-run` (writes nothing), `--kv-id` skip.
- Root type-check/lint clean, worker tsc clean, full jest 608 passing (known local-.env environmental case aside). Guide anchors the README depends on still resolve.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->