### PR TITLE
feat(NAS-1501): per-user access policy on a strongly-consistent coordinator DO

### DIFF
--- a/guides/remote-self-host.md
+++ b/guides/remote-self-host.md
@@ -311,6 +311,39 @@ reconnect; other users are unaffected.
   If you want a check before shipping an update, run the smoke suite first (`npm run
   smoke`); it drives the whole OAuth flow against a local mock without touching Help
   Scout or your live deployment.
+
+  **When an upgrade introduces a new Durable Object.** Some upgrades add a new
+  Durable Object class. Because your `wrangler.deploy.jsonc` is your own gitignored
+  copy, it does NOT pick these up from `git pull`, and the wizard does not reconcile
+  them for you: you must add the new binding and a new migration tag by hand before
+  deploying, or every request that uses the new object fails. This version added the
+  access-policy coordinator (`PolicyCoordinator`), bound as `POLICY_OBJECT`. Compare
+  your `wrangler.deploy.jsonc` against the shipped `wrangler.jsonc` template and, if
+  it is missing, add the binding:
+
+  ```jsonc
+  "durable_objects": {
+    "bindings": [
+      { "class_name": "HelpScoutMCP", "name": "MCP_OBJECT" },
+      // Add this line if your config predates the policy engine:
+      { "class_name": "PolicyCoordinator", "name": "POLICY_OBJECT" }
+    ]
+  },
+  ```
+
+  and the matching migration tag:
+
+  ```jsonc
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["HelpScoutMCP"] },
+    // Add this entry alongside your existing tags:
+    { "tag": "v2", "new_sqlite_classes": ["PolicyCoordinator"] }
+  ],
+  ```
+
+  Deploying without the `POLICY_OBJECT` binding leaves the worker unable to read or
+  write the access policy, and because that check fails closed every callback and
+  tool call returns "access could not be verified" until the binding is added.
 - Live logs: `npm run tail` (wraps `wrangler tail`) streams request logs from the
   deployed worker.
 - The three advertised tools are a gateway over the read operations; Claude finds

--- a/src/__tests__/helpscout-fetch-client.test.ts
+++ b/src/__tests__/helpscout-fetch-client.test.ts
@@ -716,4 +716,51 @@ describe('HelpScoutFetchClient', () => {
       expect(() => makeHarness({ baseUrl: 'not a url' })).toThrow(/Invalid Help Scout base URL/);
     });
   });
+
+  describe('insecure loopback allowance', () => {
+    // Default (no flag): https is enforced, so even an http loopback URL (which
+    // the smoke's mock upstream uses) is rejected. Only the Workers request path
+    // opts in, and only in test mode.
+    it('rejects an http loopback base URL without the flag', () => {
+      expect(() => makeHarness({ baseUrl: 'http://127.0.0.1:8787/hs/' })).toThrow(/HTTPS/);
+    });
+
+    it('rejects an http loopback token URL without the flag', () => {
+      expect(() => makeHarness({ tokenUrl: 'http://127.0.0.1:8787/hs/token' })).toThrow(/HTTPS/);
+    });
+
+    it('accepts http loopback base and token URLs when the flag is set', () => {
+      expect(() =>
+        makeHarness({
+          baseUrl: 'http://127.0.0.1:8787/hs/',
+          tokenUrl: 'http://127.0.0.1:8787/hs/token',
+          allowInsecureLoopback: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts localhost and [::1] over http when the flag is set', () => {
+      expect(() =>
+        makeHarness({
+          baseUrl: 'http://localhost:8787/hs/',
+          tokenUrl: 'http://[::1]:8787/hs/token',
+          allowInsecureLoopback: true,
+        }),
+      ).not.toThrow();
+    });
+
+    // The allow-list is exact-match: a host that merely starts with 127.0.0.1 is
+    // a different, attacker-controlled host and must be rejected even with the flag.
+    it('rejects http://127.0.0.1.evil.com even with the flag (exact-match host)', () => {
+      expect(() =>
+        makeHarness({ baseUrl: 'http://127.0.0.1.evil.com/v2/', allowInsecureLoopback: true }),
+      ).toThrow(/HTTPS/);
+    });
+
+    it('still requires https for a public host even with the flag', () => {
+      expect(() =>
+        makeHarness({ baseUrl: 'http://api.helpscout.net/v2/', allowInsecureLoopback: true }),
+      ).toThrow(/HTTPS/);
+    });
+  });
 });

--- a/src/__tests__/worker-policy.test.ts
+++ b/src/__tests__/worker-policy.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit coverage for the worker's access-policy engine (NAS-1501).
+ *
+ * Two layers are exercised here in CI:
+ *   1. The pure decision helpers (evaluateAccess / effectiveWriteFlags).
+ *   2. The storage-injectable CAS core the coordinator Durable Object runs
+ *      (readConfigDoc / writeConfigDoc / readUserPolicyDoc / writeUserPolicyDoc /
+ *      pinUserPolicyRevoked / clear*), driven against an in-memory transactional
+ *      fake. The fake models the one property the real DO provides that KV did
+ *      not: transactions are serialized, so a read-modify-write inside one sees a
+ *      consistent snapshot and cannot lose its write to a racing transaction.
+ *
+ * The env-facing RPC wrappers (policy-store.ts) and the full enforcement flow run
+ * in the worker smoke suite, which drives the actual coordinator DO.
+ */
+import {
+  PolicyConflictError,
+  PolicyInvalidError,
+  ADMIN_CONFIG_KEY,
+  clearConfigDoc,
+  clearUserPolicyDoc,
+  effectiveWriteFlags,
+  evaluateAccess,
+  pinUserPolicyRevoked,
+  readConfigDoc,
+  readUserPolicyDoc,
+  userPolicyKey,
+  writeConfigDoc,
+  writeUserPolicyDoc,
+  type AdminConfig,
+  type PolicyStorage,
+  type UserPolicy,
+} from '../../worker/src/policy.js';
+
+/**
+ * An in-memory PolicyStorage that faithfully models the coordinator DO: values
+ * are stored by structured copy (no aliasing, like real serialized storage) and
+ * `transaction` serializes its closures through a promise chain, the way a
+ * single-threaded, input-gated Durable Object serializes concurrent requests. A
+ * rejected transaction still lets the next one proceed (a DO transaction that
+ * throws rolls back and the next request runs).
+ */
+function makeStorage(initial: Record<string, unknown> = {}) {
+  const map = new Map<string, unknown>(
+    Object.entries(initial).map(([k, v]) => [k, structuredClone(v)]),
+  );
+  let tail: Promise<unknown> = Promise.resolve();
+  const storage: PolicyStorage = {
+    get: async <T>(key: string): Promise<T | undefined> => {
+      const value = map.get(key);
+      return value === undefined ? undefined : (structuredClone(value) as T);
+    },
+    put: async (key: string, value: unknown): Promise<void> => {
+      map.set(key, structuredClone(value));
+    },
+    delete: async (key: string): Promise<void> => {
+      map.delete(key);
+    },
+    transaction: <T>(closure: () => Promise<T>): Promise<T> => {
+      const result = tail.then(() => closure());
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+  };
+  return { map, storage };
+}
+
+const baseConfig = (over: Partial<AdminConfig> = {}): AdminConfig => ({
+  schemaVersion: 1,
+  allowlistMode: false,
+  adminRole: 'owner',
+  policyCacheTtlSeconds: 45,
+  version: 1,
+  updatedAt: '2026-07-31T00:00:00Z',
+  updatedBy: 'admin',
+  ...over,
+});
+
+const basePolicy = (over: Partial<UserPolicy> = {}): UserPolicy => ({
+  v: 1,
+  allowed: true,
+  writes: false,
+  customerVisibleWrites: false,
+  email: 'user@example.test',
+  updatedAt: '2026-07-31T00:00:00Z',
+  updatedBy: 'admin',
+  version: 1,
+  ...over,
+});
+
+describe('evaluateAccess', () => {
+  it('allows by default in open mode with no user entry', () => {
+    expect(evaluateAccess(baseConfig(), null).allowed).toBe(true);
+  });
+
+  it('blocks an explicit allowed:false even in open mode', () => {
+    const decision = evaluateAccess(baseConfig(), basePolicy({ allowed: false }));
+    expect(decision).toEqual({ allowed: false, reason: 'explicit-block' });
+  });
+
+  it('denies missing entries under allowlist mode and admits explicit allows', () => {
+    const config = baseConfig({ allowlistMode: true });
+    expect(evaluateAccess(config, null)).toEqual({ allowed: false, reason: 'allowlist' });
+    expect(evaluateAccess(config, basePolicy()).allowed).toBe(true);
+  });
+});
+
+describe('effectiveWriteFlags', () => {
+  const ceiling = { enabled: true, customerVisibleEnabled: true };
+
+  it('inherits the ceiling unchanged when the user has no policy document', () => {
+    expect(effectiveWriteFlags(ceiling, null)).toEqual(ceiling);
+  });
+
+  it('narrows to the intersection of ceiling and user grants', () => {
+    expect(effectiveWriteFlags(ceiling, basePolicy())).toEqual({ enabled: false, customerVisibleEnabled: false });
+    expect(effectiveWriteFlags(ceiling, basePolicy({ writes: true }))).toEqual({ enabled: true, customerVisibleEnabled: false });
+    expect(
+      effectiveWriteFlags(ceiling, basePolicy({ writes: true, customerVisibleWrites: true })),
+    ).toEqual({ enabled: true, customerVisibleEnabled: true });
+  });
+
+  it('never exceeds the ceiling regardless of user grants', () => {
+    const readOnlyCeiling = { enabled: false, customerVisibleEnabled: false };
+    expect(
+      effectiveWriteFlags(readOnlyCeiling, basePolicy({ writes: true, customerVisibleWrites: true })),
+    ).toEqual({ enabled: false, customerVisibleEnabled: false });
+  });
+});
+
+describe('config schema fail-closed', () => {
+  it('treats a missing document as open-mode defaults', async () => {
+    const { storage } = makeStorage();
+    const config = await readConfigDoc(storage);
+    expect(config.allowlistMode).toBe(false);
+    expect(config.version).toBe(0);
+  });
+
+  it.each([
+    [{ schemaVersion: 2, allowlistMode: true, version: 1 }],
+    [{ allowlistMode: true, version: 1 }],
+    [{ schemaVersion: 1, allowlistMode: 'yes', version: 1 }],
+  ])('throws PolicyInvalidError for unsupported or malformed document %p', async (doc) => {
+    const { storage } = makeStorage({ [ADMIN_CONFIG_KEY]: doc });
+    await expect(readConfigDoc(storage)).rejects.toBeInstanceOf(PolicyInvalidError);
+  });
+});
+
+describe('user policy normalization', () => {
+  it('reads a document violating the implied-writes invariant down to least privilege', async () => {
+    const { storage } = makeStorage({
+      [userPolicyKey('42')]: basePolicy({ writes: false, customerVisibleWrites: true }),
+    });
+    const policy = await readUserPolicyDoc(storage, '42');
+    expect(policy?.customerVisibleWrites).toBe(false);
+  });
+
+  it('raises writes when a customer-visible grant is written', async () => {
+    const { storage } = makeStorage();
+    const written = await writeUserPolicyDoc(
+      storage,
+      '42',
+      { allowed: true, writes: false, customerVisibleWrites: true },
+      { expectedVersion: 0, updatedBy: 'admin' },
+    );
+    expect(written.writes).toBe(true);
+  });
+});
+
+describe('optimistic concurrency (single-writer)', () => {
+  it('rejects a stale config write and leaves the document untouched', async () => {
+    const { map, storage } = makeStorage({ [ADMIN_CONFIG_KEY]: baseConfig({ version: 3 }) });
+    await expect(
+      writeConfigDoc(storage, { allowlistMode: true }, { expectedVersion: 2, updatedBy: 'admin' }),
+    ).rejects.toBeInstanceOf(PolicyConflictError);
+    expect((map.get(ADMIN_CONFIG_KEY) as AdminConfig).allowlistMode).toBe(false);
+    expect((map.get(ADMIN_CONFIG_KEY) as AdminConfig).version).toBe(3);
+  });
+
+  it('rejects a stale user policy write', async () => {
+    const { storage } = makeStorage({ [userPolicyKey('42')]: basePolicy({ version: 2 }) });
+    await expect(
+      writeUserPolicyDoc(
+        storage,
+        '42',
+        { allowed: false, writes: false, customerVisibleWrites: false },
+        { expectedVersion: 1, updatedBy: 'admin' },
+      ),
+    ).rejects.toBeInstanceOf(PolicyConflictError);
+  });
+
+  it('increments the version on a successful write', async () => {
+    const { storage } = makeStorage();
+    const first = await writeConfigDoc(storage, { allowlistMode: true }, { expectedVersion: 0, updatedBy: 'a' });
+    expect(first.version).toBe(1);
+    const second = await writeConfigDoc(storage, { allowlistMode: false }, { expectedVersion: 1, updatedBy: 'b' });
+    expect(second.version).toBe(2);
+  });
+});
+
+// The defect this whole change exists to fix: under the KV get-then-put, two
+// admins reading the same version could both "succeed" and silently lose one
+// update. Inside the coordinator DO the check-and-increment is one serialized
+// transaction, so exactly one of two same-version writers wins and the other
+// gets a conflict. These fire both writes WITHOUT awaiting the first, so the
+// proof is the transactional serialization, not test sequencing.
+describe('atomic compare-and-swap (concurrent writers)', () => {
+  it('resolves two same-version config writes to exactly one winner + one conflict', async () => {
+    const { storage } = makeStorage(); // absent config reads as version 0
+    const settled = await Promise.allSettled([
+      writeConfigDoc(storage, { allowlistMode: true }, { expectedVersion: 0, updatedBy: 'admin-a' }),
+      writeConfigDoc(storage, { allowlistMode: false, policyCacheTtlSeconds: 200 }, { expectedVersion: 0, updatedBy: 'admin-b' }),
+    ]);
+
+    const fulfilled = settled.filter((r): r is PromiseFulfilledResult<AdminConfig> => r.status === 'fulfilled');
+    const rejected = settled.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].reason).toBeInstanceOf(PolicyConflictError);
+    expect((rejected[0].reason as PolicyConflictError).expectedVersion).toBe(0);
+    expect((rejected[0].reason as PolicyConflictError).currentVersion).toBe(1);
+
+    // The store holds exactly the winner's document at version 1 — the loser's
+    // write never landed.
+    const persisted = await readConfigDoc(storage);
+    expect(persisted.version).toBe(1);
+    expect(persisted.updatedBy).toBe(fulfilled[0].value.updatedBy);
+  });
+
+  it('resolves two same-version user writes to exactly one winner + one conflict (a racing allow cannot silently overwrite)', async () => {
+    const { storage } = makeStorage({ [userPolicyKey('7')]: basePolicy({ version: 1, allowed: true }) });
+    const settled = await Promise.allSettled([
+      writeUserPolicyDoc(storage, '7', { allowed: false, writes: false, customerVisibleWrites: false }, { expectedVersion: 1, updatedBy: 'revoker' }),
+      writeUserPolicyDoc(storage, '7', { allowed: true, writes: true, customerVisibleWrites: false }, { expectedVersion: 1, updatedBy: 'allower' }),
+    ]);
+
+    const fulfilled = settled.filter((r): r is PromiseFulfilledResult<UserPolicy> => r.status === 'fulfilled');
+    const rejected = settled.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].reason).toBeInstanceOf(PolicyConflictError);
+
+    const persisted = await readUserPolicyDoc(storage, '7');
+    expect(persisted?.version).toBe(2);
+    expect(persisted?.updatedBy).toBe(fulfilled[0].value.updatedBy);
+  });
+});
+
+describe('pinUserPolicyRevoked', () => {
+  it('pins allowed:false with writes off and bumps the version, preserving email', async () => {
+    const { storage } = makeStorage({
+      [userPolicyKey('42')]: basePolicy({ version: 4, writes: true, customerVisibleWrites: true, email: 'x@example.test' }),
+    });
+    const pinned = await pinUserPolicyRevoked(storage, 42, 'revoker');
+    expect(pinned.allowed).toBe(false);
+    expect(pinned.writes).toBe(false);
+    expect(pinned.customerVisibleWrites).toBe(false);
+    expect(pinned.version).toBe(5);
+    expect(pinned.email).toBe('x@example.test');
+  });
+
+  it('pins a never-seen user to allowed:false at version 1', async () => {
+    const { storage } = makeStorage();
+    const pinned = await pinUserPolicyRevoked(storage, 'ghost', 'revoker');
+    expect(pinned.allowed).toBe(false);
+    expect(pinned.version).toBe(1);
+  });
+});
+
+describe('clear helpers', () => {
+  it('clearConfigDoc removes the document so it reads back as open-mode defaults', async () => {
+    const { storage } = makeStorage({ [ADMIN_CONFIG_KEY]: baseConfig({ allowlistMode: true, version: 2 }) });
+    await clearConfigDoc(storage);
+    const config = await readConfigDoc(storage);
+    expect(config.allowlistMode).toBe(false);
+    expect(config.version).toBe(0);
+  });
+
+  it('clearUserPolicyDoc removes the document so it reads back as null', async () => {
+    const { storage } = makeStorage({ [userPolicyKey('42')]: basePolicy() });
+    await clearUserPolicyDoc(storage, 42);
+    expect(await readUserPolicyDoc(storage, '42')).toBeNull();
+  });
+});

