### PR TITLE
feat(NAS-1502): audit trail and evidence exports on the policy coordinator

### DIFF
--- a/src/__tests__/policy-storage-fake.ts
+++ b/src/__tests__/policy-storage-fake.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared in-memory PolicyStorage fake for the worker policy + audit unit suites.
+ *
+ * It faithfully models the coordinator Durable Object's storage: values are
+ * stored by structured copy (no aliasing, like real serialized storage);
+ * `transaction` serializes its closures through a promise chain, the way a
+ * single-threaded, input-gated Durable Object serializes concurrent requests (a
+ * rejected transaction still lets the next proceed); and `list` returns a Map in
+ * ascending key order honoring { prefix, limit, reverse, start, startAfter, end }
+ * with `end` EXCLUSIVE, matching the Durable Objects Storage API contract the
+ * audit ledger relies on.
+ *
+ * It deliberately does NOT model transaction rollback (a rejected DO transaction
+ * rolls back, this fake does not) because the audit core never throws for
+ * control flow inside a transaction, so no test depends on rollback. This is the
+ * one place both suites get their storage semantics, so they cannot drift.
+ */
+import type { PolicyListOptions, PolicyStorage } from '../../worker/src/policy.js';
+
+export function makeStorage(initial: Record<string, unknown> = {}): {
+  map: Map<string, unknown>;
+  storage: PolicyStorage;
+} {
+  const map = new Map<string, unknown>(Object.entries(initial).map(([k, v]) => [k, structuredClone(v)]));
+  let tail: Promise<unknown> = Promise.resolve();
+
+  const storage: PolicyStorage = {
+    get: async <T>(key: string): Promise<T | undefined> => {
+      const value = map.get(key);
+      return value === undefined ? undefined : (structuredClone(value) as T);
+    },
+    put: async (key: string, value: unknown): Promise<void> => {
+      map.set(key, structuredClone(value));
+    },
+    delete: async (key: string): Promise<void> => {
+      map.delete(key);
+    },
+    list: async <T>(options: PolicyListOptions = {}): Promise<Map<string, T>> => {
+      const { prefix, limit, reverse, start, startAfter, end } = options;
+      let keys = [...map.keys()].sort();
+      if (prefix !== undefined) keys = keys.filter((k) => k.startsWith(prefix));
+      if (start !== undefined) keys = keys.filter((k) => k >= start);
+      if (startAfter !== undefined) keys = keys.filter((k) => k > startAfter);
+      if (end !== undefined) keys = keys.filter((k) => k < end); // exclusive upper bound
+      if (reverse) keys.reverse();
+      if (limit !== undefined) keys = keys.slice(0, limit);
+      const out = new Map<string, T>();
+      for (const k of keys) out.set(k, structuredClone(map.get(k)) as T);
+      return out;
+    },
+    transaction: <T>(closure: () => Promise<T>): Promise<T> => {
+      const result = tail.then(() => closure());
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+  };
+
+  return { map, storage };
+}

--- a/src/__tests__/worker-audit.test.ts
+++ b/src/__tests__/worker-audit.test.ts
@@ -29,6 +29,7 @@ import {
   userPolicyKey,
   writeConfigDoc,
   writeUserPolicyDoc,
+  clearUserPolicyDoc,
   type AdminConfig,
   type AuditEntry,
   type UserPolicy,
@@ -117,6 +118,18 @@ describe('audit rows are recorded atomically with mutations', () => {
     expect(rows[0].targetId).toBe('42');
     expect(rows[0].before).toBeNull();
     expect((rows[0].after as UserPolicy).writes).toBe(true);
+  });
+
+  it('records a user.policy.deleted row capturing the removed document as before', async () => {
+    const { map, storage } = makeStorage({ [userPolicyKey('42')]: basePolicy({ version: 3, allowed: true, writes: true }) });
+    await clearUserPolicyDoc(storage, '42', meta());
+    expect(map.has(userPolicyKey('42'))).toBe(false);
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('user.policy.deleted');
+    expect(rows[0].targetId).toBe('42');
+    expect((rows[0].before as UserPolicy).writes).toBe(true);
+    expect(rows[0].after).toBeNull();
   });
 
   it('records a user.policy.update.conflict row and leaves the document untouched', async () => {
@@ -250,6 +263,20 @@ describe('list pagination', () => {
     const page = await readAuditPage(storage, { from, to, limit: 50 });
     expect(page.entries.map((e) => e.seq)).toEqual([4, 3]); // seq 3 (:02) and seq 4 (:03), newest-first
   });
+
+  it('never returns entries past the one-year retention floor, in a page or an export', async () => {
+    const { storage } = makeStorage();
+    jest.setSystemTime(new Date(Date.UTC(2026, 0, 1, 0, 0, 0)));
+    await appendAuditRow(storage, { action: 'old', actorId: 'x', actorEmail: '', targetId: '1', outcome: 'success' });
+    // Advance past the one-year window; the old row is now beyond retention.
+    jest.setSystemTime(new Date(Date.UTC(2027, 1, 1, 0, 0, 0)));
+    await appendAuditRow(storage, { action: 'fresh', actorId: 'x', actorEmail: '', targetId: '2', outcome: 'success' });
+
+    const page = await readAuditPage(storage, { limit: 50 });
+    expect(page.entries.map((e) => e.action)).toEqual(['fresh']);
+    const range = await readAuditRange(storage);
+    expect(range.map((e) => e.action)).toEqual(['fresh']);
+  });
 });
 
 describe('CSV export quoting (RFC 4180)', () => {
@@ -258,6 +285,22 @@ describe('CSV export quoting (RFC 4180)', () => {
     const [header, row] = csv.split('\r\n');
     expect(header).toBe('a,b');
     expect(row).toBe('plain,"has,comma ""quote"" and\nnewline"');
+  });
+
+  it.each(['=cmd|/c calc', '+1+2', '-2+3', '@SUM(A1)', '\ttab-lead'])(
+    'neutralizes a spreadsheet formula-injection cell (%p)',
+    (payload) => {
+      const csv = toCsv(['a'], [[payload]]);
+      const cell = csv.split('\r\n')[1];
+      // The value is prefixed with a single quote so Excel/Sheets treat it as
+      // text, then normal RFC-4180 quoting wraps it if it also contains a comma.
+      expect(cell.startsWith("'") || cell.startsWith('"\'')).toBe(true);
+      expect(cell).toContain(payload.replace(/"/g, '""'));
+    },
+  );
+
+  it('leaves an ordinary leading character untouched', () => {
+    expect(toCsv(['a'], [['ada@example.test']]).split('\r\n')[1]).toBe('ada@example.test');
   });
 
   it('quotes JSON before/after columns that contain commas and quotes', () => {

--- a/src/__tests__/worker-audit.test.ts
+++ b/src/__tests__/worker-audit.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Unit coverage for the worker's audit trail and evidence exports (NAS-1502).
+ *
+ * Exercises the storage-injectable audit core the coordinator Durable Object runs
+ * (appendAuditRow / readAuditPage / readAuditRange / listUserPolicyDocs /
+ * buildAccessListRows / the CSV helpers) plus the atomic recording wired into the
+ * CAS mutations (writeConfigDoc / writeUserPolicyDoc / pinUserPolicyRevoked). It
+ * drives the same in-memory transactional fake as the policy suite, so the
+ * serialized-transaction and list semantics match the real DO.
+ *
+ * The full RPC surface (audit-store.ts) and the end-to-end recording of
+ * grant.created / admission.denied run in the worker smoke suite.
+ */
+import {
+  PolicyConflictError,
+  ADMIN_CONFIG_KEY,
+  AUDIT_SEQ_KEY,
+  MAX_AUDIT_ENTRIES,
+  accessListToCsv,
+  appendAuditRow,
+  auditEntriesToCsv,
+  auditEntryKey,
+  buildAccessListRows,
+  listUserPolicyDocs,
+  pinUserPolicyRevoked,
+  readAuditPage,
+  readAuditRange,
+  toCsv,
+  userPolicyKey,
+  writeConfigDoc,
+  writeUserPolicyDoc,
+  type AdminConfig,
+  type AuditEntry,
+  type UserPolicy,
+  type WriteFlagSet,
+} from '../../worker/src/policy.js';
+import { makeStorage } from './policy-storage-fake.js';
+
+const meta = (over: { expectedVersion?: number; updatedBy?: string; actorEmail?: string } = {}) => ({
+  expectedVersion: over.expectedVersion ?? 0,
+  updatedBy: over.updatedBy ?? 'admin',
+  actorEmail: over.actorEmail ?? 'admin@example.test',
+});
+
+const basePolicy = (over: Partial<UserPolicy> = {}): UserPolicy => ({
+  v: 1,
+  allowed: true,
+  writes: false,
+  customerVisibleWrites: false,
+  email: 'user@example.test',
+  updatedAt: '2026-07-31T00:00:00Z',
+  updatedBy: 'admin',
+  version: 1,
+  ...over,
+});
+
+const baseConfig = (over: Partial<AdminConfig> = {}): AdminConfig => ({
+  schemaVersion: 1,
+  allowlistMode: false,
+  adminRole: 'owner',
+  policyCacheTtlSeconds: 45,
+  version: 1,
+  updatedAt: '2026-07-31T00:00:00Z',
+  updatedBy: 'admin',
+  ...over,
+});
+
+describe('audit rows are recorded atomically with mutations', () => {
+  it('records exactly one config.updated row with correct before/after on a first write', async () => {
+    const { storage } = makeStorage();
+    await writeConfigDoc(storage, { allowlistMode: true }, meta({ actorEmail: 'a@x.test' }));
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.action).toBe('config.updated');
+    expect(row.outcome).toBe('success');
+    expect(row.targetId).toBe(ADMIN_CONFIG_KEY);
+    expect(row.actorId).toBe('admin');
+    expect(row.actorEmail).toBe('a@x.test');
+    expect(row.before).toBeNull(); // version 0 => no prior document
+    expect((row.after as AdminConfig).allowlistMode).toBe(true);
+    expect((row.after as AdminConfig).version).toBe(1);
+  });
+
+  it('records a before snapshot on a subsequent config write', async () => {
+    const { storage } = makeStorage();
+    await writeConfigDoc(storage, { allowlistMode: true }, meta({ expectedVersion: 0 }));
+    await writeConfigDoc(storage, { allowlistMode: false }, meta({ expectedVersion: 1 }));
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(2);
+    expect((rows[1].before as AdminConfig).allowlistMode).toBe(true);
+    expect((rows[1].after as AdminConfig).allowlistMode).toBe(false);
+  });
+
+  it('records a conflict row and does NOT write the document on a stale config write', async () => {
+    const { map, storage } = makeStorage({ [ADMIN_CONFIG_KEY]: baseConfig({ version: 3, allowlistMode: false }) });
+    await expect(writeConfigDoc(storage, { allowlistMode: true }, meta({ expectedVersion: 2 }))).rejects.toBeInstanceOf(
+      PolicyConflictError,
+    );
+    // Document untouched.
+    expect((map.get(ADMIN_CONFIG_KEY) as AdminConfig).allowlistMode).toBe(false);
+    expect((map.get(ADMIN_CONFIG_KEY) as AdminConfig).version).toBe(3);
+    // Exactly one row, and it is the denied conflict.
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('config.update.conflict');
+    expect(rows[0].outcome).toBe('denied');
+    expect(rows[0].after).toEqual({ expectedVersion: 2, currentVersion: 3 });
+  });
+
+  it('records exactly one user.policy.updated row with correct before/after', async () => {
+    const { storage } = makeStorage();
+    await writeUserPolicyDoc(storage, '42', { allowed: true, writes: true, customerVisibleWrites: false }, meta());
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('user.policy.updated');
+    expect(rows[0].targetId).toBe('42');
+    expect(rows[0].before).toBeNull();
+    expect((rows[0].after as UserPolicy).writes).toBe(true);
+  });
+
+  it('records a user.policy.update.conflict row and leaves the document untouched', async () => {
+    const { map, storage } = makeStorage({ [userPolicyKey('7')]: basePolicy({ version: 2, allowed: true }) });
+    await expect(
+      writeUserPolicyDoc(storage, '7', { allowed: false, writes: false, customerVisibleWrites: false }, meta({ expectedVersion: 1 })),
+    ).rejects.toBeInstanceOf(PolicyConflictError);
+    expect((map.get(userPolicyKey('7')) as UserPolicy).allowed).toBe(true);
+    expect((map.get(userPolicyKey('7')) as UserPolicy).version).toBe(2);
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('user.policy.update.conflict');
+    expect(rows[0].outcome).toBe('denied');
+  });
+
+  it('records a user.revoked row with the prior policy as before', async () => {
+    const { storage } = makeStorage({ [userPolicyKey('9')]: basePolicy({ version: 4, allowed: true, writes: true }) });
+    await pinUserPolicyRevoked(storage, '9', 'revoker', 'revoker@example.test');
+    const rows = await readAuditRange(storage);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('user.revoked');
+    expect(rows[0].actorId).toBe('revoker');
+    expect(rows[0].actorEmail).toBe('revoker@example.test');
+    expect((rows[0].before as UserPolicy).allowed).toBe(true);
+    expect((rows[0].after as UserPolicy).allowed).toBe(false);
+  });
+});
+
+describe('sequence ordering and monotonicity', () => {
+  it('assigns gap-free, strictly increasing sequence numbers in append order', async () => {
+    const { storage } = makeStorage();
+    await writeConfigDoc(storage, { allowlistMode: true }, meta({ expectedVersion: 0 }));
+    await writeUserPolicyDoc(storage, '1', { allowed: true, writes: false, customerVisibleWrites: false }, meta());
+    await pinUserPolicyRevoked(storage, '1', 'revoker');
+    const rows = await readAuditRange(storage);
+    expect(rows.map((r) => r.seq)).toEqual([1, 2, 3]);
+    expect(rows.map((r) => r.action)).toEqual(['config.updated', 'user.policy.updated', 'user.revoked']);
+  });
+
+  it('gives two concurrent same-version writers distinct sequential rows (one success, one conflict)', async () => {
+    const { storage } = makeStorage(); // absent config reads as version 0
+    const settled = await Promise.allSettled([
+      writeConfigDoc(storage, { allowlistMode: true }, meta({ expectedVersion: 0, updatedBy: 'a' })),
+      writeConfigDoc(storage, { allowlistMode: false }, meta({ expectedVersion: 0, updatedBy: 'b' })),
+    ]);
+    expect(settled.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
+    expect(settled.filter((r) => r.status === 'rejected')).toHaveLength(1);
+    const rows = await readAuditRange(storage);
+    expect(rows.map((r) => r.seq)).toEqual([1, 2]);
+    const actions = rows.map((r) => r.action).sort();
+    expect(actions).toEqual(['config.update.conflict', 'config.updated']);
+  });
+});
+
+describe('retention pruning', () => {
+  it('drops the row that falls out of the count window on append', async () => {
+    // Seed the counter just below the cap with two recent rows in place, then
+    // append one more so seq crosses the cap and the oldest in-window row is
+    // pruned. Fresh timestamps keep age pruning out of it.
+    const nowIso = new Date().toISOString();
+    const { map, storage } = makeStorage({
+      [AUDIT_SEQ_KEY]: MAX_AUDIT_ENTRIES,
+      [auditEntryKey(1)]: { seq: 1, ts: nowIso, actorId: 'x', actorEmail: '', action: 'seed', targetId: 't', before: null, after: null, outcome: 'success' },
+      [auditEntryKey(2)]: { seq: 2, ts: nowIso, actorId: 'x', actorEmail: '', action: 'seed', targetId: 't', before: null, after: null, outcome: 'success' },
+    });
+    await appendAuditRow(storage, { action: 'new', actorId: 'x', actorEmail: '', targetId: 't', outcome: 'success' });
+    expect(map.has(auditEntryKey(1))).toBe(false); // seq (MAX+1) - MAX = 1 pruned
+    expect(map.has(auditEntryKey(2))).toBe(true);
+    expect(map.has(auditEntryKey(MAX_AUDIT_ENTRIES + 1))).toBe(true);
+  });
+
+  it('prunes rows older than the age cap on append, stopping at the first fresh row', async () => {
+    jest.useFakeTimers();
+    try {
+      const twoYearsAgo = new Date('2024-01-01T00:00:00.000Z').toISOString();
+      const recent = new Date('2026-07-01T00:00:00.000Z').toISOString();
+      const { map, storage } = makeStorage({
+        [AUDIT_SEQ_KEY]: 2,
+        [auditEntryKey(1)]: { seq: 1, ts: twoYearsAgo, actorId: 'x', actorEmail: '', action: 'old', targetId: 't', before: null, after: null, outcome: 'success' },
+        [auditEntryKey(2)]: { seq: 2, ts: recent, actorId: 'x', actorEmail: '', action: 'fresh', targetId: 't', before: null, after: null, outcome: 'success' },
+      });
+      jest.setSystemTime(new Date('2026-07-31T00:00:00.000Z'));
+      await appendAuditRow(storage, { action: 'new', actorId: 'x', actorEmail: '', targetId: 't', outcome: 'success' });
+      expect(map.has(auditEntryKey(1))).toBe(false); // expired
+      expect(map.has(auditEntryKey(2))).toBe(true); // within a year
+      expect(map.has(auditEntryKey(3))).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('list pagination', () => {
+  async function seed(n: number) {
+    jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const { storage } = makeStorage();
+    for (let i = 0; i < n; i++) {
+      jest.setSystemTime(new Date(Date.UTC(2026, 0, 1, 0, 0, i)));
+      await appendAuditRow(storage, { action: `a${i}`, actorId: 'x', actorEmail: '', targetId: String(i), outcome: 'success' });
+    }
+    return storage;
+  }
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('returns newest-first pages and walks the cursor to exhaustion', async () => {
+    const storage = await seed(5);
+    const p1 = await readAuditPage(storage, { limit: 2 });
+    expect(p1.entries.map((e) => e.seq)).toEqual([5, 4]);
+    expect(p1.nextCursor).toBe('4');
+    const p2 = await readAuditPage(storage, { limit: 2, cursor: p1.nextCursor });
+    expect(p2.entries.map((e) => e.seq)).toEqual([3, 2]);
+    expect(p2.nextCursor).toBe('2');
+    const p3 = await readAuditPage(storage, { limit: 2, cursor: p2.nextCursor });
+    expect(p3.entries.map((e) => e.seq)).toEqual([1]);
+    expect(p3.nextCursor).toBeUndefined();
+  });
+
+  it('clamps the limit to [1, 200]', async () => {
+    const storage = await seed(3);
+    expect((await readAuditPage(storage, { limit: 0 })).entries.length).toBe(1); // clamps up to 1
+    expect((await readAuditPage(storage, { limit: 999 })).entries.length).toBe(3); // clamps down, only 3 exist
+    expect((await readAuditPage(storage, {})).entries.length).toBe(3); // default 50, only 3 exist
+  });
+
+  it('filters by from/to timestamp bounds', async () => {
+    const storage = await seed(5); // ts at seconds :00..:04 on 2026-01-01
+    const from = new Date(Date.UTC(2026, 0, 1, 0, 0, 2)).toISOString();
+    const to = new Date(Date.UTC(2026, 0, 1, 0, 0, 3)).toISOString();
+    const page = await readAuditPage(storage, { from, to, limit: 50 });
+    expect(page.entries.map((e) => e.seq)).toEqual([4, 3]); // seq 3 (:02) and seq 4 (:03), newest-first
+  });
+});
+
+describe('CSV export quoting (RFC 4180)', () => {
+  it('quotes and escapes a value containing a comma, quote, and newline', () => {
+    const csv = toCsv(['a', 'b'], [['plain', 'has,comma "quote" and\nnewline']]);
+    const [header, row] = csv.split('\r\n');
+    expect(header).toBe('a,b');
+    expect(row).toBe('plain,"has,comma ""quote"" and\nnewline"');
+  });
+
+  it('quotes JSON before/after columns that contain commas and quotes', () => {
+    const entries: AuditEntry[] = [
+      {
+        seq: 1,
+        ts: '2026-01-01T00:00:00.000Z',
+        actorId: 'admin',
+        actorEmail: 'a@x.test',
+        action: 'config.updated',
+        targetId: 'admin:config:v1',
+        before: null,
+        after: { allowlistMode: true, adminRole: 'owner' },
+        outcome: 'success',
+      },
+    ];
+    const csv = auditEntriesToCsv(entries);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('seq,ts,actorId,actorEmail,action,targetId,before,after,outcome');
+    // The after JSON has a comma, so the whole cell is quoted and its quotes doubled.
+    expect(lines[1]).toContain('"{""allowlistMode"":true,""adminRole"":""owner""}"');
+  });
+});
+
+describe('listUserPolicyDocs', () => {
+  it('returns only user policy documents, keyed by hsUserId, ignoring config and audit keys', async () => {
+    const { storage } = makeStorage({
+      [ADMIN_CONFIG_KEY]: baseConfig(),
+      [userPolicyKey('100')]: basePolicy({ email: 'a@x.test' }),
+      [userPolicyKey('200')]: basePolicy({ email: 'b@x.test' }),
+    });
+    await appendAuditRow(storage, { action: 'noise', actorId: 'x', actorEmail: '', targetId: 't', outcome: 'success' });
+    const users = await listUserPolicyDocs(storage);
+    expect(users.map((u) => u.hsUserId).sort()).toEqual(['100', '200']);
+    expect(users.find((u) => u.hsUserId === '100')?.policy.email).toBe('a@x.test');
+  });
+});
+
+describe('access-list effective flags', () => {
+  const narrowedCeiling: WriteFlagSet = { enabled: true, customerVisibleEnabled: false };
+
+  it('narrows a full user grant to the ceiling', () => {
+    const rows = buildAccessListRows(baseConfig({ allowlistMode: false }), narrowedCeiling, [
+      { hsUserId: '1010', policy: basePolicy({ allowed: true, writes: true, customerVisibleWrites: true }) },
+    ]);
+    expect(rows[0].writes).toBe(true);
+    expect(rows[0].customerVisibleWrites).toBe(true);
+    expect(rows[0].effectiveWrites).toBe(true);
+    expect(rows[0].effectiveCustomerVisibleWrites).toBe(false); // ceiling withholds customer-visible
+    expect(rows[0].effectiveAllowed).toBe(true);
+  });
+
+  it('reflects an explicit block and allowlist admission in effectiveAllowed', () => {
+    const blocked = buildAccessListRows(baseConfig({ allowlistMode: false }), narrowedCeiling, [
+      { hsUserId: '1', policy: basePolicy({ allowed: false, writes: true }) },
+    ]);
+    // effectiveAllowed is the admission decision; the effective WRITE flags are
+    // the ceiling intersection reported independently (admission is the separate
+    // column a reader gates on), so a blocked user still shows their write reach.
+    expect(blocked[0].effectiveAllowed).toBe(false);
+    expect(blocked[0].effectiveWrites).toBe(true);
+
+    const allowlistBlocked = buildAccessListRows(baseConfig({ allowlistMode: true }), narrowedCeiling, [
+      { hsUserId: '2', policy: basePolicy({ allowed: false }) },
+    ]);
+    expect(allowlistBlocked[0].effectiveAllowed).toBe(false);
+
+    const allowlisted = buildAccessListRows(baseConfig({ allowlistMode: true }), narrowedCeiling, [
+      { hsUserId: '3', policy: basePolicy({ allowed: true }) },
+    ]);
+    expect(allowlisted[0].effectiveAllowed).toBe(true);
+  });
+
+  it('sorts rows by hsUserId for a stable export', () => {
+    const rows = buildAccessListRows(baseConfig(), narrowedCeiling, [
+      { hsUserId: '30', policy: basePolicy() },
+      { hsUserId: '10', policy: basePolicy() },
+      { hsUserId: '20', policy: basePolicy() },
+    ]);
+    expect(rows.map((r) => r.hsUserId)).toEqual(['10', '20', '30']);
+  });
+
+  it('serializes access-list rows to CSV with the documented header', () => {
+    const rows = buildAccessListRows(baseConfig(), narrowedCeiling, [
+      { hsUserId: '1010', policy: basePolicy({ writes: true, email: 'u@x.test' }) },
+    ]);
+    const csv = accessListToCsv(rows);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe(
+      'hsUserId,email,allowed,writes,customerVisibleWrites,effectiveAllowed,effectiveWrites,effectiveCustomerVisibleWrites,updatedAt,updatedBy,version',
+    );
+    expect(lines[1].startsWith('1010,u@x.test,true,true,false')).toBe(true);
+  });
+});

--- a/src/__tests__/worker-policy.test.ts
+++ b/src/__tests__/worker-policy.test.ts
@@ -28,45 +28,9 @@ import {
   writeConfigDoc,
   writeUserPolicyDoc,
   type AdminConfig,
-  type PolicyStorage,
   type UserPolicy,
 } from '../../worker/src/policy.js';
-
-/**
- * An in-memory PolicyStorage that faithfully models the coordinator DO: values
- * are stored by structured copy (no aliasing, like real serialized storage) and
- * `transaction` serializes its closures through a promise chain, the way a
- * single-threaded, input-gated Durable Object serializes concurrent requests. A
- * rejected transaction still lets the next one proceed (a DO transaction that
- * throws rolls back and the next request runs).
- */
-function makeStorage(initial: Record<string, unknown> = {}) {
-  const map = new Map<string, unknown>(
-    Object.entries(initial).map(([k, v]) => [k, structuredClone(v)]),
-  );
-  let tail: Promise<unknown> = Promise.resolve();
-  const storage: PolicyStorage = {
-    get: async <T>(key: string): Promise<T | undefined> => {
-      const value = map.get(key);
-      return value === undefined ? undefined : (structuredClone(value) as T);
-    },
-    put: async (key: string, value: unknown): Promise<void> => {
-      map.set(key, structuredClone(value));
-    },
-    delete: async (key: string): Promise<void> => {
-      map.delete(key);
-    },
-    transaction: <T>(closure: () => Promise<T>): Promise<T> => {
-      const result = tail.then(() => closure());
-      tail = result.then(
-        () => undefined,
-        () => undefined,
-      );
-      return result;
-    },
-  };
-  return { map, storage };
-}
+import { makeStorage } from './policy-storage-fake.js';
 
 const baseConfig = (over: Partial<AdminConfig> = {}): AdminConfig => ({
   schemaVersion: 1,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "moduleResolution": "node"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/__tests__/policy-storage-fake.ts"]
 }

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -756,6 +756,78 @@ async function runPolicyMode({ mock }) {
   check('revoke pins the policy to allowed:false', rev8.body.result?.policy?.allowed === false, JSON.stringify(rev8.body.result?.policy));
   const postRevoke8 = await runFullFlow({ clientId, resource, mock });
   check('a fresh callback immediately after revoke is denied (403, no stale admit)', postRevoke8.stopped === 'callback' && postRevoke8.status === 403, `status ${postRevoke8.status}`);
+
+  // [P9] audit trail + evidence exports (NAS-1502). Drive a known, deterministic
+  // subsequence on a per-run-unique user so its audit rows are unambiguous even
+  // though the ledger is append-only and persists across wrangler-dev sessions;
+  // seed a second user for the access-list evidence, then read the ledger and the
+  // exports back through the secret-gated test route.
+  console.log('[P9] audit trail and evidence exports');
+  const auditUser = 2_000_000 + Math.floor(Math.random() * 1_000_000);
+  const auditUser2 = auditUser + 1;
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: auditUser });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: auditUser2 });
+
+  // config.updated -> user.policy.updated -> grant.created (for auditUser)
+  await policyRoute({ op: 'putConfig', patch: { allowlistMode: false, policyCacheTtlSeconds: 15 }, expectedVersion: 0 });
+  await policyRoute({ op: 'putUserPolicy', hsUserId: auditUser, input: { allowed: true, writes: false, customerVisibleWrites: false }, expectedVersion: 0 });
+  mock.state.userId = auditUser;
+  const grantFlow = await runFullFlow({ clientId, resource, mock });
+  check('P9 seeded user connects (grant minted)', typeof grantFlow.accessToken === 'string' && grantFlow.accessToken.length > 0);
+  // user.revoked -> admission.denied (explicit-block) for auditUser
+  await policyRoute({ op: 'revokeUser', hsUserId: auditUser });
+  const deniedFlow = await runFullFlow({ clientId, resource, mock });
+  check('P9 revoked user is denied at callback (feeds admission.denied)', deniedFlow.stopped === 'callback' && deniedFlow.status === 403, `status ${deniedFlow.status}`);
+  // A second user with a full grant, to prove ceiling narrowing in the access list.
+  await policyRoute({ op: 'putUserPolicy', hsUserId: auditUser2, input: { allowed: true, writes: true, customerVisibleWrites: true }, expectedVersion: 0 });
+
+  // Full ledger (bounded by retention), ascending chronological.
+  const exp = await policyRoute({ op: 'auditExport', format: 'json' });
+  check('auditExport json returns generatedAt/deploymentId/entries', exp.status === 200 && typeof exp.body.export?.generatedAt === 'string' && typeof exp.body.export?.deploymentId === 'string' && exp.body.export.deploymentId.length > 0 && Array.isArray(exp.body.export?.entries), JSON.stringify({ status: exp.status, keys: Object.keys(exp.body.export || {}) }));
+  const entries = exp.body.export?.entries || [];
+
+  // The per-run-unique user's subsequence is unambiguous (no other test touches it).
+  const subseq = entries.filter((e) => e.targetId === String(auditUser));
+  const subActions = subseq.map((e) => e.action);
+  check('audit records the seeded user subsequence in order', JSON.stringify(subActions) === JSON.stringify(['user.policy.updated', 'grant.created', 'user.revoked', 'admission.denied']), JSON.stringify(subActions));
+  check('audit sequence numbers are strictly increasing in chronological order', subseq.every((e, i) => i === 0 || e.seq > subseq[i - 1].seq));
+
+  const grantRow = subseq.find((e) => e.action === 'grant.created');
+  check('grant.created actor is the user themselves', grantRow?.actorId === String(auditUser) && (grantRow?.actorEmail || '').includes(MOCK_USER.email), JSON.stringify(grantRow));
+  check('grant.created after carries the clientId', grantRow?.after?.clientId === clientId, JSON.stringify(grantRow?.after));
+  const denyRow = subseq.find((e) => e.action === 'admission.denied');
+  check('admission.denied carries the explicit-block reason and denied outcome', denyRow?.after?.reason === 'explicit-block' && denyRow?.outcome === 'denied', JSON.stringify(denyRow));
+  const updRow = subseq.find((e) => e.action === 'user.policy.updated');
+  check('user.policy.updated actor is the admin identity', updRow?.actorId === 'smoke-harness', JSON.stringify(updRow));
+
+  // A conflict row is durable evidence even though it wrote no document (P6/P7).
+  check('a config.update.conflict row exists from the P6/P7 conflict', entries.some((e) => e.action === 'config.update.conflict' && e.outcome === 'denied'));
+
+  // Pagination shape: a newest-first page plus a cursor.
+  const pageRes = await policyRoute({ op: 'auditList', limit: 3 });
+  const page = pageRes.body.page;
+  check('auditList returns a newest-first page', pageRes.status === 200 && Array.isArray(page?.entries) && page.entries.length === 3 && page.entries[0].seq > page.entries[1].seq, JSON.stringify({ status: pageRes.status, n: page?.entries?.length }));
+  check('auditList returns a next cursor when more remain', typeof page?.nextCursor === 'string' && page.nextCursor.length > 0, JSON.stringify(page?.nextCursor));
+  const page2 = (await policyRoute({ op: 'auditList', limit: 3, cursor: page.nextCursor })).body.page;
+  check('auditList cursor advances strictly below the previous page', Array.isArray(page2?.entries) && page2.entries.length > 0 && page2.entries[0].seq < page.entries[2].seq, JSON.stringify(page2?.entries?.map((e) => e.seq)));
+
+  // CSV export: parseable header + at least one quoted row.
+  const csvRes = await policyRoute({ op: 'auditExport', format: 'csv' });
+  const csv = csvRes.body.export?.csv || '';
+  const csvLines = csv.split('\r\n');
+  check('auditExport csv has the documented header row', csvLines[0] === 'seq,ts,actorId,actorEmail,action,targetId,before,after,outcome', csvLines[0]);
+  check('auditExport csv has quoted data rows', csvLines.length > 1 && csv.includes('""'), `lines ${csvLines.length}`);
+
+  // Access-list evidence: current effective entitlements under the ceiling.
+  const alRes = await policyRoute({ op: 'accessListExport', format: 'json' });
+  const al = alRes.body.export;
+  check('accessListExport json is stamped with generatedAt/deploymentId/config', alRes.status === 200 && typeof al?.generatedAt === 'string' && typeof al?.deploymentId === 'string' && al?.config?.ceiling?.enabled === true, JSON.stringify({ status: alRes.status, config: al?.config }));
+  const fullRow = (al?.rows || []).find((r) => r.hsUserId === String(auditUser2));
+  check('access list shows the full-grant user with its stored grants', fullRow?.allowed === true && fullRow?.writes === true && fullRow?.customerVisibleWrites === true, JSON.stringify(fullRow));
+  check('access list narrows customer-visible writes to the ceiling (off)', fullRow?.effectiveWrites === true && fullRow?.effectiveCustomerVisibleWrites === false, JSON.stringify(fullRow));
+  const revokedRow = (al?.rows || []).find((r) => r.hsUserId === String(auditUser));
+  check('access list shows the revoked user as not allowed', revokedRow?.allowed === false && revokedRow?.effectiveAllowed === false, JSON.stringify(revokedRow));
 }
 
 async function main() {

--- a/worker/src/audit-store.ts
+++ b/worker/src/audit-store.ts
@@ -1,0 +1,230 @@
+/**
+ * Env-facing reads and evidence exports over the audit ledger (NAS-1502).
+ *
+ * These are plain functions the future admin GUI (NAS-1503) will call from its
+ * admin-gated endpoints, and that the secret-gated test route drives in the
+ * smoke. They own NO HTTP surface and NO auth of their own: this ticket builds
+ * the storage, recording, and export logic; the GUI wraps it in authorization.
+ *
+ * The authoritative ledger lives in the ONE policy coordinator Durable Object
+ * (policy-coordinator.ts): mutations record their audit rows inside the same
+ * transaction as the document they change, so ordering is authoritative and the
+ * ledger cannot drift from the policy documents. This module resolves that DO by
+ * the same fixed name every policy read/write uses and RPCs its audit methods.
+ *
+ * The two observational recorders (recordGrantCreated / recordAdmissionDenied)
+ * are best-effort by contract: a failed audit append must NOT fail the
+ * user-facing /callback flow, so they swallow and log rather than throw.
+ */
+import { logger } from '../../src/utils/logger.js';
+import type { Env } from './mcp-agent.js';
+import {
+  POLICY_COORDINATOR_NAME,
+  accessListToCsv,
+  auditEntriesToCsv,
+  type AccessListRow,
+  type AdminConfig,
+  type AuditEntry,
+  type AuditEventInput,
+  type AuditListOptions,
+  type AuditListPage,
+  type UserPolicy,
+  type WriteFlagSet,
+} from './policy.js';
+
+/** The coordinator's audit RPC surface, as seen through its Durable Object stub. */
+interface AuditCoordinatorStub {
+  appendAuditEvent(input: AuditEventInput): Promise<void>;
+  listAuditPage(options: AuditListOptions): Promise<AuditListPage>;
+  listAuditRange(options: { from?: string; to?: string }): Promise<AuditEntry[]>;
+  listUserPolicies(): Promise<Array<{ hsUserId: string; policy: UserPolicy }>>;
+  computeAccessList(ceiling: WriteFlagSet): Promise<{ config: AdminConfig; rows: AccessListRow[] }>;
+}
+
+/** The subset of the worker env the audit reads/exports need. */
+export interface AuditStoreEnv {
+  POLICY_OBJECT: DurableObjectNamespace;
+  HELPSCOUT_ENABLE_WRITES?: string;
+  HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES?: string;
+}
+
+/** Resolve the single coordinator instance by its fixed name (same as policy-store). */
+function coordinator(env: AuditStoreEnv): AuditCoordinatorStub {
+  const namespace = env.POLICY_OBJECT;
+  if (!namespace) {
+    throw new Error(
+      "POLICY_OBJECT Durable Object binding is missing from this deployment's wrangler config. " +
+        "The audit trail requires it. Add the POLICY_OBJECT binding and the v2 migration to your " +
+        'wrangler.deploy.jsonc, then re-deploy. See the upgrade section of guides/remote-self-host.md.',
+    );
+  }
+  const id = namespace.idFromName(POLICY_COORDINATOR_NAME);
+  return namespace.get(id) as unknown as AuditCoordinatorStub;
+}
+
+/**
+ * A stable per-deployment identifier stamped on every export, derived WITHOUT any
+ * new config: the coordinator Durable Object id is idFromName(POLICY_COORDINATOR_NAME),
+ * a deterministic hash of the name within THIS deployment's DO namespace, so its
+ * hex string is stable across restarts and distinct across deployments.
+ */
+export function deploymentId(env: AuditStoreEnv): string {
+  return env.POLICY_OBJECT.idFromName(POLICY_COORDINATOR_NAME).toString();
+}
+
+/** The deployment write ceiling read off the env vars (the same gate the agent uses). */
+function ceilingFromEnv(env: AuditStoreEnv): WriteFlagSet {
+  return {
+    enabled: env.HELPSCOUT_ENABLE_WRITES === 'true',
+    customerVisibleEnabled: env.HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES === 'true',
+  };
+}
+
+/**
+ * Record a grant.created event after completeAuthorization succeeds. The actor is
+ * the user themselves. Best-effort: a failed append is logged, never thrown, so a
+ * completed sign-in is never turned into a failure by an audit hiccup.
+ */
+export async function recordGrantCreated(
+  env: Env,
+  args: { hsUserId: string | number; email: string; clientId: string },
+): Promise<void> {
+  try {
+    await coordinator(env).appendAuditEvent({
+      action: 'grant.created',
+      actorId: String(args.hsUserId),
+      actorEmail: args.email,
+      targetId: String(args.hsUserId),
+      before: null,
+      after: { clientId: args.clientId },
+      outcome: 'success',
+    });
+  } catch (error) {
+    logger.warn('Audit append failed (grant.created)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Record an admission.denied event when the /callback gate denies a sign-in. The
+ * reason is the evaluateAccess reason (explicit-block | allowlist). Best-effort,
+ * for the same reason as recordGrantCreated.
+ */
+export async function recordAdmissionDenied(
+  env: Env,
+  args: { hsUserId: string | number; email: string; reason: 'explicit-block' | 'allowlist' | undefined },
+): Promise<void> {
+  try {
+    await coordinator(env).appendAuditEvent({
+      action: 'admission.denied',
+      actorId: String(args.hsUserId),
+      actorEmail: args.email,
+      targetId: String(args.hsUserId),
+      before: null,
+      after: { reason: args.reason ?? 'denied' },
+      outcome: 'denied',
+    });
+  } catch (error) {
+    logger.warn('Audit append failed (admission.denied)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** A newest-first page of audit entries plus the cursor for the next (older) page. */
+export async function listAuditEntries(env: AuditStoreEnv, options: AuditListOptions = {}): Promise<AuditListPage> {
+  return coordinator(env).listAuditPage(options);
+}
+
+/** Discriminated JSON audit export: the full range plus provenance stamps. */
+export interface AuditExportJson {
+  format: 'json';
+  generatedAt: string;
+  deploymentId: string;
+  count: number;
+  entries: AuditEntry[];
+}
+
+/** Discriminated CSV audit export: an RFC-4180 document plus provenance stamps. */
+export interface AuditExportCsv {
+  format: 'csv';
+  generatedAt: string;
+  deploymentId: string;
+  count: number;
+  csv: string;
+}
+
+export type AuditExport = AuditExportJson | AuditExportCsv;
+
+/**
+ * Export the full audit range (bounded by retention) as JSON or CSV, stamped with
+ * generatedAt and the stable deploymentId. JSON carries the structured entries;
+ * CSV is RFC-4180 with a header row and quoted before/after JSON columns.
+ */
+export async function exportAuditLog(
+  env: AuditStoreEnv,
+  options: { from?: string; to?: string; format: 'json' | 'csv' },
+): Promise<AuditExport> {
+  const entries = await coordinator(env).listAuditRange({ from: options.from, to: options.to });
+  const generatedAt = new Date().toISOString();
+  const id = deploymentId(env);
+  if (options.format === 'csv') {
+    return { format: 'csv', generatedAt, deploymentId: id, count: entries.length, csv: auditEntriesToCsv(entries) };
+  }
+  return { format: 'json', generatedAt, deploymentId: id, count: entries.length, entries };
+}
+
+/** The config provenance stamped on an access-list export. */
+export interface AccessListConfigSummary {
+  allowlistMode: boolean;
+  adminRole: AdminConfig['adminRole'];
+  ceiling: WriteFlagSet;
+}
+
+/** Discriminated JSON access-list export: current effective entitlements + stamps. */
+export interface AccessListExportJson {
+  format: 'json';
+  generatedAt: string;
+  deploymentId: string;
+  count: number;
+  config: AccessListConfigSummary;
+  rows: AccessListRow[];
+}
+
+/** Discriminated CSV access-list export. */
+export interface AccessListExportCsv {
+  format: 'csv';
+  generatedAt: string;
+  deploymentId: string;
+  count: number;
+  config: AccessListConfigSummary;
+  csv: string;
+}
+
+export type AccessListExport = AccessListExportJson | AccessListExportCsv;
+
+/**
+ * Export the CURRENT effective entitlements: every user policy evaluated against
+ * the deployment config and the env write ceiling, each row carrying the stored
+ * grants, the effective flags under the ceiling, and the mutation provenance.
+ * Stamped with generatedAt, the stable deploymentId, and the config summary.
+ */
+export async function exportAccessList(
+  env: AuditStoreEnv,
+  options: { format: 'json' | 'csv' },
+): Promise<AccessListExport> {
+  const ceiling = ceilingFromEnv(env);
+  const { config, rows } = await coordinator(env).computeAccessList(ceiling);
+  const generatedAt = new Date().toISOString();
+  const id = deploymentId(env);
+  const summary: AccessListConfigSummary = {
+    allowlistMode: config.allowlistMode,
+    adminRole: config.adminRole,
+    ceiling,
+  };
+  if (options.format === 'csv') {
+    return { format: 'csv', generatedAt, deploymentId: id, count: rows.length, config: summary, csv: accessListToCsv(rows) };
+  }
+  return { format: 'json', generatedAt, deploymentId: id, count: rows.length, config: summary, rows };
+}

--- a/worker/src/audit-store.ts
+++ b/worker/src/audit-store.ts
@@ -180,6 +180,19 @@ export interface AccessListConfigSummary {
   allowlistMode: boolean;
   adminRole: AdminConfig['adminRole'];
   ceiling: WriteFlagSet;
+  /**
+   * What the rows represent, so a reader does not mistake the list for the full
+   * set of people with access. The rows are the users with an explicit policy
+   * document. In open mode any full Help Scout User seat that has never been
+   * configured is ALSO admitted (with the deployment ceiling as its write
+   * grant) and does not appear here; in allowlist mode only listed allowed:true
+   * users have access.
+   */
+  scope: {
+    represents: 'users-with-an-explicit-policy';
+    unlistedFullSeatUsersHaveAccess: boolean;
+    note: string;
+  };
 }
 
 /** Discriminated JSON access-list export: current effective entitlements + stamps. */
@@ -222,6 +235,13 @@ export async function exportAccessList(
     allowlistMode: config.allowlistMode,
     adminRole: config.adminRole,
     ceiling,
+    scope: {
+      represents: 'users-with-an-explicit-policy',
+      unlistedFullSeatUsersHaveAccess: !config.allowlistMode,
+      note: config.allowlistMode
+        ? 'Allowlist mode: only the users listed here with allowed=true can connect.'
+        : 'Open mode: the users listed here are the explicitly-configured ones. Any full Help Scout User seat that has not been configured is also admitted, with the deployment write ceiling as its grant, and is not enumerated here.',
+    },
   };
   if (options.format === 'csv') {
     return { format: 'csv', generatedAt, deploymentId: id, count: rows.length, config: summary, csv: accessListToCsv(rows) };

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -27,8 +27,9 @@ import {
   verifyConsentCookie,
   type ConsentTransaction,
 } from './oauth-cookie.js';
-import { evaluateAccess } from './policy.js';
+import { evaluateAccess, type AccessDecision } from './policy.js';
 import { getConfig, getUserPolicy } from './policy-store.js';
+import { recordAdmissionDenied, recordGrantCreated } from './audit-store.js';
 import { handleTestPolicyRoute } from './test-policy-route.js';
 
 /** HTML-escape untrusted values before echoing them into a page. */
@@ -405,13 +406,13 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
   // strongly consistent, so a user blocked moments earlier is denied here with no
   // stale-colo admit. A coordinator failure fails closed: no grant is completed.
   // The consent cookie is cleared like every terminal path.
-  let accessAllowed: boolean;
+  let decision: AccessDecision;
   try {
     const [config, userPolicy] = await Promise.all([
       getConfig(env),
       getUserPolicy(env, userId),
     ]);
-    accessAllowed = evaluateAccess(config, userPolicy).allowed;
+    decision = evaluateAccess(config, userPolicy);
   } catch {
     return htmlResponse(
       page(
@@ -423,7 +424,9 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
       { 'Set-Cookie': buildConsentClearCookie() },
     );
   }
-  if (!accessAllowed) {
+  if (!decision.allowed) {
+    // Observational audit row; best-effort, never fails the user-facing deny.
+    await recordAdmissionDenied(env, { hsUserId: userId, email, reason: decision.reason });
     return htmlResponse(
       page(
         'Help Scout access not enabled',
@@ -442,6 +445,9 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
     scope: txn.oauthReq.scope,
     props: { accessToken, refreshToken, expiresAt, userId, name, email },
   });
+
+  // Observational audit row after the grant is minted; best-effort, off the path.
+  await recordGrantCreated(env, { hsUserId: userId, email, clientId: txn.oauthReq.clientId });
 
   return new Response(null, {
     status: 302,

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -459,6 +459,18 @@ async function handleCallback(request: Request, env: Env): Promise<Response> {
  * The defaultHandler the OAuth shell delegates to. Metadata, /token, and
  * /register are the library's; /authorize, /approve, and /callback are ours.
  */
+/**
+ * The test-policy route key must be a real secret, not a guessable enable flag.
+ * Rejecting the empty value and a small set of trivial values ("true", "1", ...)
+ * disarms the footgun where an operator, misreading a doc, sets the var to
+ * "true": that would make X-Test-Policy-Key: true a public key over the whole
+ * policy store. A real per-run secret is always long, so require length >= 16.
+ */
+function isStrongTestPolicyKey(value: string | undefined): value is string {
+  if (typeof value !== 'string' || value.length < 16) return false;
+  return !['true', 'false', '1', '0', 'yes', 'on', 'enabled'].includes(value.toLowerCase());
+}
+
 export const helpScoutHandler: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -474,8 +486,7 @@ export const helpScoutHandler: ExportedHandler<Env> = {
     // it, and asserts a missing/wrong key 404s.
     const testPolicyKey = env.HELPSCOUT_TEST_POLICY_ROUTES;
     if (
-      typeof testPolicyKey === 'string' &&
-      testPolicyKey.length > 0 &&
+      isStrongTestPolicyKey(testPolicyKey) &&
       request.headers.get('X-Test-Policy-Key') === testPolicyKey &&
       url.pathname === '/__test__/policy' &&
       request.method === 'POST'

--- a/worker/src/policy-coordinator.ts
+++ b/worker/src/policy-coordinator.ts
@@ -93,8 +93,8 @@ export class PolicyCoordinator extends DurableObject {
     return this.envelope(() => writeConfigDoc(this.store, patch, meta));
   }
 
-  async deleteConfigDoc(): Promise<void> {
-    await clearConfigDoc(this.store);
+  async deleteConfigDoc(meta?: MutationMeta): Promise<void> {
+    await clearConfigDoc(this.store, meta);
   }
 
   async getUserPolicyDoc(hsUserId: string): Promise<UserPolicyDocResult> {
@@ -105,8 +105,8 @@ export class PolicyCoordinator extends DurableObject {
     return this.envelope(() => writeUserPolicyDoc(this.store, hsUserId, input, meta));
   }
 
-  async deleteUserPolicyDoc(hsUserId: string): Promise<void> {
-    await clearUserPolicyDoc(this.store, hsUserId);
+  async deleteUserPolicyDoc(hsUserId: string, meta?: MutationMeta): Promise<void> {
+    await clearUserPolicyDoc(this.store, hsUserId, meta);
   }
 
   async pinRevokedUser(hsUserId: string, updatedBy: string, actorEmail?: string): Promise<UserPolicyWriteResult> {

--- a/worker/src/policy-coordinator.ts
+++ b/worker/src/policy-coordinator.ts
@@ -33,22 +33,36 @@
 import { DurableObject } from 'cloudflare:workers';
 
 import {
+  appendAuditRow,
+  buildAccessListRows,
   clearConfigDoc,
   clearUserPolicyDoc,
+  listUserPolicyDocs,
   pinUserPolicyRevoked,
+  readAuditPage,
+  readAuditRange,
   readConfigDoc,
   readUserPolicyDoc,
   toPolicyErrorEnvelope,
   writeConfigDoc,
   writeUserPolicyDoc,
+  type AccessListRow,
+  type AdminConfig,
+  type AuditEntry,
+  type AuditEventInput,
+  type AuditListOptions,
+  type AuditListPage,
   type ConfigDocResult,
   type ConfigPatch,
   type MutationMeta,
   type PolicyErrorEnvelope,
+  type PolicyListOptions,
   type PolicyStorage,
+  type UserPolicy,
   type UserPolicyDocResult,
   type UserPolicyInput,
   type UserPolicyWriteResult,
+  type WriteFlagSet,
 } from './policy.js';
 
 export class PolicyCoordinator extends DurableObject {
@@ -67,6 +81,7 @@ export class PolicyCoordinator extends DurableObject {
     delete: async (key: string): Promise<void> => {
       await this.ctx.storage.delete(key);
     },
+    list: <T>(options?: PolicyListOptions): Promise<Map<string, T>> => this.ctx.storage.list<T>(options),
     transaction: <T>(closure: () => Promise<T>): Promise<T> => this.ctx.storage.transaction(() => closure()),
   };
 
@@ -94,8 +109,45 @@ export class PolicyCoordinator extends DurableObject {
     await clearUserPolicyDoc(this.store, hsUserId);
   }
 
-  async pinRevokedUser(hsUserId: string, updatedBy: string): Promise<UserPolicyWriteResult> {
-    return this.envelope(() => pinUserPolicyRevoked(this.store, hsUserId, updatedBy));
+  async pinRevokedUser(hsUserId: string, updatedBy: string, actorEmail?: string): Promise<UserPolicyWriteResult> {
+    return this.envelope(() => pinUserPolicyRevoked(this.store, hsUserId, updatedBy, actorEmail ?? ''));
+  }
+
+  /**
+   * Append one observational audit event (grant.created / admission.denied) in
+   * its own transaction. Policy MUTATIONS record their rows inside the mutation
+   * transaction (writeConfigDoc / writeUserPolicyDoc / pinUserPolicyRevoked), so
+   * this is only for events that are not themselves document writes.
+   */
+  async appendAuditEvent(input: AuditEventInput): Promise<void> {
+    await this.store.transaction(() => appendAuditRow(this.store, input));
+  }
+
+  /** A newest-first page of audit rows (opportunistically age-pruned). */
+  async listAuditPage(options: AuditListOptions): Promise<AuditListPage> {
+    return readAuditPage(this.store, options);
+  }
+
+  /** The full audit range (bounded by retention), ascending chronological. */
+  async listAuditRange(options: { from?: string; to?: string }): Promise<AuditEntry[]> {
+    return readAuditRange(this.store, options);
+  }
+
+  /** Every stored user policy document, for the access-list evidence export. */
+  async listUserPolicies(): Promise<Array<{ hsUserId: string; policy: UserPolicy }>> {
+    return listUserPolicyDocs(this.store);
+  }
+
+  /**
+   * Compute the current effective entitlements for every user policy, evaluated
+   * against the deployment config and the caller-supplied env write ceiling. The
+   * config lives in the coordinator's own storage; the ceiling is an env fact the
+   * worker passes in.
+   */
+  async computeAccessList(ceiling: WriteFlagSet): Promise<{ config: AdminConfig; rows: AccessListRow[] }> {
+    const config = await readConfigDoc(this.store);
+    const users = await listUserPolicyDocs(this.store);
+    return { config, rows: buildAccessListRows(config, ceiling, users) };
   }
 
   /**

--- a/worker/src/policy-store.ts
+++ b/worker/src/policy-store.ts
@@ -44,10 +44,10 @@ import {
 interface PolicyCoordinatorStub {
   getConfigDoc(): Promise<ConfigDocResult>;
   putConfigDoc(patch: ConfigPatch, meta: MutationMeta): Promise<ConfigDocResult>;
-  deleteConfigDoc(): Promise<void>;
+  deleteConfigDoc(meta?: MutationMeta): Promise<void>;
   getUserPolicyDoc(hsUserId: string): Promise<UserPolicyDocResult>;
   putUserPolicyDoc(hsUserId: string, input: UserPolicyInput, meta: MutationMeta): Promise<UserPolicyWriteResult>;
-  deleteUserPolicyDoc(hsUserId: string): Promise<void>;
+  deleteUserPolicyDoc(hsUserId: string, meta?: MutationMeta): Promise<void>;
   pinRevokedUser(hsUserId: string, updatedBy: string, actorEmail?: string): Promise<UserPolicyWriteResult>;
 }
 
@@ -108,8 +108,8 @@ export async function putConfig(env: PolicyStoreEnv, patch: ConfigPatch, opts: M
 }
 
 /** Delete the config document (harness/admin seam). Absence reads as open-mode defaults. */
-export async function deleteConfig(env: PolicyStoreEnv): Promise<void> {
-  await coordinator(env).deleteConfigDoc();
+export async function deleteConfig(env: PolicyStoreEnv, meta?: MutationMeta): Promise<void> {
+  await coordinator(env).deleteConfigDoc(meta);
 }
 
 /** Read one user's policy, or null when the user has no explicit entry. */
@@ -142,8 +142,8 @@ export async function putUserPolicy(
 }
 
 /** Delete one user's policy document (harness/admin seam). */
-export async function deleteUserPolicy(env: PolicyStoreEnv, hsUserId: string | number): Promise<void> {
-  await coordinator(env).deleteUserPolicyDoc(String(hsUserId));
+export async function deleteUserPolicy(env: PolicyStoreEnv, hsUserId: string | number, meta?: MutationMeta): Promise<void> {
+  await coordinator(env).deleteUserPolicyDoc(String(hsUserId), meta);
 }
 
 /**

--- a/worker/src/policy-store.ts
+++ b/worker/src/policy-store.ts
@@ -48,7 +48,7 @@ interface PolicyCoordinatorStub {
   getUserPolicyDoc(hsUserId: string): Promise<UserPolicyDocResult>;
   putUserPolicyDoc(hsUserId: string, input: UserPolicyInput, meta: MutationMeta): Promise<UserPolicyWriteResult>;
   deleteUserPolicyDoc(hsUserId: string): Promise<void>;
-  pinRevokedUser(hsUserId: string, updatedBy: string): Promise<UserPolicyWriteResult>;
+  pinRevokedUser(hsUserId: string, updatedBy: string, actorEmail?: string): Promise<UserPolicyWriteResult>;
 }
 
 /** The subset of the worker env the read/write policy functions need. */
@@ -100,6 +100,7 @@ export async function putConfig(env: PolicyStoreEnv, patch: ConfigPatch, opts: M
   const result = await coordinator(env).putConfigDoc(patch, {
     expectedVersion: opts.expectedVersion,
     updatedBy: opts.updatedBy,
+    actorEmail: opts.actorEmail,
   });
   if (!result.ok) throwPolicyError(result.error);
   await opts.audit?.({ type: 'config.updated', version: result.value.version, updatedBy: opts.updatedBy, config: result.value });
@@ -133,6 +134,7 @@ export async function putUserPolicy(
   const result = await coordinator(env).putUserPolicyDoc(id, input, {
     expectedVersion: opts.expectedVersion,
     updatedBy: opts.updatedBy,
+    actorEmail: opts.actorEmail,
   });
   if (!result.ok) throwPolicyError(result.error);
   await opts.audit?.({ type: 'user.policy.updated', hsUserId: id, version: result.value.version, updatedBy: opts.updatedBy, policy: result.value });
@@ -164,11 +166,11 @@ export async function deleteUserPolicy(env: PolicyStoreEnv, hsUserId: string | n
 export async function revokeUser(
   env: PolicyRevokeEnv,
   hsUserId: string | number,
-  opts: { updatedBy: string; audit?: PolicyAuditHook },
+  opts: { updatedBy: string; actorEmail?: string; audit?: PolicyAuditHook },
 ): Promise<RevokeUserResult> {
   const id = String(hsUserId);
 
-  const result = await coordinator(env).pinRevokedUser(id, opts.updatedBy);
+  const result = await coordinator(env).pinRevokedUser(id, opts.updatedBy, opts.actorEmail);
   if (!result.ok) throwPolicyError(result.error);
   const policy = result.value;
 

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -53,9 +53,12 @@ export const ADMIN_CONFIG_KEY = 'admin:config:v1';
  */
 export const POLICY_COORDINATOR_NAME = 'policy-coordinator';
 
+/** The shared prefix every per-user policy document key carries. */
+export const USER_POLICY_PREFIX = 'policy:user:';
+
 /** The storage key for one user's policy document. */
 export function userPolicyKey(hsUserId: string | number): string {
-  return `policy:user:${String(hsUserId)}`;
+  return `${USER_POLICY_PREFIX}${String(hsUserId)}`;
 }
 
 /** Default policy cache TTL, in seconds, when the config document is missing. */
@@ -124,7 +127,25 @@ export interface PolicyStorage {
   get<T = unknown>(key: string): Promise<T | undefined>;
   put(key: string, value: unknown): Promise<void>;
   delete(key: string): Promise<void>;
+  list<T = unknown>(options?: PolicyListOptions): Promise<Map<string, T>>;
   transaction<T>(closure: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * The subset of the Durable Objects storage list options the audit ledger and
+ * the access-list export use. Mirrors the runtime contract: results come back in
+ * ascending UTF-8 key order, `prefix` scopes the range, `end` is EXCLUSIVE, and
+ * `reverse` flips the returned order (developers.cloudflare.com, Durable Objects
+ * Storage API `list(options)`). The coordinator binds this to ctx.storage.list
+ * and the unit fake implements the same shape over an in-memory map.
+ */
+export interface PolicyListOptions {
+  prefix?: string;
+  limit?: number;
+  reverse?: boolean;
+  start?: string;
+  startAfter?: string;
+  end?: string;
 }
 
 /**
@@ -174,12 +195,14 @@ export type PolicyAuditEvent =
 
 export type PolicyAuditHook = (event: PolicyAuditEvent) => void | Promise<void>;
 
-/** The version guard + identity a mutation carries across the DO boundary (audit-free). */
+/** The version guard + identity a mutation carries across the DO boundary. */
 export interface MutationMeta {
   /** Optimistic-concurrency guard: the version the caller believes is current. */
   expectedVersion: number;
   /** Identity of the admin performing the change; stored for display/audit. */
   updatedBy: string;
+  /** Optional display email of the admin, recorded on the audit row (NAS-1502). */
+  actorEmail?: string;
 }
 
 /** What the env-facing mutation functions accept: a MutationMeta plus the audit sink. */
@@ -303,27 +326,56 @@ export async function writeConfigDoc(
   patch: ConfigPatch,
   meta: MutationMeta,
 ): Promise<AdminConfig> {
-  return storage.transaction(async () => {
-    const current = normalizeConfig((await storage.get<Partial<AdminConfig>>(ADMIN_CONFIG_KEY)) ?? null);
-    if (current.version !== meta.expectedVersion) {
-      throw new PolicyConflictError(
-        `Config version conflict: expected ${meta.expectedVersion}, found ${current.version}. Re-read and retry.`,
-        meta.expectedVersion,
-        current.version,
-      );
-    }
-    const next: AdminConfig = {
-      schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
-      allowlistMode: patch.allowlistMode ?? current.allowlistMode,
-      adminRole: patch.adminRole ?? current.adminRole,
-      policyCacheTtlSeconds: clampTtl(patch.policyCacheTtlSeconds ?? current.policyCacheTtlSeconds),
-      version: current.version + 1,
-      updatedAt: new Date().toISOString(),
-      updatedBy: meta.updatedBy,
-    };
-    await storage.put(ADMIN_CONFIG_KEY, next);
-    return next;
-  });
+  // The whole read-compare-write PLUS its audit row commit in one transaction, so
+  // the ledger never drifts from the document. On conflict we write ONLY the
+  // denied audit row and return a marker; the throw happens after the transaction
+  // commits, so we never rely on rollback (the in-memory unit fake does not model
+  // it) and the conflict row is the sole write.
+  const outcome = await storage.transaction(
+    async (): Promise<{ ok: true; config: AdminConfig } | { ok: false; currentVersion: number }> => {
+      const current = normalizeConfig((await storage.get<Partial<AdminConfig>>(ADMIN_CONFIG_KEY)) ?? null);
+      if (current.version !== meta.expectedVersion) {
+        await appendAuditRow(storage, {
+          action: 'config.update.conflict',
+          actorId: meta.updatedBy,
+          actorEmail: meta.actorEmail ?? '',
+          targetId: ADMIN_CONFIG_KEY,
+          before: null,
+          after: { expectedVersion: meta.expectedVersion, currentVersion: current.version },
+          outcome: 'denied',
+        });
+        return { ok: false, currentVersion: current.version };
+      }
+      const next: AdminConfig = {
+        schemaVersion: POLICY_CONFIG_SCHEMA_VERSION,
+        allowlistMode: patch.allowlistMode ?? current.allowlistMode,
+        adminRole: patch.adminRole ?? current.adminRole,
+        policyCacheTtlSeconds: clampTtl(patch.policyCacheTtlSeconds ?? current.policyCacheTtlSeconds),
+        version: current.version + 1,
+        updatedAt: new Date().toISOString(),
+        updatedBy: meta.updatedBy,
+      };
+      await storage.put(ADMIN_CONFIG_KEY, next);
+      await appendAuditRow(storage, {
+        action: 'config.updated',
+        actorId: meta.updatedBy,
+        actorEmail: meta.actorEmail ?? '',
+        targetId: ADMIN_CONFIG_KEY,
+        before: current.version === 0 ? null : current,
+        after: next,
+        outcome: 'success',
+      });
+      return { ok: true, config: next };
+    },
+  );
+  if (!outcome.ok) {
+    throw new PolicyConflictError(
+      `Config version conflict: expected ${meta.expectedVersion}, found ${outcome.currentVersion}. Re-read and retry.`,
+      meta.expectedVersion,
+      outcome.currentVersion,
+    );
+  }
+  return outcome.config;
 }
 
 /** Delete the config document (harness/admin seam). Absence reads as open-mode defaults. */
@@ -383,32 +435,56 @@ export async function writeUserPolicyDoc(
   meta: MutationMeta,
 ): Promise<UserPolicy> {
   const id = String(hsUserId);
-  return storage.transaction(async () => {
-    const raw = await storage.get<Partial<UserPolicy>>(userPolicyKey(id));
-    const current = raw ? normalizeUserPolicy(raw) : null;
-    const currentVersion = current?.version ?? 0;
-    if (currentVersion !== meta.expectedVersion) {
-      throw new PolicyConflictError(
-        `User policy version conflict for ${id}: expected ${meta.expectedVersion}, found ${currentVersion}. Re-read and retry.`,
-        meta.expectedVersion,
-        currentVersion,
-      );
-    }
-    const customerVisibleWrites = input.customerVisibleWrites === true;
-    const writes = customerVisibleWrites || input.writes === true;
-    const next: UserPolicy = {
-      v: POLICY_USER_SCHEMA_VERSION,
-      allowed: input.allowed === true,
-      writes,
-      customerVisibleWrites,
-      email: input.email ?? current?.email ?? '',
-      updatedAt: new Date().toISOString(),
-      updatedBy: meta.updatedBy,
-      version: currentVersion + 1,
-    };
-    await storage.put(userPolicyKey(id), next);
-    return next;
-  });
+  const outcome = await storage.transaction(
+    async (): Promise<{ ok: true; policy: UserPolicy } | { ok: false; currentVersion: number }> => {
+      const raw = await storage.get<Partial<UserPolicy>>(userPolicyKey(id));
+      const current = raw ? normalizeUserPolicy(raw) : null;
+      const currentVersion = current?.version ?? 0;
+      if (currentVersion !== meta.expectedVersion) {
+        await appendAuditRow(storage, {
+          action: 'user.policy.update.conflict',
+          actorId: meta.updatedBy,
+          actorEmail: meta.actorEmail ?? '',
+          targetId: id,
+          before: null,
+          after: { expectedVersion: meta.expectedVersion, currentVersion },
+          outcome: 'denied',
+        });
+        return { ok: false, currentVersion };
+      }
+      const customerVisibleWrites = input.customerVisibleWrites === true;
+      const writes = customerVisibleWrites || input.writes === true;
+      const next: UserPolicy = {
+        v: POLICY_USER_SCHEMA_VERSION,
+        allowed: input.allowed === true,
+        writes,
+        customerVisibleWrites,
+        email: input.email ?? current?.email ?? '',
+        updatedAt: new Date().toISOString(),
+        updatedBy: meta.updatedBy,
+        version: currentVersion + 1,
+      };
+      await storage.put(userPolicyKey(id), next);
+      await appendAuditRow(storage, {
+        action: 'user.policy.updated',
+        actorId: meta.updatedBy,
+        actorEmail: meta.actorEmail ?? '',
+        targetId: id,
+        before: current,
+        after: next,
+        outcome: 'success',
+      });
+      return { ok: true, policy: next };
+    },
+  );
+  if (!outcome.ok) {
+    throw new PolicyConflictError(
+      `User policy version conflict for ${id}: expected ${meta.expectedVersion}, found ${outcome.currentVersion}. Re-read and retry.`,
+      meta.expectedVersion,
+      outcome.currentVersion,
+    );
+  }
+  return outcome.policy;
 }
 
 /** Delete one user's policy document (harness/admin seam). */
@@ -428,6 +504,7 @@ export async function pinUserPolicyRevoked(
   storage: PolicyStorage,
   hsUserId: string | number,
   updatedBy: string,
+  actorEmail = '',
 ): Promise<UserPolicy> {
   const id = String(hsUserId);
   return storage.transaction(async () => {
@@ -444,6 +521,15 @@ export async function pinUserPolicyRevoked(
       version: (current?.version ?? 0) + 1,
     };
     await storage.put(userPolicyKey(id), next);
+    await appendAuditRow(storage, {
+      action: 'user.revoked',
+      actorId: updatedBy,
+      actorEmail,
+      targetId: id,
+      before: current,
+      after: next,
+      outcome: 'success',
+    });
     return next;
   });
 }
@@ -503,4 +589,369 @@ export function effectiveWriteFlags(ceiling: WriteFlagSet, userPolicy: UserPolic
   const enabled = ceiling.enabled && userPolicy.writes === true;
   const customerVisibleEnabled = enabled && ceiling.customerVisibleEnabled && userPolicy.customerVisibleWrites === true;
   return { enabled, customerVisibleEnabled };
+}
+
+// --- Audit trail (NAS-1502) ------------------------------------------------
+//
+// The coordinator DO is also the audit ledger. Every policy MUTATION records its
+// audit row in the SAME storage transaction as the document it changes (see
+// writeConfigDoc / writeUserPolicyDoc / pinUserPolicyRevoked above), so a row and
+// the mutation it describes commit together or not at all, so the ledger cannot
+// drift from the documents, and a conflict that writes nothing to a document
+// still leaves a durable denied row. Observational events that are NOT mutations
+// (a grant minted at /callback, an admission denied at the gate) are appended via
+// appendAuditRow in their own transaction, best-effort and off the user path.
+//
+// Storage model (the same key-value PolicyStorage the CAS core runs over, chosen
+// over the SQL API so the audit core stays unit-testable against the existing
+// in-memory transactional fake, and so an audit row commits inside the very same
+// transaction as its mutation with no second storage abstraction):
+//   audit:seq                 a maintained monotonic counter (last-used seq)
+//   audit:entry:{padded seq}  one immutable row per event, seq zero-padded so the
+//                             ascending UTF-8 key order the DO lists in IS the
+//                             sequence (and wall-clock) order.
+// The counter is incremented inside the serialized transaction, so sequence
+// numbers are gap-free and strictly ordered for free: the single-threaded,
+// input-gated Durable Object provides that with no extra coordination.
+//
+// Retention is bounded two ways, both documented on the reader/writer:
+//   - by COUNT: at most MAX_AUDIT_ENTRIES rows are kept. Each append drops the one
+//     row that just fell out of the window (a single delete), so the live set
+//     stays the most-recent MAX_AUDIT_ENTRIES with O(1) work per append.
+//   - by AGE: rows older than AUDIT_MAX_AGE_MS are swept on append AND on list, a
+//     bounded batch at a time from the oldest key forward (ascending order means
+//     the first non-expired row ends the sweep).
+//
+// Cloudflare storage APIs relied on (developers.cloudflare.com, Durable Objects
+// Storage API): storage.list(options) returns a Map in ascending UTF-8 key order
+// and honors { prefix, limit, reverse, end } where `end` is EXCLUSIVE, and that
+// is what makes newest-first pagination a reverse-listing bounded by the cursor key;
+// storage.transaction(closure) commits its body atomically, and on the SQLite
+// backend operations performed directly on ctx.storage inside the closure are
+// part of the transaction. The core never throws for control flow inside a
+// transaction, so it never depends on transaction rollback.
+
+/** The counter key holding the last-used audit sequence number. */
+export const AUDIT_SEQ_KEY = 'audit:seq';
+
+/** The shared prefix every audit row key carries (kept distinct from the counter). */
+export const AUDIT_ENTRY_PREFIX = 'audit:entry:';
+
+/** Count-based retention: keep at most this many of the most recent rows. */
+export const MAX_AUDIT_ENTRIES = 10_000;
+
+/** Age-based retention: rows older than this (~1 year) are pruned on append/list. */
+export const AUDIT_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Zero-pad width for the seq in a row key, so lexicographic order == numeric order. */
+const AUDIT_SEQ_PAD = 16;
+
+/** Bounded number of oldest rows examined per age-prune sweep. */
+const AUDIT_AGE_PRUNE_BATCH = 32;
+
+/** Pagination clamp for the audit list. */
+export const AUDIT_LIST_MIN_LIMIT = 1;
+export const AUDIT_LIST_MAX_LIMIT = 200;
+export const AUDIT_LIST_DEFAULT_LIMIT = 50;
+
+/** The storage key for one audit row at a given sequence number. */
+export function auditEntryKey(seq: number): string {
+  return `${AUDIT_ENTRY_PREFIX}${String(seq).padStart(AUDIT_SEQ_PAD, '0')}`;
+}
+
+export type AuditOutcome = 'success' | 'denied';
+
+/** One immutable audit row. `before`/`after` are event-shaped snapshots (nullable). */
+export interface AuditEntry {
+  seq: number;
+  ts: string;
+  actorId: string;
+  actorEmail: string;
+  action: string;
+  targetId: string;
+  before: unknown;
+  after: unknown;
+  outcome: AuditOutcome;
+}
+
+/** What a caller supplies to record one event; seq/ts are assigned on append. */
+export interface AuditEventInput {
+  action: string;
+  actorId: string;
+  actorEmail: string;
+  targetId: string;
+  before?: unknown;
+  after?: unknown;
+  outcome: AuditOutcome;
+}
+
+/** Options for a newest-first page of audit rows. */
+export interface AuditListOptions {
+  /** Opaque continuation from a previous page (the seq to read strictly below). */
+  cursor?: string;
+  /** Clamped to [AUDIT_LIST_MIN_LIMIT, AUDIT_LIST_MAX_LIMIT], default AUDIT_LIST_DEFAULT_LIMIT. */
+  limit?: number;
+  /** Inclusive lower bound on ts (ISO). */
+  from?: string;
+  /** Inclusive upper bound on ts (ISO). */
+  to?: string;
+}
+
+/** A newest-first page plus the cursor to fetch the next (older) page, if any. */
+export interface AuditListPage {
+  entries: AuditEntry[];
+  nextCursor?: string;
+}
+
+function clampAuditLimit(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return AUDIT_LIST_DEFAULT_LIMIT;
+  return Math.min(AUDIT_LIST_MAX_LIMIT, Math.max(AUDIT_LIST_MIN_LIMIT, Math.floor(value)));
+}
+
+/** A cursor is the decimal seq to continue strictly below; anything else means "from newest". */
+function decodeAuditCursor(cursor: string | undefined): number | undefined {
+  if (cursor === undefined) return undefined;
+  const n = Number(cursor);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Append one audit row, assign its sequence, and prune. MUST run inside a
+ * transaction supplied by the caller (a mutation's own transaction, or a
+ * standalone transaction for an observational event), so the seq read, the row
+ * write, the counter bump, and the pruning all commit together.
+ */
+export async function appendAuditRow(storage: PolicyStorage, input: AuditEventInput): Promise<AuditEntry> {
+  const seq = ((await storage.get<number>(AUDIT_SEQ_KEY)) ?? 0) + 1;
+  const entry: AuditEntry = {
+    seq,
+    ts: new Date().toISOString(),
+    actorId: input.actorId,
+    actorEmail: input.actorEmail,
+    action: input.action,
+    targetId: input.targetId,
+    before: input.before ?? null,
+    after: input.after ?? null,
+    outcome: input.outcome,
+  };
+  await storage.put(auditEntryKey(seq), entry);
+  await storage.put(AUDIT_SEQ_KEY, seq);
+  // Count-based retention: drop the single row that just fell out of the window.
+  if (seq > MAX_AUDIT_ENTRIES) {
+    await storage.delete(auditEntryKey(seq - MAX_AUDIT_ENTRIES));
+  }
+  await pruneAuditByAge(storage, Date.now());
+  return entry;
+}
+
+/** Sweep a bounded batch of the oldest rows, deleting those past the age cutoff. */
+async function pruneAuditByAge(storage: PolicyStorage, nowMs: number): Promise<void> {
+  const cutoff = new Date(nowMs - AUDIT_MAX_AGE_MS).toISOString();
+  const oldest = await storage.list<AuditEntry>({ prefix: AUDIT_ENTRY_PREFIX, limit: AUDIT_AGE_PRUNE_BATCH });
+  for (const [key, entry] of oldest) {
+    // Ascending order: the first row that is not expired ends the sweep.
+    if (!entry || entry.ts >= cutoff) break;
+    await storage.delete(key);
+  }
+}
+
+/**
+ * Read a newest-first page of audit rows, applying optional ts bounds and the
+ * cursor. Also opportunistically age-prunes. Pulls descending chunks and refills
+ * across the `to`/`from` filter so a page is never short because filtered rows
+ * sat at the top; because ts is non-decreasing with seq, a row older than `from`
+ * ends the scan.
+ */
+export async function readAuditPage(storage: PolicyStorage, options: AuditListOptions): Promise<AuditListPage> {
+  await pruneAuditByAge(storage, Date.now());
+  const limit = clampAuditLimit(options.limit);
+  const { from, to } = options;
+  const chunk = limit + 1;
+  const collected: AuditEntry[] = [];
+  let endExclusiveSeq = decodeAuditCursor(options.cursor);
+  let done = false;
+
+  while (!done && collected.length <= limit) {
+    const listOptions: PolicyListOptions = { prefix: AUDIT_ENTRY_PREFIX, reverse: true, limit: chunk };
+    if (endExclusiveSeq !== undefined) listOptions.end = auditEntryKey(endExclusiveSeq);
+    const page = await storage.list<AuditEntry>(listOptions);
+    if (page.size === 0) break;
+
+    let smallestSeq = Number.POSITIVE_INFINITY;
+    for (const entry of page.values()) {
+      if (entry.seq < smallestSeq) smallestSeq = entry.seq;
+      if (to !== undefined && entry.ts > to) continue;
+      if (from !== undefined && entry.ts < from) {
+        done = true;
+        break;
+      }
+      collected.push(entry);
+      if (collected.length > limit) break;
+    }
+    if (page.size < chunk) break; // storage exhausted
+    endExclusiveSeq = smallestSeq; // continue strictly below the smallest seq seen
+  }
+
+  const hasMore = collected.length > limit;
+  const entries = collected.slice(0, limit);
+  const nextCursor = hasMore ? String(entries[entries.length - 1].seq) : undefined;
+  return { entries, nextCursor };
+}
+
+/**
+ * Read the full audit range (bounded by retention) in ascending, chronological
+ * order for an evidence export. Retention caps the row count, so listing the
+ * whole prefix is bounded.
+ */
+export async function readAuditRange(
+  storage: PolicyStorage,
+  options: { from?: string; to?: string } = {},
+): Promise<AuditEntry[]> {
+  const { from, to } = options;
+  const all = await storage.list<AuditEntry>({ prefix: AUDIT_ENTRY_PREFIX });
+  const out: AuditEntry[] = [];
+  for (const entry of all.values()) {
+    if (from !== undefined && entry.ts < from) continue;
+    if (to !== undefined && entry.ts > to) continue;
+    out.push(entry);
+  }
+  return out;
+}
+
+/** List every stored user policy document (normalized), keyed by hsUserId. */
+export async function listUserPolicyDocs(
+  storage: PolicyStorage,
+): Promise<Array<{ hsUserId: string; policy: UserPolicy }>> {
+  const all = await storage.list<Partial<UserPolicy>>({ prefix: USER_POLICY_PREFIX });
+  const out: Array<{ hsUserId: string; policy: UserPolicy }> = [];
+  for (const [key, raw] of all) {
+    out.push({ hsUserId: key.slice(USER_POLICY_PREFIX.length), policy: normalizeUserPolicy(raw) });
+  }
+  return out;
+}
+
+/** One row of the current-entitlements evidence export. */
+export interface AccessListRow {
+  hsUserId: string;
+  email: string;
+  allowed: boolean;
+  writes: boolean;
+  customerVisibleWrites: boolean;
+  /** Admission decision under the current config (allowlist mode + explicit block). */
+  effectiveAllowed: boolean;
+  /** Write flag after intersecting the user grant with the deployment ceiling. */
+  effectiveWrites: boolean;
+  /** Customer-visible write flag after the same intersection. */
+  effectiveCustomerVisibleWrites: boolean;
+  updatedAt: string;
+  updatedBy: string;
+  version: number;
+}
+
+/**
+ * Compute the current effective entitlements for every user policy, under the
+ * deployment config and the env write ceiling. `effectiveAllowed` is the real
+ * admission decision (evaluateAccess); the write flags are narrowed to the
+ * ceiling (effectiveWriteFlags). Sorted by hsUserId for a stable export.
+ */
+export function buildAccessListRows(
+  config: AdminConfig,
+  ceiling: WriteFlagSet,
+  users: Array<{ hsUserId: string; policy: UserPolicy }>,
+): AccessListRow[] {
+  return users
+    .map(({ hsUserId, policy }) => {
+      const effective = effectiveWriteFlags(ceiling, policy);
+      return {
+        hsUserId,
+        email: policy.email,
+        allowed: policy.allowed,
+        writes: policy.writes,
+        customerVisibleWrites: policy.customerVisibleWrites,
+        effectiveAllowed: evaluateAccess(config, policy).allowed,
+        effectiveWrites: effective.enabled,
+        effectiveCustomerVisibleWrites: effective.customerVisibleEnabled,
+        updatedAt: policy.updatedAt,
+        updatedBy: policy.updatedBy,
+        version: policy.version,
+      };
+    })
+    .sort((a, b) => (a.hsUserId < b.hsUserId ? -1 : a.hsUserId > b.hsUserId ? 1 : 0));
+}
+
+/** RFC-4180 field quoting: wrap in quotes and double any embedded quote when needed. */
+function csvCell(value: unknown): string {
+  const s = value === null || value === undefined ? '' : typeof value === 'string' ? value : String(value);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+/** Build an RFC-4180 CSV (CRLF line breaks, quoted fields) from a header + rows. */
+export function toCsv(headers: string[], rows: unknown[][]): string {
+  const lines = [headers.map(csvCell).join(',')];
+  for (const row of rows) lines.push(row.map(csvCell).join(','));
+  return lines.join('\r\n');
+}
+
+export const AUDIT_CSV_HEADERS = [
+  'seq',
+  'ts',
+  'actorId',
+  'actorEmail',
+  'action',
+  'targetId',
+  'before',
+  'after',
+  'outcome',
+] as const;
+
+/** Serialize audit rows to CSV; before/after are JSON so commas/quotes get quoted. */
+export function auditEntriesToCsv(entries: AuditEntry[]): string {
+  return toCsv(
+    [...AUDIT_CSV_HEADERS],
+    entries.map((e) => [
+      e.seq,
+      e.ts,
+      e.actorId,
+      e.actorEmail,
+      e.action,
+      e.targetId,
+      e.before === null || e.before === undefined ? '' : JSON.stringify(e.before),
+      e.after === null || e.after === undefined ? '' : JSON.stringify(e.after),
+      e.outcome,
+    ]),
+  );
+}
+
+export const ACCESS_LIST_CSV_HEADERS = [
+  'hsUserId',
+  'email',
+  'allowed',
+  'writes',
+  'customerVisibleWrites',
+  'effectiveAllowed',
+  'effectiveWrites',
+  'effectiveCustomerVisibleWrites',
+  'updatedAt',
+  'updatedBy',
+  'version',
+] as const;
+
+/** Serialize access-list rows to CSV. */
+export function accessListToCsv(rows: AccessListRow[]): string {
+  return toCsv(
+    [...ACCESS_LIST_CSV_HEADERS],
+    rows.map((r) => [
+      r.hsUserId,
+      r.email,
+      r.allowed,
+      r.writes,
+      r.customerVisibleWrites,
+      r.effectiveAllowed,
+      r.effectiveWrites,
+      r.effectiveCustomerVisibleWrites,
+      r.updatedAt,
+      r.updatedBy,
+      r.version,
+    ]),
+  );
 }

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -379,8 +379,26 @@ export async function writeConfigDoc(
 }
 
 /** Delete the config document (harness/admin seam). Absence reads as open-mode defaults. */
-export async function clearConfigDoc(storage: PolicyStorage): Promise<void> {
-  await storage.delete(ADMIN_CONFIG_KEY);
+export async function clearConfigDoc(storage: PolicyStorage, meta?: MutationMeta): Promise<void> {
+  // Record the deletion so the ledger has no hole: capture the removed document
+  // as `before`, delete it, and append the row in one transaction.
+  await storage.transaction(async () => {
+    const before = (await storage.get<Partial<AdminConfig>>(ADMIN_CONFIG_KEY)) ?? null;
+    await storage.delete(ADMIN_CONFIG_KEY);
+    // Only record a deletion of something that existed: deleting an absent
+    // document is a no-op and must not fabricate a phantom ledger entry.
+    if (before !== null) {
+      await appendAuditRow(storage, {
+        action: 'config.deleted',
+        actorId: meta?.updatedBy ?? '',
+        actorEmail: meta?.actorEmail ?? '',
+        targetId: ADMIN_CONFIG_KEY,
+        before: before as Record<string, unknown>,
+        after: null,
+        outcome: 'success',
+      });
+    }
+  });
 }
 
 // --- User policy ----------------------------------------------------------
@@ -488,8 +506,28 @@ export async function writeUserPolicyDoc(
 }
 
 /** Delete one user's policy document (harness/admin seam). */
-export async function clearUserPolicyDoc(storage: PolicyStorage, hsUserId: string | number): Promise<void> {
-  await storage.delete(userPolicyKey(String(hsUserId)));
+export async function clearUserPolicyDoc(
+  storage: PolicyStorage,
+  hsUserId: string | number,
+  meta?: MutationMeta,
+): Promise<void> {
+  const id = String(hsUserId);
+  await storage.transaction(async () => {
+    const before = (await storage.get<Partial<UserPolicy>>(userPolicyKey(id))) ?? null;
+    await storage.delete(userPolicyKey(id));
+    // Only record a deletion of something that existed (see clearConfigDoc).
+    if (before !== null) {
+      await appendAuditRow(storage, {
+        action: 'user.policy.deleted',
+        actorId: meta?.updatedBy ?? '',
+        actorEmail: meta?.actorEmail ?? '',
+        targetId: id,
+        before: before as Record<string, unknown>,
+        after: null,
+        outcome: 'success',
+      });
+    }
+  });
 }
 
 /**
@@ -765,7 +803,11 @@ async function pruneAuditByAge(storage: PolicyStorage, nowMs: number): Promise<v
 export async function readAuditPage(storage: PolicyStorage, options: AuditListOptions): Promise<AuditListPage> {
   await pruneAuditByAge(storage, Date.now());
   const limit = clampAuditLimit(options.limit);
-  const { from, to } = options;
+  // Enforce the retention floor on the result regardless of the bounded sweep,
+  // so a listing never surfaces a record past the one-year window.
+  const floor = new Date(Date.now() - AUDIT_MAX_AGE_MS).toISOString();
+  const from = options.from !== undefined && options.from > floor ? options.from : floor;
+  const { to } = options;
   const chunk = limit + 1;
   const collected: AuditEntry[] = [];
   let endExclusiveSeq = decodeAuditCursor(options.cursor);
@@ -807,11 +849,19 @@ export async function readAuditRange(
   storage: PolicyStorage,
   options: { from?: string; to?: string } = {},
 ): Promise<AuditEntry[]> {
-  const { from, to } = options;
+  await pruneAuditByAge(storage, Date.now());
+  // The retention floor is enforced on the RESULT, not just via the opportunistic
+  // sweep (which is bounded per call): an export must never hand back a record
+  // older than the one-year window we promise to have discarded, even if the
+  // sweep has not yet reached it. The effective lower bound is the later of the
+  // caller's `from` and the retention floor.
+  const floor = new Date(Date.now() - AUDIT_MAX_AGE_MS).toISOString();
+  const from = options.from !== undefined && options.from > floor ? options.from : floor;
+  const { to } = options;
   const all = await storage.list<AuditEntry>({ prefix: AUDIT_ENTRY_PREFIX });
   const out: AuditEntry[] = [];
   for (const entry of all.values()) {
-    if (from !== undefined && entry.ts < from) continue;
+    if (entry.ts < from) continue;
     if (to !== undefined && entry.ts > to) continue;
     out.push(entry);
   }
@@ -879,9 +929,18 @@ export function buildAccessListRows(
     .sort((a, b) => (a.hsUserId < b.hsUserId ? -1 : a.hsUserId > b.hsUserId ? 1 : 0));
 }
 
-/** RFC-4180 field quoting: wrap in quotes and double any embedded quote when needed. */
+/**
+ * RFC-4180 field quoting, plus spreadsheet formula-injection neutralization.
+ * A cell whose text begins with =, +, -, @, or a tab/CR is treated by Excel and
+ * Google Sheets as a formula, so a value like `=cmd|...` in a user-controlled
+ * field (email, updatedBy, the before/after JSON) could execute when an operator
+ * opens the evidence export. Prefix such a cell with a single quote, which those
+ * tools render as a leading text marker and strip on display, before applying
+ * normal RFC-4180 quoting.
+ */
 function csvCell(value: unknown): string {
-  const s = value === null || value === undefined ? '' : typeof value === 'string' ? value : String(value);
+  let s = value === null || value === undefined ? '' : typeof value === 'string' ? value : String(value);
+  if (s.length > 0 && /^[=+\-@\t\r]/.test(s)) s = `'${s}`;
   return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/worker/src/test-policy-route.ts
+++ b/worker/src/test-policy-route.ts
@@ -4,9 +4,11 @@
  * The worker has no admin API yet (NAS-1503), and `wrangler dev` exposes no way
  * to reach into the coordinator DO's storage mid-run, so the smoke suite needs an
  * in-process seam to seed the config/policy documents and to drive revokeUser.
- * This route provides exactly that and NOTHING else: it is mounted only when
- * HELPSCOUT_TEST_POLICY_ROUTES === "true", which the deployment template never
- * sets and the smoke asserts is absent by default (the route 404s without it).
+ * This route provides exactly that and NOTHING else. It is gated by a SECRET,
+ * never a boolean: HELPSCOUT_TEST_POLICY_ROUTES holds a long random key (not the
+ * literal "true", which the mount guard rejects), and a request must present
+ * that exact key in the X-Test-Policy-Key header. The deployment template never
+ * sets the var, and the smoke asserts the route 404s without a valid key.
  *
  * It is a thin dispatch over the same exported policy functions the real admin
  * API will call, so it exercises the production seams (which now RPC the

--- a/worker/src/test-policy-route.ts
+++ b/worker/src/test-policy-route.ts
@@ -24,6 +24,7 @@ import {
   putUserPolicy,
   revokeUser,
 } from './policy-store.js';
+import { exportAccessList, exportAuditLog, listAuditEntries } from './audit-store.js';
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -40,6 +41,12 @@ interface TestCommand {
   input?: UserPolicyInput;
   expectedVersion?: number;
   updatedBy?: string;
+  // Audit read/export parameters (NAS-1502).
+  cursor?: string;
+  limit?: number;
+  from?: string;
+  to?: string;
+  format?: 'json' | 'csv';
 }
 
 export async function handleTestPolicyRoute(request: Request, env: Env): Promise<Response> {
@@ -86,6 +93,19 @@ export async function handleTestPolicyRoute(request: Request, env: Env): Promise
       }
       case 'revokeUser':
         return json({ result: await revokeUser(env, String(command.hsUserId), { updatedBy }) });
+      case 'auditList':
+        return json({
+          page: await listAuditEntries(env, {
+            cursor: command.cursor,
+            limit: command.limit,
+            from: command.from,
+            to: command.to,
+          }),
+        });
+      case 'auditExport':
+        return json({ export: await exportAuditLog(env, { from: command.from, to: command.to, format: command.format ?? 'json' }) });
+      case 'accessListExport':
+        return json({ export: await exportAccessList(env, { format: command.format ?? 'json' }) });
       default:
         return json({ error: `Unknown op: ${command.op}` }, 400);
     }


### PR DESCRIPTION
## What

The audit and evidence layer for self-hosted access management (parent NAS-1500), building on the NAS-1501 coordinator.

**Ledger.** An append-only audit log lives in the policy coordinator's own transactional storage, extending the existing Durable Object rather than adding a new class (so upgrading operators face no new binding to hand-add). Every mutation row commits in the same transaction as the document change it describes: config and user-policy updates carry before/after, a stale-version attempt writes exactly one denied conflict row and nothing else (the conflict error is thrown after commit, so nothing relies on rollback semantics), and a hard revoke records the pinned policy. Grant creation and admission denials are appended from the callback handler as best-effort observational rows that never fail the user-facing flow. Sequence numbers are monotonic (zero-padded keys make key order equal event order); retention prunes by count (10,000) and age (one year) on append and read.

**Evidence surface** (plain functions the NAS-1503 GUI will expose behind its admin session):
- newest-first paginated audit list (cursor, clamped limit, date bounds)
- dated audit export, JSON or RFC-4180 CSV, stamped with generation time and a stable deployment id derived from the coordinator DO id
- an effective-entitlements access list: every stored user policy evaluated against the deployment config and the env write ceiling, with stored grants, effective flags, and provenance

These are the artifacts a SOC 2 / ISO-minded reviewer actually asks for (who has access, who changed it, when, prove it), as downloads rather than dashboards.

The secret-gated test route gains read ops (auditList / auditExport / accessListExport) so the smoke can drive the full path; its 404-invisible semantics are unchanged.

## Verification

- 20 new unit tests (root suite 655 passing, known local-.env case aside): atomic recording including conflict-writes-only-a-row, sequence monotonicity under concurrent writers, both retention sweeps, pagination boundaries, CSV quoting with comma/quote/newline, and ceiling-narrowed effective flags, against a shared in-memory transactional fake now used by both worker suites.
- Smoke grows 98 to 117 checks: an ordered-subsequence assertion over the ledger (config.updated, user.policy.updated, user.revoked, admission.denied, grant.created with correct actors and targets), conflict-row presence from the concurrent-CAS section, JSON export shape (generatedAt, deploymentId, entries), CSV header and quoting, and the access list showing seeded and revoked users with correct effective flags.
- Type-check, lint, worker tsc clean; all runs performed directly, not inherited.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->