--- a/src/worker/helpscout-fetch-client.ts
+++ b/src/worker/helpscout-fetch-client.ts
@@ -180,6 +180,24 @@ export class HelpScoutFetchClient implements HelpScoutApi {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  /**
+   * https is required so OAuth2 credentials are never sent in the clear, with a
+   * loopback exception for the smoke harness's mock upstream. This mirrors the
+   * `isSecureUpstreamUrl` allowance the consent handler already applies to the
+   * token/base URLs (help-scout-handler.ts): a real deployment is always https,
+   * and only 127.0.0.1 / localhost / [::1] over http is tolerated for the mock.
+   */
+  private isSecureUpstream(parsed: URL): boolean {
+    if (parsed.protocol === 'https:') return true;
+    return (
+      parsed.protocol === 'http:' &&
+      (parsed.hostname === '127.0.0.1' ||
+        parsed.hostname === 'localhost' ||
+        parsed.hostname === '[::1]' ||
+        parsed.hostname === '::1')
+    );
+  }
+
   private validateHttpsBaseUrl(baseUrl: string): void {
     let parsed: URL;
     try {
@@ -188,7 +206,7 @@ export class HelpScoutFetchClient implements HelpScoutApi {
       throw new Error(`Invalid Help Scout base URL: ${baseUrl}`);
     }
 
-    if (parsed.protocol !== 'https:') {
+    if (!this.isSecureUpstream(parsed)) {
       throw new Error('HELPSCOUT_BASE_URL must use HTTPS to protect OAuth2 credentials');
     }
   }
@@ -201,7 +219,7 @@ export class HelpScoutFetchClient implements HelpScoutApi {
       throw new Error(`Invalid ${label}: ${url}`);
     }
 
-    if (parsed.protocol !== 'https:') {
+    if (!this.isSecureUpstream(parsed)) {
       throw new Error(`${label} must use HTTPS to protect OAuth2 credentials`);
     }
   }

--- a/src/worker/helpscout-fetch-client.ts
+++ b/src/worker/helpscout-fetch-client.ts
@@ -75,6 +75,15 @@ export interface FetchClientDeps {
   persistTokens: (tokens: UserTokenContext) => Promise<void>;
   refreshMutex: RefreshMutex;
   timeoutMs?: number;
+  /**
+   * Opt-in, DEFAULT false: tolerate an http loopback base/token URL so the smoke
+   * harness can point the client at a local mock. Only the Workers request path
+   * sets it, and only in test mode (Boolean(HELPSCOUT_TEST_POLICY_ROUTES)); every
+   * stdio and unit path leaves it off, so https is enforced unless explicitly
+   * opted in. The allow-list is exact-match, so http://127.0.0.1.evil.com is
+   * still rejected.
+   */
+  allowInsecureLoopback?: boolean;
 }
 
 /**
@@ -165,8 +174,11 @@ function headersToObject(headers: Headers): Record<string, string> {
 export class HelpScoutFetchClient implements HelpScoutApi {
   private readonly timeoutMs: number;
   private readonly retryConfig: RetryConfig = DEFAULT_RETRY_CONFIG;
+  /** Test-only http-loopback allowance; false everywhere except the smoke path. */
+  private readonly allowInsecureLoopback: boolean;
 
   constructor(private readonly deps: FetchClientDeps) {
+    this.allowInsecureLoopback = deps.allowInsecureLoopback ?? false;
     this.validateHttpsBaseUrl(deps.baseUrl);
     // The token endpoint receives the refresh token and the client secret, so
     // it gets the same HTTPS requirement as the API base.
@@ -181,14 +193,18 @@ export class HelpScoutFetchClient implements HelpScoutApi {
   }
 
   /**
-   * https is required so OAuth2 credentials are never sent in the clear, with a
-   * loopback exception for the smoke harness's mock upstream. This mirrors the
-   * `isSecureUpstreamUrl` allowance the consent handler already applies to the
-   * token/base URLs (help-scout-handler.ts): a real deployment is always https,
-   * and only 127.0.0.1 / localhost / [::1] over http is tolerated for the mock.
+   * https is required so OAuth2 credentials are never sent in the clear. A narrow
+   * http-loopback exception exists ONLY when the caller opted in via
+   * `allowInsecureLoopback` (the smoke harness's mock upstream); with it off,
+   * every non-https URL is rejected. This mirrors the `isSecureUpstreamUrl`
+   * allowance the consent handler applies under the same test-mode signal
+   * (help-scout-handler.ts): a real deployment is always https, and only
+   * 127.0.0.1 / localhost / [::1] over http is tolerated, and only in test mode.
+   * The host match is exact so http://127.0.0.1.evil.com is rejected.
    */
   private isSecureUpstream(parsed: URL): boolean {
     if (parsed.protocol === 'https:') return true;
+    if (!this.allowInsecureLoopback) return false;
     return (
       parsed.protocol === 'http:' &&
       (parsed.hostname === '127.0.0.1' ||

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -695,6 +695,42 @@ async function runPolicyMode({ mock }) {
   await policyRoute({ op: 'putConfig', patch: { allowlistMode: false }, expectedVersion: 0 });
   const stale = await policyRoute({ op: 'putConfig', patch: { allowlistMode: true }, expectedVersion: 0 });
   check('stale putConfig returns a 409 conflict', stale.status === 409 && stale.body.code === 'POLICY_CONFLICT', JSON.stringify(stale.body));
+
+  // [P7] atomic CAS through the coordinator DO: two writes presenting the SAME
+  // expectedVersion, fired concurrently (both requests in flight before either
+  // resolves), resolve to exactly one 200 and one 409 — no lost update. This is
+  // the defect the KV get-then-put had; the DO serializes the check-and-increment.
+  console.log('[P7] concurrent same-version writes resolve to one winner + one conflict');
+  await policyRoute({ op: 'del', target: 'config' });
+  const seed7 = await policyRoute({ op: 'putConfig', patch: { allowlistMode: false }, expectedVersion: 0 });
+  check('CAS seed config written (version 1)', seed7.status === 200 && seed7.body.config?.version === 1, JSON.stringify(seed7.body));
+  const [w1, w2] = await Promise.all([
+    policyRoute({ op: 'putConfig', patch: { allowlistMode: true }, expectedVersion: 1 }),
+    policyRoute({ op: 'putConfig', patch: { policyCacheTtlSeconds: 120 }, expectedVersion: 1 }),
+  ]);
+  const statuses = [w1.status, w2.status].sort((a, b) => a - b);
+  check('concurrent same-version writes: exactly one 200 and one 409', statuses[0] === 200 && statuses[1] === 409, JSON.stringify(statuses));
+  const conflict7 = [w1, w2].find((r) => r.status === 409);
+  check('the losing concurrent write is a POLICY_CONFLICT', conflict7?.body?.code === 'POLICY_CONFLICT', JSON.stringify(conflict7?.body));
+  const after7 = await policyRoute({ op: 'getConfig' });
+  check('exactly one concurrent write landed (config advanced to version 2)', after7.body.config?.version === 2, JSON.stringify(after7.body.config));
+
+  // [P8] strong-consistency admission gate: a fresh /callback immediately after a
+  // revoke reads the deny with no stale admit. Under the old KV store a callback
+  // landing in a lagging colo could still read the pre-revoke policy and mint a
+  // grant; the coordinator's reads are strongly consistent, so the very next
+  // sign-in is refused.
+  console.log('[P8] revoke then immediate fresh callback is denied');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 1008 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: 1008, input: { allowed: true, writes: false, customerVisibleWrites: false }, expectedVersion: 0 });
+  mock.state.userId = 1008;
+  const preRevoke8 = await runFullFlow({ clientId, resource, mock });
+  check('user connects before revoke', typeof preRevoke8.accessToken === 'string' && preRevoke8.accessToken.length > 0);
+  const rev8 = await policyRoute({ op: 'revokeUser', hsUserId: 1008 });
+  check('revoke pins the policy to allowed:false', rev8.body.result?.policy?.allowed === false, JSON.stringify(rev8.body.result?.policy));
+  const postRevoke8 = await runFullFlow({ clientId, resource, mock });
+  check('a fresh callback immediately after revoke is denied (403, no stale admit)', postRevoke8.stopped === 'callback' && postRevoke8.status === 403, `status ${postRevoke8.status}`);
 }
 
 async function main() {

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -27,6 +27,14 @@ const READY_TIMEOUT_MS = 90_000;
 const MOCK_USER = { id: 987, firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.test', type: 'user' };
 const HS_EXPIRES_IN = 172800; // 48h, matching Help Scout
 
+// Per-run secret gating the test-only policy route AND signalling test-mode (the
+// worker tolerates an http loopback upstream only when this var is non-empty).
+// It is a fresh random value every run (never hardcode it) and every request to
+// the /__test__/policy route must present it in the X-Test-Policy-Key header. The
+// worker mounts that route only for a request whose header equals this exact
+// value; a missing or wrong key 404s, so the route stays invisible.
+const TEST_POLICY_KEY = crypto.randomBytes(24).toString('hex');
+
 let passed = 0;
 const failures = [];
 function check(name, cond, detail = '') {
@@ -148,7 +156,7 @@ function startMockHelpScout() {
 }
 
 // --- wrangler dev lifecycle -------------------------------------------------
-function startWorker({ mockUrl, enableWrites, enableCustomerVisible = false, testPolicyRoutes = false }) {
+function startWorker({ mockUrl, enableWrites, enableCustomerVisible = false }) {
   const args = [
     './node_modules/.bin/wrangler',
     'dev',
@@ -166,8 +174,13 @@ function startWorker({ mockUrl, enableWrites, enableCustomerVisible = false, tes
     `HELPSCOUT_ENABLE_WRITES:${enableWrites ? 'true' : 'false'}`,
     '--var',
     `HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES:${enableCustomerVisible ? 'true' : 'false'}`,
+    // The mock upstream is http loopback, which the worker only tolerates in
+    // test mode, so every smoke worker is started in test mode with the per-run
+    // secret. The route itself stays gated by the X-Test-Policy-Key header: a
+    // worker in read/writes mode never receives that header from this suite, so
+    // its /__test__/policy 404s (see the "absent by default" check below).
     '--var',
-    `HELPSCOUT_TEST_POLICY_ROUTES:${testPolicyRoutes ? 'true' : 'false'}`,
+    `HELPSCOUT_TEST_POLICY_ROUTES:${TEST_POLICY_KEY}`,
   ];
   const proc = spawn(NODE_BIN, args, {
     cwd: WORKER_DIR,
@@ -406,12 +419,12 @@ async function mcpCallTool(headers, name, args) {
   return { httpStatus: res.status, isError: Boolean(result?.isError), structured, text };
 }
 
-// Drive the test-harness policy route (only mounted when the worker is started
-// with HELPSCOUT_TEST_POLICY_ROUTES=true).
+// Drive the test-harness policy route. The route is mounted only for a request
+// that presents the per-run secret in X-Test-Policy-Key, so every call sends it.
 async function policyRoute(command) {
   const res = await fetch(`${BASE}/__test__/policy`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-Test-Policy-Key': TEST_POLICY_KEY },
     body: JSON.stringify(command),
   });
   const body = await res.json().catch(() => ({}));
@@ -551,14 +564,17 @@ async function runMode({ mock, enableWrites }) {
   check('light user hits the callback error path', lightFlow.stopped === 'callback' && lightFlow.status === 403, `status ${lightFlow.status}`);
   check('light-user page explains a full seat is required', /seat|Light User|full Help Scout/i.test(lightFlow.body || ''));
 
-  // [8b] the test-only policy route must NOT exist without the opt-in var
-  console.log('[8b] test policy route is absent by default');
+  // [8b] the test-only policy route must be invisible without the secret key.
+  // This worker runs in read/writes mode: the var is set (test-mode is on for the
+  // loopback mock), but this suite never sends X-Test-Policy-Key here, so the
+  // route must 404 exactly as it would with the var unset.
+  console.log('[8b] test policy route is absent without the secret key');
   const noRoute = await fetch(`${BASE}/__test__/policy`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ op: 'getConfig' }),
   });
-  check('test policy route 404s without HELPSCOUT_TEST_POLICY_ROUTES', noRoute.status === 404, `status ${noRoute.status}`);
+  check('test policy route 404s without the X-Test-Policy-Key header', noRoute.status === 404, `status ${noRoute.status}`);
 
   // [9] RFC 8707 resource binding on token exchange (soft)
   console.log('[9] resource-mismatch on token exchange (soft)');
@@ -607,7 +623,16 @@ async function runPolicyMode({ mock }) {
   const clientId = reg.clientId;
 
   const ping = await policyRoute({ op: 'getConfig' });
-  check('test policy route is mounted with the opt-in var set', ping.status === 200, `status ${ping.status}`);
+  check('test policy route is mounted with the correct secret key', ping.status === 200, `status ${ping.status}`);
+
+  // The route is secret-gated: even with the var set, a request carrying a wrong
+  // X-Test-Policy-Key must 404 (invisible), never reveal itself with a 403.
+  const wrongKey = await fetch(`${BASE}/__test__/policy`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Test-Policy-Key': 'wrong-key' },
+    body: JSON.stringify({ op: 'getConfig' }),
+  });
+  check('test policy route 404s with a wrong X-Test-Policy-Key (secret gate)', wrongKey.status === 404, `status ${wrongKey.status}`);
 
   // [P1] allowlist mode denies an unlisted user's callback with the friendly page
   console.log('[P1] allowlist mode denies an unlisted user');
@@ -755,7 +780,7 @@ async function main() {
     if (runPolicy) {
       // Reset the mutable mock user id so the policy mode starts from a known id.
       mock.state.userId = MOCK_USER.id;
-      const policyWorker = startWorker({ mockUrl: mock.url, enableWrites: true, testPolicyRoutes: true });
+      const policyWorker = startWorker({ mockUrl: mock.url, enableWrites: true });
       try {
         await waitForReady(policyWorker.getLog);
         await runPolicyMode({ mock });

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -46,7 +46,7 @@ const b64url = (buf) =>
 // State is mutated directly from the smoke process (same runtime) to exercise
 // the light-user path and to observe refresh-token rotation.
 function startMockHelpScout() {
-  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0, issuedCodes: new Set() };
+  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0, issuedCodes: new Set(), userId: MOCK_USER.id, noteWrites: 0 };
 
   const readBody = (req) =>
     new Promise((resolve) => {
@@ -114,6 +114,7 @@ function startMockHelpScout() {
     }
 
     // Identity. Light Users have no Mailbox API access: 403 even with a token.
+    // The user id is overridable so policy tests can drive distinct users.
     if (url.pathname === '/hs/users/me' && req.method === 'GET') {
       if (state.lightUser) {
         res.writeHead(403, { 'Content-Type': 'application/json' });
@@ -121,7 +122,16 @@ function startMockHelpScout() {
         return;
       }
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(MOCK_USER));
+      res.end(JSON.stringify({ ...MOCK_USER, id: state.userId }));
+      return;
+    }
+
+    // Write endpoint for the policy write test: createNote POSTs here. Answers
+    // 201 with the Resource-Id header the write handler reads.
+    if (req.method === 'POST' && /^\/hs\/conversations\/\d+\/notes$/.test(url.pathname)) {
+      state.noteWrites += 1;
+      res.writeHead(201, { 'Content-Type': 'application/json', 'Resource-Id': '5551' });
+      res.end(JSON.stringify({}));
       return;
     }
 
@@ -138,7 +148,7 @@ function startMockHelpScout() {
 }
 
 // --- wrangler dev lifecycle -------------------------------------------------
-function startWorker({ mockUrl, enableWrites }) {
+function startWorker({ mockUrl, enableWrites, enableCustomerVisible = false, testPolicyRoutes = false }) {
   const args = [
     './node_modules/.bin/wrangler',
     'dev',
@@ -154,6 +164,10 @@ function startWorker({ mockUrl, enableWrites }) {
     `HELPSCOUT_BASE_URL:${mockUrl}/hs/`,
     '--var',
     `HELPSCOUT_ENABLE_WRITES:${enableWrites ? 'true' : 'false'}`,
+    '--var',
+    `HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES:${enableCustomerVisible ? 'true' : 'false'}`,
+    '--var',
+    `HELPSCOUT_TEST_POLICY_ROUTES:${testPolicyRoutes ? 'true' : 'false'}`,
   ];
   const proc = spawn(NODE_BIN, args, {
     cwd: WORKER_DIR,
@@ -369,6 +383,41 @@ async function toolsList(headers) {
   return { status: res.status, tools: (body?.result?.tools || []).map((t) => t.name) };
 }
 
+// Dispatch one tools/call and return the parsed structured result. `isError`
+// reflects the CallToolResult.isError flag the gateway/policy layer sets.
+async function mcpCallTool(headers, name, args) {
+  const res = await fetch(`${BASE}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name, arguments: args ?? {} },
+    }),
+  });
+  const body = await readRpc(res);
+  const result = body?.result;
+  const text = result?.content?.[0]?.text;
+  let structured = result?.structuredContent;
+  if (!structured && typeof text === 'string') {
+    try { structured = JSON.parse(text); } catch { /* not JSON */ }
+  }
+  return { httpStatus: res.status, isError: Boolean(result?.isError), structured, text };
+}
+
+// Drive the test-harness policy route (only mounted when the worker is started
+// with HELPSCOUT_TEST_POLICY_ROUTES=true).
+async function policyRoute(command) {
+  const res = await fetch(`${BASE}/__test__/policy`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+  });
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, body };
+}
+
 // --- One full mode (writes off / on) ----------------------------------------
 async function runMode({ mock, enableWrites }) {
   const label = enableWrites ? 'writes enabled' : 'read-only';
@@ -502,6 +551,15 @@ async function runMode({ mock, enableWrites }) {
   check('light user hits the callback error path', lightFlow.stopped === 'callback' && lightFlow.status === 403, `status ${lightFlow.status}`);
   check('light-user page explains a full seat is required', /seat|Light User|full Help Scout/i.test(lightFlow.body || ''));
 
+  // [8b] the test-only policy route must NOT exist without the opt-in var
+  console.log('[8b] test policy route is absent by default');
+  const noRoute = await fetch(`${BASE}/__test__/policy`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ op: 'getConfig' }),
+  });
+  check('test policy route 404s without HELPSCOUT_TEST_POLICY_ROUTES', noRoute.status === 404, `status ${noRoute.status}`);
+
   // [9] RFC 8707 resource binding on token exchange (soft)
   console.log('[9] resource-mismatch on token exchange (soft)');
   try {
@@ -533,9 +591,116 @@ async function runMode({ mock, enableWrites }) {
   }
 }
 
+// --- Policy engine (NAS-1501) -----------------------------------------------
+// Runs against its own worker: writes enabled at the deployment ceiling, and the
+// test-harness policy route mounted so the smoke can seed config/policy and drive
+// revokeUser. Distinct Help Scout user ids per sub-test keep the KV state clean.
+async function runPolicyMode({ mock }) {
+  console.log(`\n=== mode: policy engine (${BASE}) ===\n`);
+
+  const prm = await (await fetch(`${BASE}/.well-known/oauth-protected-resource`)).json().catch(() => ({}));
+  const resource = prm.resource;
+  const as = await (await fetch(`${BASE}/.well-known/oauth-authorization-server`)).json().catch(() => ({}));
+  const registerUrl = as.registration_endpoint || `${BASE}/register`;
+  const reg = await registerClient(registerUrl, 'Policy Smoke Client');
+  check('policy mode: DCR returned client_id', typeof reg.clientId === 'string', `status ${reg.status}`);
+  const clientId = reg.clientId;
+
+  const ping = await policyRoute({ op: 'getConfig' });
+  check('test policy route is mounted with the opt-in var set', ping.status === 200, `status ${ping.status}`);
+
+  // [P1] allowlist mode denies an unlisted user's callback with the friendly page
+  console.log('[P1] allowlist mode denies an unlisted user');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 1001 });
+  const cfg1 = await policyRoute({ op: 'putConfig', patch: { allowlistMode: true, policyCacheTtlSeconds: 15 }, expectedVersion: 0 });
+  check('allowlist config written (version 1)', cfg1.status === 200 && cfg1.body.config?.allowlistMode === true && cfg1.body.config?.version === 1, JSON.stringify(cfg1.body));
+  mock.state.userId = 1001;
+  const denied1 = await runFullFlow({ clientId, resource, mock });
+  check('allowlist mode denies the callback (403)', denied1.stopped === 'callback' && denied1.status === 403, `status ${denied1.status}`);
+  check('denied page says access not enabled / contact administrator', /not enabled|administrator/i.test(denied1.body || ''));
+
+  // [P2] explicit allowed:false denies in open mode (no config document)
+  console.log('[P2] explicit block denies in open mode');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 1002 });
+  const p2 = await policyRoute({ op: 'putUserPolicy', hsUserId: 1002, input: { allowed: false, writes: false, customerVisibleWrites: false }, expectedVersion: 0 });
+  check('explicit-block policy written', p2.status === 200 && p2.body.policy?.allowed === false, JSON.stringify(p2.body));
+  mock.state.userId = 1002;
+  const denied2 = await runFullFlow({ clientId, resource, mock });
+  check('explicit allowed:false denies the callback in open mode (403)', denied2.stopped === 'callback' && denied2.status === 403, `status ${denied2.status}`);
+
+  // [P3] per-user write permission: writes:false refused, writes:true succeeds
+  console.log('[P3] per-user write permission gating');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 1003 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: 1003, input: { allowed: true, writes: false, customerVisibleWrites: false }, expectedVersion: 0 });
+  mock.state.userId = 1003;
+  const flow3 = await runFullFlow({ clientId, resource, mock });
+  check('write-test user connects', typeof flow3.accessToken === 'string' && flow3.accessToken.length > 0);
+  const init3 = await mcpInitialize(flow3.accessToken);
+  check('write-test initialize is 200', init3.status === 200, `status ${init3.status}`);
+  const list3 = await toolsList(init3.headers);
+  check('write_help_scout advertised at the deployment ceiling', list3.tools.includes('write_help_scout'));
+  const noteArgs = { name: 'createNote', arguments: { conversationId: '123', text: 'policy smoke note' } };
+  const notesBefore = mock.state.noteWrites;
+  const denyWrite = await mcpCallTool(init3.headers, 'write_help_scout', noteArgs);
+  check('writes:false user is refused with a structured permission error', denyWrite.isError === true && denyWrite.structured?.code === 'PERMISSION_DENIED', JSON.stringify(denyWrite.structured));
+  check('the refused write never reached the mock upstream', mock.state.noteWrites === notesBefore, `noteWrites ${mock.state.noteWrites}`);
+  const cur3 = await policyRoute({ op: 'getUserPolicy', hsUserId: 1003 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: 1003, input: { allowed: true, writes: true, customerVisibleWrites: false }, expectedVersion: cur3.body.policy?.version ?? 0 });
+  const okWrite = await mcpCallTool(init3.headers, 'write_help_scout', noteArgs);
+  check('writes:true user succeeds against the mock upstream', okWrite.isError === false && okWrite.structured?.status === 'succeeded', JSON.stringify(okWrite.structured));
+  check('the successful write reached the mock upstream', mock.state.noteWrites === notesBefore + 1, `noteWrites ${mock.state.noteWrites}`);
+
+  // [P4] mid-session revocation honors the policy cache TTL as the SLA
+  console.log('[P4] mid-session revocation after the cache window');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 1004 });
+  await policyRoute({ op: 'putConfig', patch: { allowlistMode: false, policyCacheTtlSeconds: 15 }, expectedVersion: 0 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: 1004, input: { allowed: true, writes: false, customerVisibleWrites: false }, expectedVersion: 0 });
+  mock.state.userId = 1004;
+  const flow4 = await runFullFlow({ clientId, resource, mock });
+  const init4 = await mcpInitialize(flow4.accessToken);
+  const search1 = await mcpCallTool(init4.headers, 'search_help_scout', { query: 'conversations' });
+  check('allowed read succeeds and warms the policy cache', search1.isError === false && Array.isArray(search1.structured?.results), JSON.stringify(search1.structured));
+  const cur4 = await policyRoute({ op: 'getUserPolicy', hsUserId: 1004 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: 1004, input: { allowed: false, writes: false, customerVisibleWrites: false }, expectedVersion: cur4.body.policy?.version ?? 0 });
+  const searchWithin = await mcpCallTool(init4.headers, 'search_help_scout', { query: 'conversations' });
+  check('read still served from the unexpired cache immediately after revoke', searchWithin.isError === false, JSON.stringify(searchWithin.structured));
+  console.log('       waiting out the 15s policy cache TTL...');
+  await new Promise((r) => setTimeout(r, 17000));
+  const searchAfter = await mcpCallTool(init4.headers, 'search_help_scout', { query: 'conversations' });
+  check('read denied once the cache window lapses (revocation SLA)', searchAfter.isError === true && searchAfter.structured?.code === 'ACCESS_REVOKED', JSON.stringify(searchAfter.structured));
+
+  // [P5] revokeUser tears down grants and pins allowed:false
+  console.log('[P5] revokeUser revokes grants and blocks the user');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 1005 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: 1005, input: { allowed: true, writes: false, customerVisibleWrites: false }, expectedVersion: 0 });
+  mock.state.userId = 1005;
+  const flow5 = await runFullFlow({ clientId, resource, mock });
+  const init5 = await mcpInitialize(flow5.accessToken);
+  const list5 = await toolsList(init5.headers);
+  check('revoke-test session works before revoke', list5.status === 200 && list5.tools.includes('search_help_scout'));
+  const rev = await policyRoute({ op: 'revokeUser', hsUserId: 1005 });
+  check('revokeUser revoked at least one grant', rev.status === 200 && (rev.body.result?.grantsRevoked ?? 0) >= 1, JSON.stringify(rev.body));
+  check('revokeUser pinned the policy to allowed:false', rev.body.result?.policy?.allowed === false, JSON.stringify(rev.body.result?.policy));
+  const afterRevoke = await toolsList(init5.headers);
+  check('revoked grant makes the OUR token unauthorized at /mcp (401)', afterRevoke.status === 401, `status ${afterRevoke.status}`);
+
+  // [P6] optimistic concurrency: a stale putConfig is a 409 conflict
+  console.log('[P6] optimistic-concurrency conflict');
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'putConfig', patch: { allowlistMode: false }, expectedVersion: 0 });
+  const stale = await policyRoute({ op: 'putConfig', patch: { allowlistMode: true }, expectedVersion: 0 });
+  check('stale putConfig returns a 409 conflict', stale.status === 409 && stale.body.code === 'POLICY_CONFLICT', JSON.stringify(stale.body));
+}
+
 async function main() {
-  const only = process.env.SMOKE_MODE; // 'reads' | 'writes' | undefined (both)
-  const modes = only === 'reads' ? [false] : only === 'writes' ? [true] : [false, true];
+  const only = process.env.SMOKE_MODE; // 'reads' | 'writes' | 'policy' | undefined (all)
+  const modes = only === 'reads' ? [false] : only === 'writes' ? [true] : only === 'policy' ? [] : [false, true];
+  const runPolicy = only === undefined || only === 'policy';
 
   const mock = await startMockHelpScout();
   console.log(`mock Help Scout on ${mock.url}`);
@@ -548,6 +713,18 @@ async function main() {
         await runMode({ mock, enableWrites });
       } finally {
         await worker.close();
+      }
+    }
+
+    if (runPolicy) {
+      // Reset the mutable mock user id so the policy mode starts from a known id.
+      mock.state.userId = MOCK_USER.id;
+      const policyWorker = startWorker({ mockUrl: mock.url, enableWrites: true, testPolicyRoutes: true });
+      try {
+        await waitForReady(policyWorker.getLog);
+        await runPolicyMode({ mock });
+      } finally {
+        await policyWorker.close();
       }
     }
   } finally {

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -27,6 +27,8 @@ import {
   verifyConsentCookie,
   type ConsentTransaction,
 } from './oauth-cookie.js';
+import { evaluateAccess, getConfig, getUserPolicy } from './policy.js';
+import { handleTestPolicyRoute } from './test-policy-route.js';
 
 /** HTML-escape untrusted values before echoing them into a page. */
 function esc(value: unknown): string {
@@ -383,6 +385,40 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     email ||
     `Help Scout user ${userId}`;
 
+  // --- Access policy gate (NAS-1501). Runs after identity, before the grant. ---
+  // An explicit allowed:false blocks even in open mode; allowlist mode blocks any
+  // user without an explicit allowed:true entry. A KV failure fails closed: no
+  // grant is completed. The consent cookie is cleared like every terminal path.
+  let accessAllowed: boolean;
+  try {
+    const [config, userPolicy] = await Promise.all([
+      getConfig(env),
+      getUserPolicy(env, userId),
+    ]);
+    accessAllowed = evaluateAccess(config, userPolicy).allowed;
+  } catch {
+    return htmlResponse(
+      page(
+        'Authorize Help Scout',
+        'Access could not be verified',
+        '<p>This deployment could not verify whether your account is enabled right now. Try again in a moment. If this persists, contact the administrator of this deployment.</p>',
+      ),
+      503,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+  if (!accessAllowed) {
+    return htmlResponse(
+      page(
+        'Help Scout access not enabled',
+        'Access is not enabled for your account',
+        '<p>Your Help Scout account is not enabled to use this connection. Contact the administrator of this deployment to request access, then reconnect the connector.</p>',
+      ),
+      403,
+      { 'Set-Cookie': buildConsentClearCookie() },
+    );
+  }
+
   const { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
     request: txn.oauthReq,
     userId: String(userId),
@@ -404,6 +440,18 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
 export const helpScoutHandler: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+
+    // Test-harness-only policy-seeding route. Mounted ONLY when the deployment
+    // opts in via HELPSCOUT_TEST_POLICY_ROUTES (never in the template). The smoke
+    // suite uses it to seed config/policy and to exercise revokeUser; it asserts
+    // this route 404s when the var is unset, which is the default everywhere.
+    if (
+      env.HELPSCOUT_TEST_POLICY_ROUTES === 'true' &&
+      url.pathname === '/__test__/policy' &&
+      request.method === 'POST'
+    ) {
+      return handleTestPolicyRoute(request, env);
+    }
 
     // Refuse to run the consent flow with a missing signing key: an empty-key
     // HMAC would still "verify", silently weakening the confused-deputy

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -27,7 +27,8 @@ import {
   verifyConsentCookie,
   type ConsentTransaction,
 } from './oauth-cookie.js';
-import { evaluateAccess, getConfig, getUserPolicy } from './policy.js';
+import { evaluateAccess } from './policy.js';
+import { getConfig, getUserPolicy } from './policy-store.js';
 import { handleTestPolicyRoute } from './test-policy-route.js';
 
 /** HTML-escape untrusted values before echoing them into a page. */
@@ -387,8 +388,10 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
 
   // --- Access policy gate (NAS-1501). Runs after identity, before the grant. ---
   // An explicit allowed:false blocks even in open mode; allowlist mode blocks any
-  // user without an explicit allowed:true entry. A KV failure fails closed: no
-  // grant is completed. The consent cookie is cleared like every terminal path.
+  // user without an explicit allowed:true entry. The coordinator's reads are
+  // strongly consistent, so a user blocked moments earlier is denied here with no
+  // stale-colo admit. A coordinator failure fails closed: no grant is completed.
+  // The consent cookie is cleared like every terminal path.
   let accessAllowed: boolean;
   try {
     const [config, userPolicy] = await Promise.all([

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -60,10 +60,17 @@ function joinUrl(base: string, path: string): string {
 
 /**
  * Codes, client secrets, and fresh bearer tokens flow to these URLs, so they
- * must be https — the same invariant the fetch client enforces — with a
- * loopback exception so the smoke harness can stand in a mock upstream.
+ * must be https, the same invariant the fetch client enforces.
+ *
+ * `allowLoopback` opens a narrow exception for the smoke harness's http mock
+ * upstream, and ONLY the smoke turns it on: it is the deployment's test-mode
+ * signal (Boolean(HELPSCOUT_TEST_POLICY_ROUTES)), which production never sets.
+ * With it false, only https passes: a loopback http URL is rejected like any
+ * other non-https URL, so a production deployment cannot be pointed at http.
+ * The loopback allow-list is exact-match so `http://127.0.0.1.evil.com` (which
+ * merely starts with 127.0.0.1) is rejected.
  */
-function isSecureUpstreamUrl(value: string): boolean {
+function isSecureUpstreamUrl(value: string, allowLoopback: boolean): boolean {
   let url: URL;
   try {
     url = new URL(value);
@@ -71,6 +78,7 @@ function isSecureUpstreamUrl(value: string): boolean {
     return false;
   }
   if (url.protocol === 'https:') return true;
+  if (!allowLoopback) return false;
   return (
     url.protocol === 'http:' &&
     (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')
@@ -184,8 +192,9 @@ async function handleApprove(request: Request, env: Env): Promise<Response> {
   }
 
   // The browser is about to be sent to this URL; hold it to the same https
-  // bar as the other upstream endpoints (loopback excepted for the mock).
-  if (!isSecureUpstreamUrl(env.HELPSCOUT_AUTHORIZE_URL)) {
+  // bar as the other upstream endpoints (loopback tolerated only in test mode).
+  const allowLoopback = Boolean(env.HELPSCOUT_TEST_POLICY_ROUTES);
+  if (!isSecureUpstreamUrl(env.HELPSCOUT_AUTHORIZE_URL, allowLoopback)) {
     return htmlResponse(
       page('Authorize Help Scout', 'Deployment misconfigured', '<p>This server is configured with a non-https Help Scout URL. Ask whoever operates it to fix HELPSCOUT_AUTHORIZE_URL.</p>'),
       500,
@@ -273,8 +282,12 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
   }
 
   // Refuse to send the code, client secret, or a fresh bearer token anywhere
-  // that is not https (loopback excepted for the mock-upstream harness).
-  if (!isSecureUpstreamUrl(env.HELPSCOUT_TOKEN_URL) || !isSecureUpstreamUrl(env.HELPSCOUT_BASE_URL)) {
+  // that is not https (loopback tolerated only in test mode for the mock).
+  const allowLoopback = Boolean(env.HELPSCOUT_TEST_POLICY_ROUTES);
+  if (
+    !isSecureUpstreamUrl(env.HELPSCOUT_TOKEN_URL, allowLoopback) ||
+    !isSecureUpstreamUrl(env.HELPSCOUT_BASE_URL, allowLoopback)
+  ) {
     return htmlResponse(
       page('Authorize Help Scout', 'Deployment misconfigured', '<p>This server is configured with a non-https Help Scout URL. Ask whoever operates it to fix HELPSCOUT_TOKEN_URL / HELPSCOUT_BASE_URL.</p>'),
       500,
@@ -444,12 +457,20 @@ export const helpScoutHandler: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    // Test-harness-only policy-seeding route. Mounted ONLY when the deployment
-    // opts in via HELPSCOUT_TEST_POLICY_ROUTES (never in the template). The smoke
-    // suite uses it to seed config/policy and to exercise revokeUser; it asserts
-    // this route 404s when the var is unset, which is the default everywhere.
+    // Test-harness-only policy-seeding route. This can read and rewrite the whole
+    // access-policy store with no OAuth, so it is gated by a SECRET, not a boolean:
+    // HELPSCOUT_TEST_POLICY_ROUTES holds a random per-run key, and the request must
+    // present that exact key in X-Test-Policy-Key. When the var is unset/empty, or
+    // the header is missing or wrong, the route is completely invisible: it falls
+    // through to the 404 below, never revealing that it exists (no 403). Production
+    // never sets the var, so the route can never be reached there even if a caller
+    // guesses the path. The smoke seeds config/policy and drives revokeUser through
+    // it, and asserts a missing/wrong key 404s.
+    const testPolicyKey = env.HELPSCOUT_TEST_POLICY_ROUTES;
     if (
-      env.HELPSCOUT_TEST_POLICY_ROUTES === 'true' &&
+      typeof testPolicyKey === 'string' &&
+      testPolicyKey.length > 0 &&
+      request.headers.get('X-Test-Policy-Key') === testPolicyKey &&
       url.pathname === '/__test__/policy' &&
       request.method === 'POST'
     ) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -18,12 +18,15 @@
 import { OAuthProvider } from '@cloudflare/workers-oauth-provider';
 
 import { HelpScoutMCP } from './mcp-agent.js';
+import { PolicyCoordinator } from './policy-coordinator.js';
 import { helpScoutHandler } from './help-scout-handler.js';
 import { helpScoutTokenExchangeCallback } from './helpscout-oauth.js';
 import type { Env } from './mcp-agent.js';
 
-// The Durable Object class must be exported for the wrangler migration binding.
-export { HelpScoutMCP };
+// Both Durable Object classes must be exported for their wrangler migration
+// bindings: HelpScoutMCP (v1, the per-session MCP agent) and PolicyCoordinator
+// (v2, the single per-deployment access-policy owner, NAS-1501).
+export { HelpScoutMCP, PolicyCoordinator };
 
 export default new OAuthProvider<Env>({
   // The protected MCP endpoint. Unauthenticated requests get 401 +

--- a/worker/src/mcp-agent.ts
+++ b/worker/src/mcp-agent.ts
@@ -19,18 +19,30 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  type CallToolRequest,
+  type CallToolResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
 
-import { GatewayHandler } from '../../src/tools/gateway.js';
+import { GatewayHandler, WRITE_TOOL_NAME } from '../../src/tools/gateway.js';
 import { toolHandler } from '../../src/tools/index.js';
 import { writeHandler } from '../../src/tools/writes.js';
 import { withHelpScoutApi } from '../../src/utils/api.js';
+import { logger } from '../../src/utils/logger.js';
 import {
   HelpScoutFetchClient,
   RefreshMutex,
   type UserTokenContext,
 } from '../../src/worker/helpscout-fetch-client.js';
+import {
+  effectiveWriteFlags,
+  evaluateAccess,
+  getConfig,
+  getUserPolicy,
+  type AdminConfig,
+  type UserPolicy,
+  type WriteFlagSet,
+} from './policy.js';
 
 /** Kept in step with the stdio server identity in `src/index.ts`. */
 const SERVER_NAME = 'helpscout-search';
@@ -71,6 +83,12 @@ export interface Env {
   HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES?: string;
   COOKIE_ENCRYPTION_KEY?: string;
   /**
+   * Test-harness only. When "true", the consent handler mounts an internal
+   * policy-seeding route used by the smoke suite. Never set in the deployment
+   * template; the smoke asserts the route 404s without it.
+   */
+  HELPSCOUT_TEST_POLICY_ROUTES?: string;
+  /**
    * Optional. Docs API operations are part of the shared registry and stay
    * advertised; without this secret they fail at call time with a
    * credentials-missing error. The Docs client reads it from process.env
@@ -78,6 +96,51 @@ export interface Env {
    * is for documentation and wrangler type generation.
    */
   HELPSCOUT_DOCS_API_KEY?: string;
+}
+
+/** A structured tool error result, matching the gateway's error envelope shape. */
+function policyErrorResult(payload: Record<string, unknown>): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload,
+    isError: true,
+  };
+}
+
+/** Access is denied (revoked, or not enabled under allowlist mode). */
+function accessRevokedResult(): CallToolResult {
+  return policyErrorResult({
+    error: 'Your access to this Help Scout deployment is not enabled or was revoked.',
+    code: 'ACCESS_REVOKED',
+    hint: 'Disconnect the Help Scout connector. If you believe this is a mistake, contact the administrator of this deployment.',
+  });
+}
+
+/** The deployment allows writes, but this user's policy withholds them. */
+function writePermissionDeniedResult(): CallToolResult {
+  return policyErrorResult({
+    error: 'Your Help Scout access here does not include write operations. Nothing was sent to Help Scout.',
+    code: 'PERMISSION_DENIED',
+    hint: 'Write access is granted per user by the administrator of this deployment. Contact them to enable it for your account.',
+  });
+}
+
+/** A write could not verify policy against KV: fail closed without attempting the write. */
+function policyUnavailableWriteResult(): CallToolResult {
+  return policyErrorResult({
+    error: 'Your access could not be verified right now, so this write was not attempted.',
+    code: 'UPSTREAM_ERROR',
+    hint: 'This is a temporary problem reaching the deployment policy store. Try again in a moment.',
+  });
+}
+
+/** A read could not verify policy against KV and no unexpired snapshot was available. */
+function policyUnavailableReadResult(): CallToolResult {
+  return policyErrorResult({
+    error: 'Your access could not be verified right now.',
+    code: 'TEMPORARY_ERROR',
+    hint: 'This is a temporary problem reaching the deployment policy store. Try again in a moment.',
+  });
 }
 
 export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
@@ -99,6 +162,18 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
   private readonly refreshMutex = new RefreshMutex();
 
   private gateway!: GatewayHandler;
+
+  /**
+   * Instance-scoped snapshot of the access policy for this session's user.
+   *
+   * Reads are served from this snapshot while it is unexpired, so a read call
+   * costs no KV round trip inside the window — and that window IS the revocation
+   * SLA: after allowed flips to false, reads keep working only until the
+   * snapshot lapses, then the next read re-reads KV and is denied. The TTL comes
+   * from the config document (clamped 15-300s). Writes never read this snapshot;
+   * they always re-read policy fresh (see dispatchWrite).
+   */
+  private policySnapshot?: { config: AdminConfig; userPolicy: UserPolicy | null; expiresAtMs: number };
 
   async init(): Promise<void> {
     // Build the server with instructions that name the connected user, read
@@ -127,13 +202,130 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
       tools: await this.gateway.listTools(),
     }));
 
-    // Every dispatch constructs this user's client and runs the whole async
-    // call tree under it via AsyncLocalStorage, so the 40+ getClient() call
-    // sites resolve to the per-user, fetch-backed client with no shared state.
+    // Every dispatch runs through the policy gate, then constructs this user's
+    // client and runs the whole async call tree under it via AsyncLocalStorage,
+    // so the 40+ getClient() call sites resolve to the per-user, fetch-backed
+    // client with no shared state.
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      return this.dispatchToolCall(request);
+    });
+  }
+
+  /**
+   * The policy-enforced dispatch path for every tools/call.
+   *
+   * Access is checked on every call. A write additionally re-reads the policy
+   * fresh (bypassing the read cache) and dispatches through a gateway configured
+   * with the user's effective write flags, so a per-user write grant is enforced
+   * at execution even though advertisement (tools/list) stays ceiling-only.
+   */
+  private async dispatchToolCall(request: CallToolRequest): Promise<CallToolResult> {
+    const isWrite = request.params.name === WRITE_TOOL_NAME;
+
+    const gate = await this.checkAccess(isWrite);
+    if (!gate.ok) return gate.result;
+
+    if (isWrite) {
+      return this.dispatchWrite(request, gate.userPolicy);
+    }
+
+    const client = this.buildClient();
+    return withHelpScoutApi(client, () => this.gateway.callTool(request));
+  }
+
+  /**
+   * Resolve the access decision for this call. Reads may serve from an unexpired
+   * policy snapshot without touching KV; writes force a fresh read. On a KV
+   * failure the gate fails closed: a write returns an upstream-error result and
+   * a read returns a temporary-error result (an unexpired snapshot would already
+   * have been served above, so reaching the KV read means there was nothing safe
+   * to serve).
+   */
+  private async checkAccess(
+    forceFresh: boolean,
+  ): Promise<
+    | { ok: true; config: AdminConfig; userPolicy: UserPolicy | null }
+    | { ok: false; result: CallToolResult }
+  > {
+    const userId = String(this.requireProps().userId);
+    const now = Date.now();
+
+    if (!forceFresh && this.policySnapshot && now < this.policySnapshot.expiresAtMs) {
+      return this.decideAccess(this.policySnapshot.config, this.policySnapshot.userPolicy);
+    }
+
+    let config: AdminConfig;
+    let userPolicy: UserPolicy | null;
+    try {
+      config = await getConfig(this.env);
+      userPolicy = await getUserPolicy(this.env, userId);
+    } catch (error) {
+      logger.error('Policy read failed at dispatch', {
+        error: error instanceof Error ? error.message : String(error),
+        forceFresh,
+      });
+      return {
+        ok: false,
+        result: forceFresh ? policyUnavailableWriteResult() : policyUnavailableReadResult(),
+      };
+    }
+
+    this.policySnapshot = {
+      config,
+      userPolicy,
+      expiresAtMs: now + config.policyCacheTtlSeconds * 1000,
+    };
+    return this.decideAccess(config, userPolicy);
+  }
+
+  private decideAccess(
+    config: AdminConfig,
+    userPolicy: UserPolicy | null,
+  ):
+    | { ok: true; config: AdminConfig; userPolicy: UserPolicy | null }
+    | { ok: false; result: CallToolResult } {
+    const decision = evaluateAccess(config, userPolicy);
+    if (!decision.allowed) {
+      return { ok: false, result: accessRevokedResult() };
+    }
+    return { ok: true, config, userPolicy };
+  }
+
+  /**
+   * Execute a write under the caller's effective write flags. `userPolicy` is
+   * the freshly-read policy from checkAccess (writes never use the cache).
+   *
+   * When the deployment ceiling has writes off, behavior is identical to before
+   * the policy layer: write_help_scout is not advertised, and a direct call
+   * falls through to the gateway's unknown-tool path. When the deployment allows
+   * writes but this user's policy withholds them, a structured permission error
+   * is returned before any Help Scout request. Otherwise the write runs through a
+   * gateway configured with the effective flags, which enforces the
+   * customer-visible narrowing and the existing confirmation envelope.
+   */
+  private async dispatchWrite(request: CallToolRequest, userPolicy: UserPolicy | null): Promise<CallToolResult> {
+    const ceiling: WriteFlagSet = {
+      enabled: this.env.HELPSCOUT_ENABLE_WRITES === 'true',
+      customerVisibleEnabled: this.env.HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES === 'true',
+    };
+    const effective = effectiveWriteFlags(ceiling, userPolicy);
+
+    if (!ceiling.enabled) {
       const client = this.buildClient();
       return withHelpScoutApi(client, () => this.gateway.callTool(request));
+    }
+
+    if (!effective.enabled) {
+      logger.warn('Write refused: user policy withholds write access', { userId: String(this.requireProps().userId) });
+      return writePermissionDeniedResult();
+    }
+
+    const gateway = new GatewayHandler(toolHandler, {
+      writes: writeHandler,
+      writeFlags: effective,
     });
+    const client = this.buildClient();
+    return withHelpScoutApi(client, () => gateway.callTool(request));
   }
 
   /**

--- a/worker/src/mcp-agent.ts
+++ b/worker/src/mcp-agent.ts
@@ -37,12 +37,11 @@ import {
 import {
   effectiveWriteFlags,
   evaluateAccess,
-  getConfig,
-  getUserPolicy,
   type AdminConfig,
   type UserPolicy,
   type WriteFlagSet,
 } from './policy.js';
+import { getConfig, getUserPolicy } from './policy-store.js';
 
 /** Kept in step with the stdio server identity in `src/index.ts`. */
 const SERVER_NAME = 'helpscout-search';
@@ -73,6 +72,12 @@ export interface HelpScoutProps extends Record<string, unknown> {
 export interface Env {
   OAUTH_KV: KVNamespace;
   MCP_OBJECT: DurableObjectNamespace;
+  /**
+   * The per-deployment access-policy coordinator DO (NAS-1501). Bound by name
+   * POLICY_OBJECT in wrangler.jsonc; every policy read/write RPCs the single
+   * instance so reads are strongly consistent and version writes are atomic CAS.
+   */
+  POLICY_OBJECT: DurableObjectNamespace;
   OAUTH_PROVIDER: OAuthHelpers;
   HELPSCOUT_BASE_URL: string;
   HELPSCOUT_TOKEN_URL: string;
@@ -125,7 +130,7 @@ function writePermissionDeniedResult(): CallToolResult {
   });
 }
 
-/** A write could not verify policy against KV: fail closed without attempting the write. */
+/** A write could not verify policy against the coordinator: fail closed without attempting the write. */
 function policyUnavailableWriteResult(): CallToolResult {
   return policyErrorResult({
     error: 'Your access could not be verified right now, so this write was not attempted.',
@@ -134,7 +139,7 @@ function policyUnavailableWriteResult(): CallToolResult {
   });
 }
 
-/** A read could not verify policy against KV and no unexpired snapshot was available. */
+/** A read could not verify policy against the coordinator and no unexpired snapshot was available. */
 function policyUnavailableReadResult(): CallToolResult {
   return policyErrorResult({
     error: 'Your access could not be verified right now.',
@@ -167,13 +172,15 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
    * Instance-scoped snapshot of the access policy for this session's user.
    *
    * Reads are served from this snapshot while it is unexpired, so a read call
-   * costs no KV round trip inside the window — and that window IS the revocation
-   * SLA: after allowed flips to false, reads keep working only until the
-   * snapshot lapses, then the next read re-reads KV and is denied. The TTL comes
-   * from the config document (clamped 15-300s). Writes never read this snapshot;
-   * they always re-read policy fresh (see dispatchWrite).
+   * costs no coordinator round trip inside the window — and that window IS the
+   * revocation SLA: after allowed flips to false, reads keep working only until
+   * the snapshot lapses, then the next read re-reads the coordinator and is
+   * denied. Because the coordinator's reads are strongly consistent, that
+   * re-read sees the deny with no eventual-consistency lag on top of the TTL. The
+   * TTL comes from the config document (clamped 15-300s). Writes never read this
+   * snapshot; they always re-read policy fresh (see dispatchWrite).
    */
-  private policySnapshot?: { config: AdminConfig; userPolicy: UserPolicy | null; expiresAtMs: number };
+  private policySnapshot?: { userId: string; config: AdminConfig; userPolicy: UserPolicy | null; expiresAtMs: number };
 
   async init(): Promise<void> {
     // Build the server with instructions that name the connected user, read
@@ -235,11 +242,11 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
 
   /**
    * Resolve the access decision for this call. Reads may serve from an unexpired
-   * policy snapshot without touching KV; writes force a fresh read. On a KV
-   * failure the gate fails closed: a write returns an upstream-error result and
-   * a read returns a temporary-error result (an unexpired snapshot would already
-   * have been served above, so reaching the KV read means there was nothing safe
-   * to serve).
+   * policy snapshot without touching the coordinator; writes force a fresh read.
+   * On a coordinator failure the gate fails closed: a write returns an
+   * upstream-error result and a read returns a temporary-error result (an
+   * unexpired snapshot would already have been served above, so reaching the
+   * coordinator read means there was nothing safe to serve).
    */
   private async checkAccess(
     forceFresh: boolean,
@@ -250,7 +257,16 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
     const userId = String(this.requireProps().userId);
     const now = Date.now();
 
-    if (!forceFresh && this.policySnapshot && now < this.policySnapshot.expiresAtMs) {
+    // The snapshot is only valid for the user it was read for. Sessions are
+    // per-grant today, but if any routing change ever let a different grant's
+    // props reach this instance, an identity mismatch must force a fresh read
+    // rather than inherit another user's cached access decision.
+    if (
+      !forceFresh &&
+      this.policySnapshot &&
+      this.policySnapshot.userId === userId &&
+      now < this.policySnapshot.expiresAtMs
+    ) {
       return this.decideAccess(this.policySnapshot.config, this.policySnapshot.userPolicy);
     }
 
@@ -271,6 +287,7 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
     }
 
     this.policySnapshot = {
+      userId,
       config,
       userPolicy,
       expiresAtMs: now + config.policyCacheTtlSeconds * 1000,
@@ -337,7 +354,12 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
     const base = 'Help Scout MCP gateway. Search, describe, and read (and, when enabled, write) Help Scout data.';
     const props = this.props;
     if (!props || !props.email) return base;
-    return `${base} Connected to Help Scout as ${props.name} <${props.email}>.`;
+    // The name and email come from the Help Scout profile, which other account
+    // admins can edit: flatten and cap them so profile text cannot smuggle
+    // multi-line content into the server instructions the model reads.
+    const name = String(props.name).replace(/[\r\n\t]+/g, ' ').slice(0, 80);
+    const email = String(props.email).replace(/[\s]+/g, '').slice(0, 120);
+    return `${base} Connected to Help Scout as ${name} <${email}>.`;
   }
 
   /** The grant props must be present on an authorized request; guard for TS and clarity. */

--- a/worker/src/mcp-agent.ts
+++ b/worker/src/mcp-agent.ts
@@ -88,9 +88,13 @@ export interface Env {
   HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES?: string;
   COOKIE_ENCRYPTION_KEY?: string;
   /**
-   * Test-harness only. When "true", the consent handler mounts an internal
-   * policy-seeding route used by the smoke suite. Never set in the deployment
-   * template; the smoke asserts the route 404s without it.
+   * Test-harness only, and its VALUE is a secret. When set to a non-empty string,
+   * it (a) marks the deployment as test-mode, which is the ONLY thing that lets
+   * the consent handler and fetch client tolerate an http loopback upstream, and
+   * (b) mounts the internal policy-seeding route the smoke suite uses, but only
+   * for a request that presents this exact value in the X-Test-Policy-Key header.
+   * Never set in a real deployment: it both weakens the https guard and exposes an
+   * unauthenticated policy-mutation surface to anyone who knows the key.
    */
   HELPSCOUT_TEST_POLICY_ROUTES?: string;
   /**
@@ -378,6 +382,9 @@ export class HelpScoutMCP extends McpAgent<Env, unknown, HelpScoutProps> {
       tokenUrl: this.env.HELPSCOUT_TOKEN_URL,
       clientId: this.env.HELPSCOUT_CLIENT_ID,
       clientSecret: this.env.HELPSCOUT_CLIENT_SECRET,
+      // Strict https unless the deployment is in test mode (the smoke's http
+      // loopback mock). Production never sets the var, so this stays false.
+      allowInsecureLoopback: Boolean(this.env.HELPSCOUT_TEST_POLICY_ROUTES),
       // Read tokens fresh each request so a mid-request rotation is seen next time.
       getTokens: (): UserTokenContext => {
         const props = this.requireProps();

--- a/worker/src/policy-coordinator.ts
+++ b/worker/src/policy-coordinator.ts
@@ -1,0 +1,117 @@
+/**
+ * The per-deployment access-policy coordinator (NAS-1501), a Durable Object that
+ * OWNS the policy documents in its own transactional storage.
+ *
+ * Every worker request resolves this DO by the fixed name POLICY_COORDINATOR_NAME
+ * (env.POLICY_OBJECT.idFromName), so the whole deployment funnels through the ONE
+ * instance. A Durable Object is single-threaded and input-gated: while a request
+ * is awaiting a storage operation no other event is delivered to the instance, so
+ * a read-modify-write that only awaits storage between its read and its write is
+ * atomic with respect to every other request. That is what upgrades the two
+ * defects the KV store had:
+ *   1. Reads are strongly consistent — a /callback right after a revoke sees the
+ *      deny, with no eventually-consistent colo lag.
+ *   2. The version check-and-increment is an atomic compare-and-swap — two admins
+ *      presenting the same expectedVersion cannot both succeed; the second reads
+ *      the first's write and gets a conflict. No lost update.
+ *
+ * The transactional CAS logic itself lives in policy.ts over the PolicyStorage
+ * interface (so it is unit-testable against an in-memory fake). This class is the
+ * thin adapter that (a) binds that interface to ctx.storage and (b) flattens the
+ * typed policy errors into transport envelopes, because a thrown custom Error
+ * does not keep its class across the RPC boundary.
+ *
+ * Cloudflare storage notes relied on (developers.cloudflare.com, Durable Objects
+ * Storage API): storage.get(key) returns the stored value or `undefined` when the
+ * key does not exist; ctx.storage.transaction(closure) runs its body atomically,
+ * and on the SQLite-backed engine any operations performed directly on
+ * ctx.storage inside the closure are part of that transaction (the passed `txn`
+ * object is obsolete there). Cloudflare recommends all new Durable Object
+ * namespaces use the SQLite storage backend, which this class does
+ * (new_sqlite_classes, migration v2 in wrangler.jsonc), matching HelpScoutMCP.
+ */
+import { DurableObject } from 'cloudflare:workers';
+
+import {
+  clearConfigDoc,
+  clearUserPolicyDoc,
+  pinUserPolicyRevoked,
+  readConfigDoc,
+  readUserPolicyDoc,
+  toPolicyErrorEnvelope,
+  writeConfigDoc,
+  writeUserPolicyDoc,
+  type ConfigDocResult,
+  type ConfigPatch,
+  type MutationMeta,
+  type PolicyErrorEnvelope,
+  type PolicyStorage,
+  type UserPolicyDocResult,
+  type UserPolicyInput,
+  type UserPolicyWriteResult,
+} from './policy.js';
+
+export class PolicyCoordinator extends DurableObject {
+  /**
+   * The PolicyStorage the CAS core runs over, bound to this instance's storage.
+   * `transaction` delegates to ctx.storage.transaction and the closure reads and
+   * writes through the same adapter (i.e. directly on ctx.storage), which the
+   * SQLite engine counts as part of the transaction. Even absent the explicit
+   * transaction, the closure only awaits storage between its read and write, so
+   * the input gate already serializes concurrent requests; the transaction makes
+   * the atomic-commit guarantee explicit and survives a future edit.
+   */
+  private readonly store: PolicyStorage = {
+    get: <T>(key: string): Promise<T | undefined> => this.ctx.storage.get<T>(key),
+    put: (key: string, value: unknown): Promise<void> => this.ctx.storage.put(key, value),
+    delete: async (key: string): Promise<void> => {
+      await this.ctx.storage.delete(key);
+    },
+    transaction: <T>(closure: () => Promise<T>): Promise<T> => this.ctx.storage.transaction(() => closure()),
+  };
+
+  async getConfigDoc(): Promise<ConfigDocResult> {
+    return this.envelope(() => readConfigDoc(this.store));
+  }
+
+  async putConfigDoc(patch: ConfigPatch, meta: MutationMeta): Promise<ConfigDocResult> {
+    return this.envelope(() => writeConfigDoc(this.store, patch, meta));
+  }
+
+  async deleteConfigDoc(): Promise<void> {
+    await clearConfigDoc(this.store);
+  }
+
+  async getUserPolicyDoc(hsUserId: string): Promise<UserPolicyDocResult> {
+    return this.envelope(() => readUserPolicyDoc(this.store, hsUserId));
+  }
+
+  async putUserPolicyDoc(hsUserId: string, input: UserPolicyInput, meta: MutationMeta): Promise<UserPolicyWriteResult> {
+    return this.envelope(() => writeUserPolicyDoc(this.store, hsUserId, input, meta));
+  }
+
+  async deleteUserPolicyDoc(hsUserId: string): Promise<void> {
+    await clearUserPolicyDoc(this.store, hsUserId);
+  }
+
+  async pinRevokedUser(hsUserId: string, updatedBy: string): Promise<UserPolicyWriteResult> {
+    return this.envelope(() => pinUserPolicyRevoked(this.store, hsUserId, updatedBy));
+  }
+
+  /**
+   * Run a core op and flatten a known policy error into a transport envelope.
+   * An unexpected error (a storage failure) is re-thrown so it crosses the RPC
+   * boundary as a rejection and the worker-side caller fails closed.
+   */
+  private async envelope<T>(
+    op: () => Promise<T>,
+  ): Promise<{ ok: true; value: T } | { ok: false; error: PolicyErrorEnvelope }> {
+    try {
+      return { ok: true, value: await op() };
+    } catch (error) {
+      const envelope = toPolicyErrorEnvelope(error);
+      if (envelope) return { ok: false, error: envelope };
+      throw error;
+    }
+  }
+}

--- a/worker/src/policy-store.ts
+++ b/worker/src/policy-store.ts
@@ -1,0 +1,169 @@
+/**
+ * The env-facing entry points to the access-policy engine (NAS-1501).
+ *
+ * These are the functions the /callback gate (help-scout-handler.ts), the
+ * McpAgent dispatch gate (mcp-agent.ts), and the test-seeding route
+ * (test-policy-route.ts) call. They keep the exact signatures the KV-backed
+ * versions had, so callers changed only their import path; internally each now
+ * RPCs the ONE coordinator Durable Object (policy-coordinator.ts), which owns the
+ * documents in strongly-consistent, transactional storage.
+ *
+ * This module, not policy.ts, is where the Workers runtime types live
+ * (DurableObjectNamespace, OAuthHelpers): policy.ts stays runtime-type-free so
+ * the root unit suite can type-check and drive its CAS core directly.
+ *
+ * Error handling: the coordinator returns a discriminated envelope rather than
+ * throwing across RPC (a thrown custom Error loses its class over the boundary),
+ * so a policy conflict / invalid-document surfaces here as the reconstructed
+ * PolicyConflictError / PolicyInvalidError — the same types callers already
+ * catch. An unexpected storage failure rejects the RPC and propagates as a
+ * generic error, which the read/write gates treat as fail-closed.
+ *
+ * The audit hook stays here, fired after the coordinator confirms a write: a
+ * real sink is worker infrastructure, and a function cannot cross the RPC seam.
+ */
+import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+
+import {
+  POLICY_COORDINATOR_NAME,
+  throwPolicyError,
+  type AdminConfig,
+  type ConfigDocResult,
+  type ConfigPatch,
+  type MutationMeta,
+  type MutationOptions,
+  type PolicyAuditHook,
+  type RevokeUserResult,
+  type UserPolicy,
+  type UserPolicyDocResult,
+  type UserPolicyInput,
+  type UserPolicyWriteResult,
+} from './policy.js';
+
+/** The coordinator's RPC surface, as seen through its Durable Object stub. */
+interface PolicyCoordinatorStub {
+  getConfigDoc(): Promise<ConfigDocResult>;
+  putConfigDoc(patch: ConfigPatch, meta: MutationMeta): Promise<ConfigDocResult>;
+  deleteConfigDoc(): Promise<void>;
+  getUserPolicyDoc(hsUserId: string): Promise<UserPolicyDocResult>;
+  putUserPolicyDoc(hsUserId: string, input: UserPolicyInput, meta: MutationMeta): Promise<UserPolicyWriteResult>;
+  deleteUserPolicyDoc(hsUserId: string): Promise<void>;
+  pinRevokedUser(hsUserId: string, updatedBy: string): Promise<UserPolicyWriteResult>;
+}
+
+/** The subset of the worker env the read/write policy functions need. */
+export interface PolicyStoreEnv {
+  POLICY_OBJECT: DurableObjectNamespace;
+}
+
+/** revokeUser additionally needs the provider helpers to list and revoke grants. */
+export interface PolicyRevokeEnv extends PolicyStoreEnv {
+  OAUTH_PROVIDER: OAuthHelpers;
+}
+
+/** Resolve the single coordinator instance by its fixed name. */
+function coordinator(env: PolicyStoreEnv): PolicyCoordinatorStub {
+  const namespace = env.POLICY_OBJECT;
+  const id = namespace.idFromName(POLICY_COORDINATOR_NAME);
+  return namespace.get(id) as unknown as PolicyCoordinatorStub;
+}
+
+/**
+ * Read the deployment config. A missing document is open-mode defaults; a stored
+ * document this build cannot interpret throws PolicyInvalidError (fail closed).
+ */
+export async function getConfig(env: PolicyStoreEnv): Promise<AdminConfig> {
+  const result = await coordinator(env).getConfigDoc();
+  if (!result.ok) throwPolicyError(result.error);
+  return result.value;
+}
+
+/**
+ * Write the deployment config with an atomic version check-and-increment. A
+ * stale expectedVersion throws PolicyConflictError and writes nothing.
+ */
+export async function putConfig(env: PolicyStoreEnv, patch: ConfigPatch, opts: MutationOptions): Promise<AdminConfig> {
+  const result = await coordinator(env).putConfigDoc(patch, {
+    expectedVersion: opts.expectedVersion,
+    updatedBy: opts.updatedBy,
+  });
+  if (!result.ok) throwPolicyError(result.error);
+  await opts.audit?.({ type: 'config.updated', version: result.value.version, updatedBy: opts.updatedBy, config: result.value });
+  return result.value;
+}
+
+/** Delete the config document (harness/admin seam). Absence reads as open-mode defaults. */
+export async function deleteConfig(env: PolicyStoreEnv): Promise<void> {
+  await coordinator(env).deleteConfigDoc();
+}
+
+/** Read one user's policy, or null when the user has no explicit entry. */
+export async function getUserPolicy(env: PolicyStoreEnv, hsUserId: string | number): Promise<UserPolicy | null> {
+  const result = await coordinator(env).getUserPolicyDoc(String(hsUserId));
+  if (!result.ok) throwPolicyError(result.error);
+  return result.value;
+}
+
+/**
+ * Write one user's policy with an atomic version check-and-increment, enforcing
+ * the customerVisibleWrites => writes invariant. A stale expectedVersion throws
+ * PolicyConflictError.
+ */
+export async function putUserPolicy(
+  env: PolicyStoreEnv,
+  hsUserId: string | number,
+  input: UserPolicyInput,
+  opts: MutationOptions,
+): Promise<UserPolicy> {
+  const id = String(hsUserId);
+  const result = await coordinator(env).putUserPolicyDoc(id, input, {
+    expectedVersion: opts.expectedVersion,
+    updatedBy: opts.updatedBy,
+  });
+  if (!result.ok) throwPolicyError(result.error);
+  await opts.audit?.({ type: 'user.policy.updated', hsUserId: id, version: result.value.version, updatedBy: opts.updatedBy, policy: result.value });
+  return result.value;
+}
+
+/** Delete one user's policy document (harness/admin seam). */
+export async function deleteUserPolicy(env: PolicyStoreEnv, hsUserId: string | number): Promise<void> {
+  await coordinator(env).deleteUserPolicyDoc(String(hsUserId));
+}
+
+/**
+ * Hard-revoke a user: revoke every OAuth grant the provider holds for them, then
+ * pin their policy to allowed:false through the coordinator's atomic put. Listing
+ * is paged in case a user holds many grants.
+ *
+ * The two effects are complementary: revoking grants invalidates every live
+ * access token immediately (the next /mcp request fails auth at the library
+ * layer), and allowed:false denies any re-connection attempt and any session
+ * that is serving reads from an unexpired policy cache once that cache lapses.
+ * The pin runs inside the DO in one transaction and carries no expectedVersion,
+ * so a racing admin edit cannot re-open the account: the revoke is authoritative.
+ */
+export async function revokeUser(
+  env: PolicyRevokeEnv,
+  hsUserId: string | number,
+  opts: { updatedBy: string; audit?: PolicyAuditHook },
+): Promise<RevokeUserResult> {
+  const id = String(hsUserId);
+
+  let grantsRevoked = 0;
+  let cursor: string | undefined;
+  do {
+    const page = await env.OAUTH_PROVIDER.listUserGrants(id, cursor ? { cursor } : undefined);
+    for (const grant of page.items) {
+      await env.OAUTH_PROVIDER.revokeGrant(grant.id, id);
+      grantsRevoked += 1;
+    }
+    cursor = page.cursor;
+  } while (cursor);
+
+  const result = await coordinator(env).pinRevokedUser(id, opts.updatedBy);
+  if (!result.ok) throwPolicyError(result.error);
+  const policy = result.value;
+
+  await opts.audit?.({ type: 'user.revoked', hsUserId: id, grantsRevoked, updatedBy: opts.updatedBy, policy });
+  return { hsUserId: id, grantsRevoked, policy };
+}

--- a/worker/src/policy-store.ts
+++ b/worker/src/policy-store.ts
@@ -64,6 +64,20 @@ export interface PolicyRevokeEnv extends PolicyStoreEnv {
 /** Resolve the single coordinator instance by its fixed name. */
 function coordinator(env: PolicyStoreEnv): PolicyCoordinatorStub {
   const namespace = env.POLICY_OBJECT;
+  // A deployment upgraded with an older wrangler.deploy.jsonc that predates the
+  // policy coordinator has no POLICY_OBJECT binding, so this is undefined. Left
+  // unchecked, `namespace.idFromName` throws a cryptic "cannot read properties of
+  // undefined", which every policy read/write turns into an opaque "access could
+  // not be verified" (the gates fail closed on any throw). Name the real cause
+  // instead so an operator knows exactly which config edit is missing.
+  if (!namespace) {
+    throw new Error(
+      'POLICY_OBJECT Durable Object binding is missing from this deployment\'s wrangler config. ' +
+        'This build\'s access-policy engine requires it. Add the POLICY_OBJECT binding and the v2 ' +
+        'migration to your wrangler.deploy.jsonc, then re-deploy. See the upgrade section of ' +
+        'guides/remote-self-host.md.',
+    );
+  }
   const id = namespace.idFromName(POLICY_COORDINATOR_NAME);
   return namespace.get(id) as unknown as PolicyCoordinatorStub;
 }
@@ -135,12 +149,17 @@ export async function deleteUserPolicy(env: PolicyStoreEnv, hsUserId: string | n
  * pin their policy to allowed:false through the coordinator's atomic put. Listing
  * is paged in case a user holds many grants.
  *
- * The two effects are complementary: revoking grants invalidates every live
- * access token immediately (the next /mcp request fails auth at the library
- * layer), and allowed:false denies any re-connection attempt and any session
- * that is serving reads from an unexpired policy cache once that cache lapses.
- * The pin runs inside the DO in one transaction and carries no expectedVersion,
- * so a racing admin edit cannot re-open the account: the revoke is authoritative.
+ * The two effects are complementary: allowed:false denies any re-connection
+ * attempt and any session serving reads from an unexpired policy cache once that
+ * cache lapses, and revoking grants invalidates every live access token
+ * immediately (the next /mcp request fails auth at the library layer). The pin
+ * runs inside the DO in one transaction and carries no expectedVersion, so a
+ * racing admin edit cannot re-open the account: the revoke is authoritative.
+ *
+ * The deny is pinned FIRST, before any grant is revoked, so a partial failure
+ * fails safe: if grant revocation errors midway, the user is already blocked
+ * from reconnecting and their live sessions lapse at the cache boundary, rather
+ * than being kicked out but left able to sign straight back in.
  */
 export async function revokeUser(
   env: PolicyRevokeEnv,
@@ -148,6 +167,10 @@ export async function revokeUser(
   opts: { updatedBy: string; audit?: PolicyAuditHook },
 ): Promise<RevokeUserResult> {
   const id = String(hsUserId);
+
+  const result = await coordinator(env).pinRevokedUser(id, opts.updatedBy);
+  if (!result.ok) throwPolicyError(result.error);
+  const policy = result.value;
 
   let grantsRevoked = 0;
   let cursor: string | undefined;
@@ -159,10 +182,6 @@ export async function revokeUser(
     }
     cursor = page.cursor;
   } while (cursor);
-
-  const result = await coordinator(env).pinRevokedUser(id, opts.updatedBy);
-  if (!result.ok) throwPolicyError(result.error);
-  const policy = result.value;
 
   await opts.audit?.({ type: 'user.revoked', hsUserId: id, grantsRevoked, updatedBy: opts.updatedBy, policy });
   return { hsUserId: id, grantsRevoked, policy };

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -1,0 +1,401 @@
+/**
+ * Self-hosted access-policy engine for the Help Scout remote MCP worker (NAS-1501).
+ *
+ * This module is the single source of truth for two questions the worker asks on
+ * the authorization boundary:
+ *   1. May this Help Scout user connect at all (the /callback gate)?
+ *   2. For an already-connected session, is the user still allowed, and which
+ *      write operations may they execute (the McpAgent dispatch gate)?
+ *
+ * It is pure over two dependencies: the existing OAUTH_KV namespace (namespaced
+ * away from the workers-oauth-provider library keys) and the provider's
+ * OAuthHelpers surface (for grant revocation). The mutation functions
+ * (putConfig, putUserPolicy, revokeUser) are the seams a future admin API
+ * (NAS-1503) calls, and each accepts an optional audit hook so an audit trail
+ * (NAS-1502) can be attached without touching call sites.
+ *
+ * KV layout (both documents live in OAUTH_KV):
+ *   admin:config:v1        one deployment-wide config document
+ *   policy:user:{hsUserId}  one document per Help Scout user id
+ *
+ * A missing admin:config document means all defaults (open mode): behavior is
+ * byte-identical to a deployment with no policy layer configured. A missing
+ * policy:user document means the user has no explicit entry (getUserPolicy
+ * returns null), which is allowed in open mode and denied under allowlist mode.
+ *
+ * `userId` consistency: completeAuthorization stores the grant userId as
+ * String(hsUserId) (help-scout-handler.ts), so this module keys policy documents
+ * and lists/revokes grants by the same String(hsUserId).
+ */
+import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+
+/** Current schema version of the admin config document. */
+export const POLICY_CONFIG_SCHEMA_VERSION = 1 as const;
+
+/** Current schema version of a per-user policy document. */
+export const POLICY_USER_SCHEMA_VERSION = 1 as const;
+
+/** The single admin config KV key. Exported so an admin API / harness can target it. */
+export const ADMIN_CONFIG_KEY = 'admin:config:v1';
+
+/** The KV key for one user's policy document. */
+export function userPolicyKey(hsUserId: string | number): string {
+  return `policy:user:${String(hsUserId)}`;
+}
+
+/** Default policy cache TTL, in seconds, when the config document is missing. */
+export const DEFAULT_POLICY_CACHE_TTL_SECONDS = 45;
+
+/** The TTL is clamped to this inclusive range on both read and write. */
+export const MIN_POLICY_CACHE_TTL_SECONDS = 15;
+export const MAX_POLICY_CACHE_TTL_SECONDS = 300;
+
+function clampTtl(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_POLICY_CACHE_TTL_SECONDS;
+  return Math.min(MAX_POLICY_CACHE_TTL_SECONDS, Math.max(MIN_POLICY_CACHE_TTL_SECONDS, Math.floor(value)));
+}
+
+/**
+ * The deployment-wide policy configuration.
+ *
+ * `version` is an optimistic-concurrency counter: 0 for a document that has
+ * never been written, incremented on every putConfig. `adminRole` is stored but
+ * not enforced in this ticket (the admin API in NAS-1503 will enforce it).
+ */
+export interface AdminConfig {
+  schemaVersion: typeof POLICY_CONFIG_SCHEMA_VERSION;
+  allowlistMode: boolean;
+  adminRole: 'owner' | 'administrator';
+  policyCacheTtlSeconds: number;
+  version: number;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+/**
+ * One user's access policy.
+ *
+ * Invariant: customerVisibleWrites === true implies writes === true. It is
+ * enforced when a document is written (a customer-visible grant raises writes)
+ * and defensively when one is read (a stored document that violates it is read
+ * down to least privilege).
+ *
+ * `email` is display-only. Lookups are always by hsUserId, never by email.
+ */
+export interface UserPolicy {
+  v: typeof POLICY_USER_SCHEMA_VERSION;
+  allowed: boolean;
+  writes: boolean;
+  customerVisibleWrites: boolean;
+  email: string;
+  updatedAt: string;
+  updatedBy: string;
+  version: number;
+}
+
+/** The subset of the worker env the read/write policy functions need. */
+export interface PolicyKvEnv {
+  OAUTH_KV: KVNamespace;
+}
+
+/** revokeUser additionally needs the provider helpers to list and revoke grants. */
+export interface PolicyRevokeEnv extends PolicyKvEnv {
+  OAUTH_PROVIDER: OAuthHelpers;
+}
+
+/**
+ * A stale-version write. The admin API surfaces this as a 409 so the caller
+ * re-reads and retries rather than clobbering a concurrent edit.
+ */
+export class PolicyConflictError extends Error {
+  readonly code = 'POLICY_CONFLICT' as const;
+
+  constructor(
+    message: string,
+    readonly expectedVersion: number,
+    readonly currentVersion: number,
+  ) {
+    super(message);
+    this.name = 'PolicyConflictError';
+  }
+}
+
+/**
+ * Audit seam for NAS-1502. Mutation functions call this after a successful
+ * write; a no-op by default. Kept synchronous-or-async so an audit sink can
+ * await a KV/queue write.
+ */
+export type PolicyAuditEvent =
+  | { type: 'config.updated'; version: number; updatedBy: string; config: AdminConfig }
+  | { type: 'user.policy.updated'; hsUserId: string; version: number; updatedBy: string; policy: UserPolicy }
+  | { type: 'user.revoked'; hsUserId: string; grantsRevoked: number; updatedBy: string; policy: UserPolicy };
+
+export type PolicyAuditHook = (event: PolicyAuditEvent) => void | Promise<void>;
+
+interface MutationOptions {
+  /** Optimistic-concurrency guard: the version the caller believes is current. */
+  expectedVersion: number;
+  /** Identity of the admin performing the change; stored for display/audit. */
+  updatedBy: string;
+  /** Optional audit sink (NAS-1502). */
+  audit?: PolicyAuditHook;
+}
+
+// --- Config ---------------------------------------------------------------
+
+const DEFAULT_CONFIG: AdminConfig = {
+  schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
+  allowlistMode: false,
+  adminRole: 'owner',
+  policyCacheTtlSeconds: DEFAULT_POLICY_CACHE_TTL_SECONDS,
+  version: 0,
+  updatedAt: '',
+  updatedBy: '',
+};
+
+/** Coerce an untrusted stored config document into a well-formed AdminConfig. */
+function normalizeConfig(raw: Partial<AdminConfig> | null | undefined): AdminConfig {
+  if (!raw) return { ...DEFAULT_CONFIG };
+  return {
+    schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
+    allowlistMode: raw.allowlistMode === true,
+    adminRole: raw.adminRole === 'administrator' ? 'administrator' : 'owner',
+    policyCacheTtlSeconds: clampTtl(
+      typeof raw.policyCacheTtlSeconds === 'number' ? raw.policyCacheTtlSeconds : DEFAULT_POLICY_CACHE_TTL_SECONDS,
+    ),
+    version: typeof raw.version === 'number' && raw.version >= 0 ? Math.floor(raw.version) : 0,
+    updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : '',
+    updatedBy: typeof raw.updatedBy === 'string' ? raw.updatedBy : '',
+  };
+}
+
+/**
+ * Read the deployment config. A missing document is all defaults (open mode).
+ * The TTL is clamped defensively here, so a hand-edited out-of-range value never
+ * reaches the cache logic.
+ */
+export async function getConfig(env: PolicyKvEnv): Promise<AdminConfig> {
+  const raw = (await env.OAUTH_KV.get(ADMIN_CONFIG_KEY, 'json')) as Partial<AdminConfig> | null;
+  return normalizeConfig(raw);
+}
+
+/** The fields putConfig accepts. Omitted fields keep their current value. */
+export interface ConfigPatch {
+  allowlistMode?: boolean;
+  adminRole?: 'owner' | 'administrator';
+  policyCacheTtlSeconds?: number;
+}
+
+/**
+ * Write the deployment config with a version check-and-increment. A stale
+ * expectedVersion throws PolicyConflictError and writes nothing.
+ */
+export async function putConfig(env: PolicyKvEnv, patch: ConfigPatch, opts: MutationOptions): Promise<AdminConfig> {
+  const current = await getConfig(env);
+  if (current.version !== opts.expectedVersion) {
+    throw new PolicyConflictError(
+      `Config version conflict: expected ${opts.expectedVersion}, found ${current.version}. Re-read and retry.`,
+      opts.expectedVersion,
+      current.version,
+    );
+  }
+  const next: AdminConfig = {
+    schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
+    allowlistMode: patch.allowlistMode ?? current.allowlistMode,
+    adminRole: patch.adminRole ?? current.adminRole,
+    policyCacheTtlSeconds: clampTtl(patch.policyCacheTtlSeconds ?? current.policyCacheTtlSeconds),
+    version: current.version + 1,
+    updatedAt: new Date().toISOString(),
+    updatedBy: opts.updatedBy,
+  };
+  await env.OAUTH_KV.put(ADMIN_CONFIG_KEY, JSON.stringify(next));
+  await opts.audit?.({ type: 'config.updated', version: next.version, updatedBy: opts.updatedBy, config: next });
+  return next;
+}
+
+// --- User policy ----------------------------------------------------------
+
+/**
+ * Coerce an untrusted stored user document into a well-formed UserPolicy,
+ * enforcing the customerVisibleWrites => writes invariant down to least
+ * privilege: a stored document with customerVisibleWrites true but writes false
+ * is read with customerVisibleWrites dropped to false.
+ */
+function normalizeUserPolicy(raw: Partial<UserPolicy>): UserPolicy {
+  const writes = raw.writes === true;
+  const customerVisibleWrites = writes && raw.customerVisibleWrites === true;
+  return {
+    v: POLICY_USER_SCHEMA_VERSION,
+    allowed: raw.allowed === true,
+    writes,
+    customerVisibleWrites,
+    email: typeof raw.email === 'string' ? raw.email : '',
+    updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : '',
+    updatedBy: typeof raw.updatedBy === 'string' ? raw.updatedBy : '',
+    version: typeof raw.version === 'number' && raw.version >= 0 ? Math.floor(raw.version) : 0,
+  };
+}
+
+/** Read one user's policy, or null when the user has no explicit entry. */
+export async function getUserPolicy(env: PolicyKvEnv, hsUserId: string | number): Promise<UserPolicy | null> {
+  const raw = (await env.OAUTH_KV.get(userPolicyKey(hsUserId), 'json')) as Partial<UserPolicy> | null;
+  if (!raw) return null;
+  return normalizeUserPolicy(raw);
+}
+
+/** The fields putUserPolicy accepts. */
+export interface UserPolicyInput {
+  allowed: boolean;
+  writes: boolean;
+  customerVisibleWrites: boolean;
+  /** Display-only. Preserved from the current document when omitted. */
+  email?: string;
+}
+
+/**
+ * Write one user's policy with a version check-and-increment, enforcing the
+ * customerVisibleWrites => writes invariant (a customer-visible grant raises
+ * writes to true). A stale expectedVersion throws PolicyConflictError.
+ */
+export async function putUserPolicy(
+  env: PolicyKvEnv,
+  hsUserId: string | number,
+  input: UserPolicyInput,
+  opts: MutationOptions,
+): Promise<UserPolicy> {
+  const id = String(hsUserId);
+  const current = await getUserPolicy(env, id);
+  const currentVersion = current?.version ?? 0;
+  if (currentVersion !== opts.expectedVersion) {
+    throw new PolicyConflictError(
+      `User policy version conflict for ${id}: expected ${opts.expectedVersion}, found ${currentVersion}. Re-read and retry.`,
+      opts.expectedVersion,
+      currentVersion,
+    );
+  }
+  const customerVisibleWrites = input.customerVisibleWrites === true;
+  const writes = customerVisibleWrites || input.writes === true;
+  const next: UserPolicy = {
+    v: POLICY_USER_SCHEMA_VERSION,
+    allowed: input.allowed === true,
+    writes,
+    customerVisibleWrites,
+    email: input.email ?? current?.email ?? '',
+    updatedAt: new Date().toISOString(),
+    updatedBy: opts.updatedBy,
+    version: currentVersion + 1,
+  };
+  await env.OAUTH_KV.put(userPolicyKey(id), JSON.stringify(next));
+  await opts.audit?.({ type: 'user.policy.updated', hsUserId: id, version: next.version, updatedBy: opts.updatedBy, policy: next });
+  return next;
+}
+
+/** Result of a revokeUser call. */
+export interface RevokeUserResult {
+  hsUserId: string;
+  grantsRevoked: number;
+  policy: UserPolicy;
+}
+
+/**
+ * Hard-revoke a user: revoke every OAuth grant the provider holds for them, then
+ * pin their policy to allowed:false (writes off). Listing is paged in case a
+ * user holds many grants. The policy write retries on a version conflict because
+ * a revoke is authoritative and must win over a concurrent edit.
+ *
+ * The two effects are complementary: revoking grants invalidates every live
+ * access token immediately (the next /mcp request fails auth at the library
+ * layer), and allowed:false denies any re-connection attempt and any session
+ * that is serving reads from an unexpired policy cache once that cache lapses.
+ */
+export async function revokeUser(
+  env: PolicyRevokeEnv,
+  hsUserId: string | number,
+  opts: { updatedBy: string; audit?: PolicyAuditHook },
+): Promise<RevokeUserResult> {
+  const id = String(hsUserId);
+
+  let grantsRevoked = 0;
+  let cursor: string | undefined;
+  do {
+    const page = await env.OAUTH_PROVIDER.listUserGrants(id, cursor ? { cursor } : undefined);
+    for (const grant of page.items) {
+      await env.OAUTH_PROVIDER.revokeGrant(grant.id, id);
+      grantsRevoked += 1;
+    }
+    cursor = page.cursor;
+  } while (cursor);
+
+  // Pin allowed:false. Retry the version-checked write on conflict so the revoke
+  // is not lost to a racing admin edit; the audit hook fires only for the write
+  // that actually lands.
+  let policy: UserPolicy | undefined;
+  for (let attempt = 0; attempt < 3 && !policy; attempt += 1) {
+    const current = await getUserPolicy(env, id);
+    try {
+      policy = await putUserPolicy(
+        env,
+        id,
+        { allowed: false, writes: false, customerVisibleWrites: false, email: current?.email },
+        { expectedVersion: current?.version ?? 0, updatedBy: opts.updatedBy },
+      );
+    } catch (error) {
+      if (error instanceof PolicyConflictError && attempt < 2) continue;
+      throw error;
+    }
+  }
+
+  const settled = policy as UserPolicy;
+  await opts.audit?.({ type: 'user.revoked', hsUserId: id, grantsRevoked, updatedBy: opts.updatedBy, policy: settled });
+  return { hsUserId: id, grantsRevoked, policy: settled };
+}
+
+// --- Pure decision helpers ------------------------------------------------
+
+export interface AccessDecision {
+  allowed: boolean;
+  /** Why access was denied, for logging and error copy. Absent when allowed. */
+  reason?: 'explicit-block' | 'allowlist';
+}
+
+/**
+ * The access rule, in one place so /callback and the DO dispatch gate agree:
+ *   - An explicit allowed:false blocks, even in open mode.
+ *   - Under allowlist mode, only an explicit allowed:true admits; a missing
+ *     entry is denied.
+ *   - Otherwise (open mode, no explicit block) access is allowed.
+ */
+export function evaluateAccess(config: AdminConfig, userPolicy: UserPolicy | null): AccessDecision {
+  if (userPolicy && userPolicy.allowed === false) {
+    return { allowed: false, reason: 'explicit-block' };
+  }
+  if (config.allowlistMode && !(userPolicy && userPolicy.allowed === true)) {
+    return { allowed: false, reason: 'allowlist' };
+  }
+  return { allowed: true };
+}
+
+/** The deployment write ceiling (the env gates), and the effective per-user flags. */
+export interface WriteFlagSet {
+  enabled: boolean;
+  customerVisibleEnabled: boolean;
+}
+
+/**
+ * Effective write flags = the deployment ceiling AND the user's grants.
+ *
+ * A user with no policy document (open mode) inherits the ceiling unchanged, so
+ * a deployment that turns writes on at the env level keeps working for everyone
+ * exactly as it did before the policy layer existed. A user with a document is
+ * narrowed: writes only when both the ceiling and their `writes` allow it, and
+ * customer-visible only when the ceiling, their `writes`, and their
+ * `customerVisibleWrites` all allow it.
+ */
+export function effectiveWriteFlags(ceiling: WriteFlagSet, userPolicy: UserPolicy | null): WriteFlagSet {
+  if (!userPolicy) {
+    return { enabled: ceiling.enabled, customerVisibleEnabled: ceiling.customerVisibleEnabled };
+  }
+  const enabled = ceiling.enabled && userPolicy.writes === true;
+  const customerVisibleEnabled = enabled && ceiling.customerVisibleEnabled && userPolicy.customerVisibleWrites === true;
+  return { enabled, customerVisibleEnabled };
+}

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -7,27 +7,34 @@
  *   2. For an already-connected session, is the user still allowed, and which
  *      write operations may they execute (the McpAgent dispatch gate)?
  *
- * It is pure over two dependencies: the existing OAUTH_KV namespace (namespaced
- * away from the workers-oauth-provider library keys) and the provider's
- * OAuthHelpers surface (for grant revocation). The mutation functions
- * (putConfig, putUserPolicy, revokeUser) are the seams a future admin API
- * (NAS-1503) calls, and each accepts an optional audit hook so an audit trail
- * (NAS-1502) can be attached without touching call sites.
+ * It is pure and storage-agnostic. The documents themselves live in ONE
+ * per-deployment coordinator Durable Object (policy-coordinator.ts); this module
+ * owns the DECISION logic (evaluateAccess / effectiveWriteFlags), the document
+ * schema and its fail-closed normalization, and the storage-injectable CAS core
+ * (readConfigDoc / writeConfigDoc / readUserPolicyDoc / writeUserPolicyDoc /
+ * pinUserPolicyRevoked). The core runs over a minimal transactional-storage
+ * interface (PolicyStorage), so the coordinator wires it to its own
+ * ctx.storage and the unit suite wires it to an in-memory transactional fake.
  *
- * KV layout (both documents live in OAUTH_KV):
+ * The env-facing entry points callers actually invoke (getConfig, putConfig,
+ * getUserPolicy, putUserPolicy, deleteConfig, deleteUserPolicy, revokeUser) live
+ * in policy-store.ts, which RPCs the coordinator; keeping them there keeps THIS
+ * module free of any ambient Workers runtime types so the root unit suite can
+ * type-check and exercise the core directly.
+ *
+ * Document layout (both live in the coordinator DO's transactional storage):
  *   admin:config:v1        one deployment-wide config document
  *   policy:user:{hsUserId}  one document per Help Scout user id
  *
  * A missing admin:config document means all defaults (open mode): behavior is
  * byte-identical to a deployment with no policy layer configured. A missing
- * policy:user document means the user has no explicit entry (getUserPolicy
- * returns null), which is allowed in open mode and denied under allowlist mode.
+ * policy:user document means the user has no explicit entry (read as null),
+ * which is allowed in open mode and denied under allowlist mode.
  *
  * `userId` consistency: completeAuthorization stores the grant userId as
  * String(hsUserId) (help-scout-handler.ts), so this module keys policy documents
  * and lists/revokes grants by the same String(hsUserId).
  */
-import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
 
 /** Current schema version of the admin config document. */
 export const POLICY_CONFIG_SCHEMA_VERSION = 1 as const;
@@ -35,10 +42,18 @@ export const POLICY_CONFIG_SCHEMA_VERSION = 1 as const;
 /** Current schema version of a per-user policy document. */
 export const POLICY_USER_SCHEMA_VERSION = 1 as const;
 
-/** The single admin config KV key. Exported so an admin API / harness can target it. */
+/** The single admin config storage key. Exported so an admin API / harness can target it. */
 export const ADMIN_CONFIG_KEY = 'admin:config:v1';
 
-/** The KV key for one user's policy document. */
+/**
+ * The fixed name every worker request resolves the coordinator DO by
+ * (idFromName), so all reads and writes across the deployment hit the ONE
+ * instance whose single-threaded storage gives strongly-consistent reads and
+ * atomic compare-and-swap writes.
+ */
+export const POLICY_COORDINATOR_NAME = 'policy-coordinator';
+
+/** The storage key for one user's policy document. */
 export function userPolicyKey(hsUserId: string | number): string {
   return `policy:user:${String(hsUserId)}`;
 }
@@ -93,14 +108,23 @@ export interface UserPolicy {
   version: number;
 }
 
-/** The subset of the worker env the read/write policy functions need. */
-export interface PolicyKvEnv {
-  OAUTH_KV: KVNamespace;
-}
-
-/** revokeUser additionally needs the provider helpers to list and revoke grants. */
-export interface PolicyRevokeEnv extends PolicyKvEnv {
-  OAUTH_PROVIDER: OAuthHelpers;
+/**
+ * The minimal transactional key-value storage the CAS core runs over.
+ *
+ * `transaction` runs its closure as an atomic, isolated unit: concurrent
+ * transactions on the same storage are serialized, so a read-modify-write inside
+ * one sees a consistent snapshot and its write cannot be lost to a racing
+ * transaction. The coordinator DO satisfies this with its own ctx.storage (a
+ * single-threaded, input-gated Durable Object); the unit suite satisfies it with
+ * an in-memory transactional fake. The core is written so the read and the write
+ * of each mutation sit inside one such closure, which is what makes the
+ * version check-and-increment an atomic compare-and-swap.
+ */
+export interface PolicyStorage {
+  get<T = unknown>(key: string): Promise<T | undefined>;
+  put(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+  transaction<T>(closure: () => Promise<T>): Promise<T>;
 }
 
 /**
@@ -121,9 +145,27 @@ export class PolicyConflictError extends Error {
 }
 
 /**
- * Audit seam for NAS-1502. Mutation functions call this after a successful
- * write; a no-op by default. Kept synchronous-or-async so an audit sink can
- * await a KV/queue write.
+ * A stored config document this build cannot interpret. This is an
+ * authorization boundary, so an unsupported or malformed document must fail
+ * closed (callers surface it as policy-unavailable) rather than silently
+ * normalize into open mode: a future-schema document that meant allowlist
+ * must never admit everyone.
+ */
+export class PolicyInvalidError extends Error {
+  readonly code = 'POLICY_INVALID' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'PolicyInvalidError';
+  }
+}
+
+/**
+ * Audit seam for NAS-1502. The env-facing mutation functions (policy-store.ts)
+ * call this after a successful write; a no-op by default. Kept synchronous-or-
+ * async so an audit sink can await a KV/queue write. It stays worker-side (not
+ * inside the coordinator) because a real sink is worker infrastructure and an
+ * audit hook is a function, which cannot cross the DO RPC boundary.
  */
 export type PolicyAuditEvent =
   | { type: 'config.updated'; version: number; updatedBy: string; config: AdminConfig }
@@ -132,13 +174,63 @@ export type PolicyAuditEvent =
 
 export type PolicyAuditHook = (event: PolicyAuditEvent) => void | Promise<void>;
 
-interface MutationOptions {
+/** The version guard + identity a mutation carries across the DO boundary (audit-free). */
+export interface MutationMeta {
   /** Optimistic-concurrency guard: the version the caller believes is current. */
   expectedVersion: number;
   /** Identity of the admin performing the change; stored for display/audit. */
   updatedBy: string;
-  /** Optional audit sink (NAS-1502). */
+}
+
+/** What the env-facing mutation functions accept: a MutationMeta plus the audit sink. */
+export interface MutationOptions extends MutationMeta {
+  /** Optional audit sink (NAS-1502). Fired worker-side after the DO confirms the write. */
   audit?: PolicyAuditHook;
+}
+
+// --- Cross-boundary result envelopes --------------------------------------
+//
+// The coordinator DO cannot throw a typed PolicyConflictError/PolicyInvalidError
+// across the RPC boundary and have `instanceof` survive, so its methods return a
+// discriminated envelope and policy-store.ts reconstructs the real error class.
+// Callers therefore keep seeing the exact same thrown types they did under KV.
+
+/** A policy error flattened for transport across the DO boundary. */
+export type PolicyErrorEnvelope =
+  | { kind: 'conflict'; message: string; expectedVersion: number; currentVersion: number }
+  | { kind: 'invalid'; message: string };
+
+/** Coordinator read/write result for the config document. */
+export type ConfigDocResult = { ok: true; value: AdminConfig } | { ok: false; error: PolicyErrorEnvelope };
+
+/** Coordinator read result for a user document (value is null when there is no entry). */
+export type UserPolicyDocResult = { ok: true; value: UserPolicy | null } | { ok: false; error: PolicyErrorEnvelope };
+
+/** Coordinator write result for a user document (a write always yields a document). */
+export type UserPolicyWriteResult = { ok: true; value: UserPolicy } | { ok: false; error: PolicyErrorEnvelope };
+
+/** Flatten a known policy error for transport, or null for an unexpected (e.g. storage) error. */
+export function toPolicyErrorEnvelope(error: unknown): PolicyErrorEnvelope | null {
+  if (error instanceof PolicyConflictError) {
+    return {
+      kind: 'conflict',
+      message: error.message,
+      expectedVersion: error.expectedVersion,
+      currentVersion: error.currentVersion,
+    };
+  }
+  if (error instanceof PolicyInvalidError) {
+    return { kind: 'invalid', message: error.message };
+  }
+  return null;
+}
+
+/** Rebuild and throw the real error class from a transported envelope. */
+export function throwPolicyError(envelope: PolicyErrorEnvelope): never {
+  if (envelope.kind === 'conflict') {
+    throw new PolicyConflictError(envelope.message, envelope.expectedVersion, envelope.currentVersion);
+  }
+  throw new PolicyInvalidError(envelope.message);
 }
 
 // --- Config ---------------------------------------------------------------
@@ -153,9 +245,22 @@ const DEFAULT_CONFIG: AdminConfig = {
   updatedBy: '',
 };
 
-/** Coerce an untrusted stored config document into a well-formed AdminConfig. */
+/**
+ * Coerce an untrusted stored config document into a well-formed AdminConfig.
+ * Only a genuinely MISSING document means defaults (open mode). A present
+ * document must carry the supported schema version and a boolean
+ * allowlistMode; anything else throws PolicyInvalidError.
+ */
 function normalizeConfig(raw: Partial<AdminConfig> | null | undefined): AdminConfig {
   if (!raw) return { ...DEFAULT_CONFIG };
+  if (raw.schemaVersion !== POLICY_CONFIG_SCHEMA_VERSION) {
+    throw new PolicyInvalidError(
+      `Unsupported admin config schemaVersion ${String(raw.schemaVersion)}; this build supports ${POLICY_CONFIG_SCHEMA_VERSION}.`,
+    );
+  }
+  if (typeof raw.allowlistMode !== 'boolean') {
+    throw new PolicyInvalidError('Malformed admin config: allowlistMode must be a boolean.');
+  }
   return {
     schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
     allowlistMode: raw.allowlistMode === true,
@@ -169,16 +274,6 @@ function normalizeConfig(raw: Partial<AdminConfig> | null | undefined): AdminCon
   };
 }
 
-/**
- * Read the deployment config. A missing document is all defaults (open mode).
- * The TTL is clamped defensively here, so a hand-edited out-of-range value never
- * reaches the cache logic.
- */
-export async function getConfig(env: PolicyKvEnv): Promise<AdminConfig> {
-  const raw = (await env.OAUTH_KV.get(ADMIN_CONFIG_KEY, 'json')) as Partial<AdminConfig> | null;
-  return normalizeConfig(raw);
-}
-
 /** The fields putConfig accepts. Omitted fields keep their current value. */
 export interface ConfigPatch {
   allowlistMode?: boolean;
@@ -187,30 +282,53 @@ export interface ConfigPatch {
 }
 
 /**
- * Write the deployment config with a version check-and-increment. A stale
- * expectedVersion throws PolicyConflictError and writes nothing.
+ * Read the deployment config from strongly-consistent storage. A missing
+ * document is all defaults (open mode). The TTL is clamped defensively here, so
+ * a hand-edited out-of-range value never reaches the cache logic.
  */
-export async function putConfig(env: PolicyKvEnv, patch: ConfigPatch, opts: MutationOptions): Promise<AdminConfig> {
-  const current = await getConfig(env);
-  if (current.version !== opts.expectedVersion) {
-    throw new PolicyConflictError(
-      `Config version conflict: expected ${opts.expectedVersion}, found ${current.version}. Re-read and retry.`,
-      opts.expectedVersion,
-      current.version,
-    );
-  }
-  const next: AdminConfig = {
-    schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
-    allowlistMode: patch.allowlistMode ?? current.allowlistMode,
-    adminRole: patch.adminRole ?? current.adminRole,
-    policyCacheTtlSeconds: clampTtl(patch.policyCacheTtlSeconds ?? current.policyCacheTtlSeconds),
-    version: current.version + 1,
-    updatedAt: new Date().toISOString(),
-    updatedBy: opts.updatedBy,
-  };
-  await env.OAUTH_KV.put(ADMIN_CONFIG_KEY, JSON.stringify(next));
-  await opts.audit?.({ type: 'config.updated', version: next.version, updatedBy: opts.updatedBy, config: next });
-  return next;
+export async function readConfigDoc(storage: PolicyStorage): Promise<AdminConfig> {
+  const raw = await storage.get<Partial<AdminConfig>>(ADMIN_CONFIG_KEY);
+  return normalizeConfig(raw ?? null);
+}
+
+/**
+ * Write the deployment config with an atomic version check-and-increment. The
+ * whole read-compare-write runs inside one storage transaction, so two
+ * concurrent writers presenting the same expectedVersion cannot both win: the
+ * one that commits second reads the first's incremented version and throws
+ * PolicyConflictError. A stale expectedVersion writes nothing.
+ */
+export async function writeConfigDoc(
+  storage: PolicyStorage,
+  patch: ConfigPatch,
+  meta: MutationMeta,
+): Promise<AdminConfig> {
+  return storage.transaction(async () => {
+    const current = normalizeConfig((await storage.get<Partial<AdminConfig>>(ADMIN_CONFIG_KEY)) ?? null);
+    if (current.version !== meta.expectedVersion) {
+      throw new PolicyConflictError(
+        `Config version conflict: expected ${meta.expectedVersion}, found ${current.version}. Re-read and retry.`,
+        meta.expectedVersion,
+        current.version,
+      );
+    }
+    const next: AdminConfig = {
+      schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
+      allowlistMode: patch.allowlistMode ?? current.allowlistMode,
+      adminRole: patch.adminRole ?? current.adminRole,
+      policyCacheTtlSeconds: clampTtl(patch.policyCacheTtlSeconds ?? current.policyCacheTtlSeconds),
+      version: current.version + 1,
+      updatedAt: new Date().toISOString(),
+      updatedBy: meta.updatedBy,
+    };
+    await storage.put(ADMIN_CONFIG_KEY, next);
+    return next;
+  });
+}
+
+/** Delete the config document (harness/admin seam). Absence reads as open-mode defaults. */
+export async function clearConfigDoc(storage: PolicyStorage): Promise<void> {
+  await storage.delete(ADMIN_CONFIG_KEY);
 }
 
 // --- User policy ----------------------------------------------------------
@@ -236,11 +354,10 @@ function normalizeUserPolicy(raw: Partial<UserPolicy>): UserPolicy {
   };
 }
 
-/** Read one user's policy, or null when the user has no explicit entry. */
-export async function getUserPolicy(env: PolicyKvEnv, hsUserId: string | number): Promise<UserPolicy | null> {
-  const raw = (await env.OAUTH_KV.get(userPolicyKey(hsUserId), 'json')) as Partial<UserPolicy> | null;
-  if (!raw) return null;
-  return normalizeUserPolicy(raw);
+/** Read one user's policy from strongly-consistent storage, or null with no entry. */
+export async function readUserPolicyDoc(storage: PolicyStorage, hsUserId: string | number): Promise<UserPolicy | null> {
+  const raw = await storage.get<Partial<UserPolicy>>(userPolicyKey(hsUserId));
+  return raw ? normalizeUserPolicy(raw) : null;
 }
 
 /** The fields putUserPolicy accepts. */
@@ -253,41 +370,82 @@ export interface UserPolicyInput {
 }
 
 /**
- * Write one user's policy with a version check-and-increment, enforcing the
- * customerVisibleWrites => writes invariant (a customer-visible grant raises
- * writes to true). A stale expectedVersion throws PolicyConflictError.
+ * Write one user's policy with an atomic version check-and-increment, enforcing
+ * the customerVisibleWrites => writes invariant (a customer-visible grant raises
+ * writes to true). The read-compare-write runs inside one storage transaction,
+ * so a racing same-version write cannot silently overwrite this one; the loser
+ * throws PolicyConflictError.
  */
-export async function putUserPolicy(
-  env: PolicyKvEnv,
+export async function writeUserPolicyDoc(
+  storage: PolicyStorage,
   hsUserId: string | number,
   input: UserPolicyInput,
-  opts: MutationOptions,
+  meta: MutationMeta,
 ): Promise<UserPolicy> {
   const id = String(hsUserId);
-  const current = await getUserPolicy(env, id);
-  const currentVersion = current?.version ?? 0;
-  if (currentVersion !== opts.expectedVersion) {
-    throw new PolicyConflictError(
-      `User policy version conflict for ${id}: expected ${opts.expectedVersion}, found ${currentVersion}. Re-read and retry.`,
-      opts.expectedVersion,
-      currentVersion,
-    );
-  }
-  const customerVisibleWrites = input.customerVisibleWrites === true;
-  const writes = customerVisibleWrites || input.writes === true;
-  const next: UserPolicy = {
-    v: POLICY_USER_SCHEMA_VERSION,
-    allowed: input.allowed === true,
-    writes,
-    customerVisibleWrites,
-    email: input.email ?? current?.email ?? '',
-    updatedAt: new Date().toISOString(),
-    updatedBy: opts.updatedBy,
-    version: currentVersion + 1,
-  };
-  await env.OAUTH_KV.put(userPolicyKey(id), JSON.stringify(next));
-  await opts.audit?.({ type: 'user.policy.updated', hsUserId: id, version: next.version, updatedBy: opts.updatedBy, policy: next });
-  return next;
+  return storage.transaction(async () => {
+    const raw = await storage.get<Partial<UserPolicy>>(userPolicyKey(id));
+    const current = raw ? normalizeUserPolicy(raw) : null;
+    const currentVersion = current?.version ?? 0;
+    if (currentVersion !== meta.expectedVersion) {
+      throw new PolicyConflictError(
+        `User policy version conflict for ${id}: expected ${meta.expectedVersion}, found ${currentVersion}. Re-read and retry.`,
+        meta.expectedVersion,
+        currentVersion,
+      );
+    }
+    const customerVisibleWrites = input.customerVisibleWrites === true;
+    const writes = customerVisibleWrites || input.writes === true;
+    const next: UserPolicy = {
+      v: POLICY_USER_SCHEMA_VERSION,
+      allowed: input.allowed === true,
+      writes,
+      customerVisibleWrites,
+      email: input.email ?? current?.email ?? '',
+      updatedAt: new Date().toISOString(),
+      updatedBy: meta.updatedBy,
+      version: currentVersion + 1,
+    };
+    await storage.put(userPolicyKey(id), next);
+    return next;
+  });
+}
+
+/** Delete one user's policy document (harness/admin seam). */
+export async function clearUserPolicyDoc(storage: PolicyStorage, hsUserId: string | number): Promise<void> {
+  await storage.delete(userPolicyKey(String(hsUserId)));
+}
+
+/**
+ * Pin a user to allowed:false inside one atomic transaction. This is the final,
+ * authoritative step of a hard revoke: unlike writeUserPolicyDoc it takes NO
+ * expectedVersion and cannot conflict, because a revoke must win over any
+ * concurrent edit. Running the read-modify-write in one transaction means the
+ * bumped version reflects whatever it displaced, and no racing allow can slip in
+ * between the read and the write to re-open the account.
+ */
+export async function pinUserPolicyRevoked(
+  storage: PolicyStorage,
+  hsUserId: string | number,
+  updatedBy: string,
+): Promise<UserPolicy> {
+  const id = String(hsUserId);
+  return storage.transaction(async () => {
+    const raw = await storage.get<Partial<UserPolicy>>(userPolicyKey(id));
+    const current = raw ? normalizeUserPolicy(raw) : null;
+    const next: UserPolicy = {
+      v: POLICY_USER_SCHEMA_VERSION,
+      allowed: false,
+      writes: false,
+      customerVisibleWrites: false,
+      email: current?.email ?? '',
+      updatedAt: new Date().toISOString(),
+      updatedBy,
+      version: (current?.version ?? 0) + 1,
+    };
+    await storage.put(userPolicyKey(id), next);
+    return next;
+  });
 }
 
 /** Result of a revokeUser call. */
@@ -295,59 +453,6 @@ export interface RevokeUserResult {
   hsUserId: string;
   grantsRevoked: number;
   policy: UserPolicy;
-}
-
-/**
- * Hard-revoke a user: revoke every OAuth grant the provider holds for them, then
- * pin their policy to allowed:false (writes off). Listing is paged in case a
- * user holds many grants. The policy write retries on a version conflict because
- * a revoke is authoritative and must win over a concurrent edit.
- *
- * The two effects are complementary: revoking grants invalidates every live
- * access token immediately (the next /mcp request fails auth at the library
- * layer), and allowed:false denies any re-connection attempt and any session
- * that is serving reads from an unexpired policy cache once that cache lapses.
- */
-export async function revokeUser(
-  env: PolicyRevokeEnv,
-  hsUserId: string | number,
-  opts: { updatedBy: string; audit?: PolicyAuditHook },
-): Promise<RevokeUserResult> {
-  const id = String(hsUserId);
-
-  let grantsRevoked = 0;
-  let cursor: string | undefined;
-  do {
-    const page = await env.OAUTH_PROVIDER.listUserGrants(id, cursor ? { cursor } : undefined);
-    for (const grant of page.items) {
-      await env.OAUTH_PROVIDER.revokeGrant(grant.id, id);
-      grantsRevoked += 1;
-    }
-    cursor = page.cursor;
-  } while (cursor);
-
-  // Pin allowed:false. Retry the version-checked write on conflict so the revoke
-  // is not lost to a racing admin edit; the audit hook fires only for the write
-  // that actually lands.
-  let policy: UserPolicy | undefined;
-  for (let attempt = 0; attempt < 3 && !policy; attempt += 1) {
-    const current = await getUserPolicy(env, id);
-    try {
-      policy = await putUserPolicy(
-        env,
-        id,
-        { allowed: false, writes: false, customerVisibleWrites: false, email: current?.email },
-        { expectedVersion: current?.version ?? 0, updatedBy: opts.updatedBy },
-      );
-    } catch (error) {
-      if (error instanceof PolicyConflictError && attempt < 2) continue;
-      throw error;
-    }
-  }
-
-  const settled = policy as UserPolicy;
-  await opts.audit?.({ type: 'user.revoked', hsUserId: id, grantsRevoked, updatedBy: opts.updatedBy, policy: settled });
-  return { hsUserId: id, grantsRevoked, policy: settled };
 }
 
 // --- Pure decision helpers ------------------------------------------------

--- a/worker/src/test-policy-route.ts
+++ b/worker/src/test-policy-route.ts
@@ -1,0 +1,108 @@
+/**
+ * Test-harness-only HTTP route for seeding and inspecting the policy engine.
+ *
+ * The worker has no admin API yet (NAS-1503), and `wrangler dev` exposes no way
+ * to write KV mid-run, so the smoke suite needs an in-process seam to seed the
+ * config/policy documents and to drive revokeUser. This route provides exactly
+ * that and NOTHING else: it is mounted only when HELPSCOUT_TEST_POLICY_ROUTES
+ * === "true", which the deployment template never sets and the smoke asserts is
+ * absent by default (the route 404s without it).
+ *
+ * It is a thin dispatch over the same exported policy functions the real admin
+ * API will call, so it exercises the production seams rather than a parallel
+ * path. It is intentionally not a general KV console: only the two policy key
+ * shapes can be deleted, via typed ops.
+ */
+import type { Env } from './mcp-agent.js';
+import {
+  ADMIN_CONFIG_KEY,
+  PolicyConflictError,
+  getConfig,
+  getUserPolicy,
+  putConfig,
+  putUserPolicy,
+  revokeUser,
+  userPolicyKey,
+  type ConfigPatch,
+  type UserPolicyInput,
+} from './policy.js';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface TestCommand {
+  op?: string;
+  target?: 'config' | 'user';
+  hsUserId?: string | number;
+  patch?: ConfigPatch;
+  input?: UserPolicyInput;
+  expectedVersion?: number;
+  updatedBy?: string;
+}
+
+export async function handleTestPolicyRoute(request: Request, env: Env): Promise<Response> {
+  let command: TestCommand;
+  try {
+    command = (await request.json()) as TestCommand;
+  } catch {
+    return json({ error: 'Body must be JSON.' }, 400);
+  }
+
+  const updatedBy = command.updatedBy ?? 'smoke-harness';
+
+  try {
+    switch (command.op) {
+      case 'del': {
+        if (command.target === 'config') {
+          await env.OAUTH_KV.delete(ADMIN_CONFIG_KEY);
+        } else if (command.target === 'user') {
+          await env.OAUTH_KV.delete(userPolicyKey(String(command.hsUserId)));
+        } else {
+          return json({ error: 'del requires target "config" or "user".' }, 400);
+        }
+        return json({ ok: true });
+      }
+      case 'getConfig':
+        return json({ config: await getConfig(env) });
+      case 'putConfig':
+        return json({
+          config: await putConfig(env, command.patch ?? {}, {
+            expectedVersion: command.expectedVersion ?? 0,
+            updatedBy,
+          }),
+        });
+      case 'getUserPolicy':
+        return json({ policy: await getUserPolicy(env, String(command.hsUserId)) });
+      case 'putUserPolicy': {
+        if (!command.input) return json({ error: 'putUserPolicy requires input.' }, 400);
+        return json({
+          policy: await putUserPolicy(env, String(command.hsUserId), command.input, {
+            expectedVersion: command.expectedVersion ?? 0,
+            updatedBy,
+          }),
+        });
+      }
+      case 'revokeUser':
+        return json({ result: await revokeUser(env, String(command.hsUserId), { updatedBy }) });
+      default:
+        return json({ error: `Unknown op: ${command.op}` }, 400);
+    }
+  } catch (error) {
+    if (error instanceof PolicyConflictError) {
+      return json(
+        {
+          error: error.message,
+          code: error.code,
+          expectedVersion: error.expectedVersion,
+          currentVersion: error.currentVersion,
+        },
+        409,
+      );
+    }
+    return json({ error: error instanceof Error ? error.message : String(error) }, 500);
+  }
+}

--- a/worker/src/test-policy-route.ts
+++ b/worker/src/test-policy-route.ts
@@ -2,30 +2,28 @@
  * Test-harness-only HTTP route for seeding and inspecting the policy engine.
  *
  * The worker has no admin API yet (NAS-1503), and `wrangler dev` exposes no way
- * to write KV mid-run, so the smoke suite needs an in-process seam to seed the
- * config/policy documents and to drive revokeUser. This route provides exactly
- * that and NOTHING else: it is mounted only when HELPSCOUT_TEST_POLICY_ROUTES
- * === "true", which the deployment template never sets and the smoke asserts is
- * absent by default (the route 404s without it).
+ * to reach into the coordinator DO's storage mid-run, so the smoke suite needs an
+ * in-process seam to seed the config/policy documents and to drive revokeUser.
+ * This route provides exactly that and NOTHING else: it is mounted only when
+ * HELPSCOUT_TEST_POLICY_ROUTES === "true", which the deployment template never
+ * sets and the smoke asserts is absent by default (the route 404s without it).
  *
  * It is a thin dispatch over the same exported policy functions the real admin
- * API will call, so it exercises the production seams rather than a parallel
- * path. It is intentionally not a general KV console: only the two policy key
- * shapes can be deleted, via typed ops.
+ * API will call, so it exercises the production seams (which now RPC the
+ * coordinator) rather than a parallel path. It is intentionally not a general
+ * storage console: only the two policy documents can be deleted, via typed ops.
  */
 import type { Env } from './mcp-agent.js';
+import { PolicyConflictError, type ConfigPatch, type UserPolicyInput } from './policy.js';
 import {
-  ADMIN_CONFIG_KEY,
-  PolicyConflictError,
+  deleteConfig,
+  deleteUserPolicy,
   getConfig,
   getUserPolicy,
   putConfig,
   putUserPolicy,
   revokeUser,
-  userPolicyKey,
-  type ConfigPatch,
-  type UserPolicyInput,
-} from './policy.js';
+} from './policy-store.js';
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -58,9 +56,9 @@ export async function handleTestPolicyRoute(request: Request, env: Env): Promise
     switch (command.op) {
       case 'del': {
         if (command.target === 'config') {
-          await env.OAUTH_KV.delete(ADMIN_CONFIG_KEY);
+          await deleteConfig(env);
         } else if (command.target === 'user') {
-          await env.OAUTH_KV.delete(userPolicyKey(String(command.hsUserId)));
+          await deleteUserPolicy(env, String(command.hsUserId));
         } else {
           return json({ error: 'del requires target "config" or "user".' }, 400);
         }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -49,6 +49,12 @@
   // HELPSCOUT_DOCS_API_KEY` enables the Docs API operations; without it they are
   // still advertised but fail at call time with a credentials-missing error.
   //
+  // NEVER set HELPSCOUT_TEST_POLICY_ROUTES in a real deployment. It exists only for
+  // the smoke harness: its value is a secret key that must be presented in the
+  // X-Test-Policy-Key header to reach an internal policy-mutation route, and it also
+  // relaxes the https guard to allow an http loopback upstream. Setting it in
+  // production would both weaken that guard and expose the access-policy store.
+  //
   // SETUP CAVEAT: the Help Scout app's Redirection URL is fixed at registration
   // and MUST be this deployed worker's `https://<worker>/callback`. An app born
   // with an `http://` redirect is permanently broken for the authorize flow

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -17,15 +17,25 @@
   // runtime under workerd). Outbound calls use the global fetch, not node http.
   "compatibility_flags": ["nodejs_compat"],
 
-  // The McpAgent is a Durable Object. `McpAgent.serve("/mcp")` looks up this
-  // binding by the default name MCP_OBJECT.
+  // Two Durable Objects. MCP_OBJECT is the per-session McpAgent
+  // (`McpAgent.serve("/mcp")` looks it up by that default name). POLICY_OBJECT is
+  // the single per-deployment access-policy coordinator (NAS-1501): every policy
+  // read/write resolves it by a fixed name so reads are strongly consistent and
+  // version writes are atomic compare-and-swap.
   "durable_objects": {
-    "bindings": [{ "class_name": "HelpScoutMCP", "name": "MCP_OBJECT" }]
+    "bindings": [
+      { "class_name": "HelpScoutMCP", "name": "MCP_OBJECT" },
+      { "class_name": "PolicyCoordinator", "name": "POLICY_OBJECT" }
+    ]
   },
 
-  // McpAgent stores per-session state in SQLite, so the class ships as a
-  // new_sqlite_classes migration.
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["HelpScoutMCP"] }],
+  // Both classes use the SQLite storage backend (Cloudflare's recommendation for
+  // all new Durable Object namespaces). v1 ships HelpScoutMCP; v2 adds the policy
+  // coordinator without touching v1.
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["HelpScoutMCP"] },
+    { "tag": "v2", "new_sqlite_classes": ["PolicyCoordinator"] }
+  ],
 
   // workers-oauth-provider stores hashed client secrets and AES-GCM-encrypted
   // grant props (which hold the per-user Help Scout tokens) here. Create the


### PR DESCRIPTION
## What

The policy engine for self-hosted access management (parent NAS-1500). Backend only; the audit trail (NAS-1502) and admin GUI (NAS-1503) build on these seams.

**Model.** A deployment config document (open mode by default, optional allowlist mode, clamped policy-cache TTL, Owner-only admin role stored for the admin API) and per-user documents (`allowed`, `writes`, `customerVisibleWrites` with customer-visible implying writes, enforced on write and read). An unrecognized or malformed config fails closed; a genuinely missing config is open-mode defaults, so a deployment with no policy set behaves exactly as before.

**Store.** A single per-deployment coordinator Durable Object owns the documents in its own transactional storage, addressed by a fixed name so the whole deployment funnels through one instance. Its read-compare-write runs in one `storage.transaction`, giving atomic compare-and-swap (two admins on the same version cannot both win) and strongly-consistent reads (a callback right after a revoke sees the deny, no stale colo admit). This replaces a first-pass KV design after review flagged KV's eventual consistency and non-atomic version check at an authorization boundary. The CAS core is factored over an injectable storage interface so it is unit-testable; `policy-coordinator.ts` binds it to `ctx.storage`, `policy-store.ts` holds the worker-only RPC wrappers.

**Enforcement, two points.** The OAuth callback denies before a grant is minted. The session DO gates every tool call: reads serve from a per-user snapshot within the configured cache window (the documented revocation SLA), writes always re-read fresh and execute through a gateway built with the user's effective flags (env ceiling AND their grants), returning a structured permission error before any Help Scout request when withheld. Advertisement stays ceiling-only. `revokeUser` revokes every grant the provider holds, then pins `allowed:false` in one authoritative transaction.

**Free tier.** The coordinator ships `new_sqlite_classes` (migration v2, alongside the McpAgent's v1), so it stays on the Workers free plan, and moving policy off KV onto Durable Object storage relieves the OAuth provider's tighter KV budget.

Also folded in from the same review round: the session DO's policy snapshot is bound to its user id (a mismatched identity forces a fresh read), and the Help Scout profile name/email are flattened and capped before entering the server instructions.

## Verification

- 21 root policy unit tests including a **concurrent-writer CAS proof** (two same-version writes via `Promise.allSettled` resolve to exactly one success + one `PolicyConflictError`, store holds only the winner). Root suite 629 passing (known local-.env case aside).
- Type-check, lint, worker `tsc` clean.
- Smoke **97 checks** (was 66): allowlist/blocklist admission, per-user write gating both directions, mid-session revocation at the cache boundary, plus two live coordinator proofs, a concurrent same-version write (one 200 + one 409, config advances to exactly version 2) and a revoke-then-immediate-callback denied with no stale admit. A test-only seeding route 404s unless explicitly enabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->