### PR TITLE
feat(NAS-1503): self-hosted admin console for access management

### DIFF
--- a/guides/remote-self-host.md
+++ b/guides/remote-self-host.md
@@ -253,6 +253,28 @@ role cannot write to a mailbox gets a structured permission error. The full rule
 (confirmation envelope, dry-run) are in the
 [write tool contract](architecture/mcp-tool-contract.md#write-tool-contract).
 
+## The admin console
+
+An Owner (or an Administrator, when the deployment sets its admin role to
+`administrator`) can manage access at `https://<worker-url>/admin`. Signing in
+runs the same Help Scout login as a normal connection, but the console never
+stores your Help Scout token: it reads your identity and the account roster once
+at login, then holds only a short-lived signed session cookie. From there you can
+allow or block individual users, set each person's write tier up to the
+deployment ceiling, toggle allowlist mode, and download the audit log and access
+list as evidence.
+
+**Security note on the admin session and role changes.** Admin console sessions
+last one hour. A change to the deployment admin-role setting takes effect
+immediately, on the next request. A demotion made in Help Scout itself (for
+example dropping someone from Owner to User) is reflected in the admin console
+within at most one hour: the session captures the Help Scout role at login and
+the console does not re-read it from Help Scout on every request (it keeps no
+stored token to do so), so the demotion is picked up when the session expires and
+re-login re-reads the live role. This is separate from a user's MCP access, which
+the policy engine revokes immediately: blocking or revoking a user in the console
+denies their connector on the very next request regardless of any session.
+
 ## How tokens and sessions behave
 
 - Help Scout access tokens last about 48 hours. The token the worker issues to your

--- a/src/__tests__/worker-admin-auth.test.ts
+++ b/src/__tests__/worker-admin-auth.test.ts
@@ -190,13 +190,15 @@ describe('buildRoster merge', () => {
   ];
   const ceiling: WriteFlagSet = { enabled: true, customerVisibleEnabled: false };
 
+  const allProbed = (dir: DirectoryUser[]): Set<string> => new Set(dir.map((u) => u.hsUserId));
+
   it('merges policy + grant state, flags light users, and sorts by email', () => {
     const policies = new Map<string, UserPolicy>([
       ['20', policy({ allowed: false, version: 2 })],
       ['40', policy({ allowed: true, writes: true, customerVisibleWrites: true, version: 5 })],
     ]);
     const connected = new Set<string>(['10']);
-    const rows = buildRoster(directory, policies, connected, config(), ceiling);
+    const rows = buildRoster(directory, policies, connected, allProbed(directory), config(), ceiling);
 
     // Sorted by email: blocked, light, owner, writer.
     expect(rows.map((r) => r.hsUserId)).toEqual(['20', '30', '10', '40']);
@@ -204,6 +206,7 @@ describe('buildRoster merge', () => {
     const owner = rows.find((r) => r.hsUserId === '10')!;
     expect(owner.policyState).toBe('open-default');
     expect(owner.connected).toBe(true);
+    expect(owner.connectionProbed).toBe(true);
     expect(owner.writeTier).toBe('writes'); // open-default inherits the ceiling cap
     expect(owner.version).toBe(0);
 
@@ -224,8 +227,29 @@ describe('buildRoster merge', () => {
   });
 
   it('reflects allowlist admission in effectiveAllowed', () => {
-    const rows = buildRoster(directory, new Map(), new Set(), config({ allowlistMode: true }), ceiling);
+    const rows = buildRoster(directory, new Map(), new Set(), allProbed(directory), config({ allowlistMode: true }), ceiling);
     // In allowlist mode, an unconfigured user is not admitted.
     expect(rows.every((r) => r.effectiveAllowed === false)).toBe(true);
+  });
+
+  it('represents an unprobed user honestly instead of reporting them disconnected', () => {
+    // Only user 10 was probed (and found connected); user 40 was probed but has
+    // no grant; users 20 and 30 were NOT probed at all (over the cap).
+    const connected = new Set<string>(['10']);
+    const probed = new Set<string>(['10', '40']);
+    const rows = buildRoster(directory, new Map(), connected, probed, config(), ceiling);
+
+    const probedConnected = rows.find((r) => r.hsUserId === '10')!;
+    expect(probedConnected.connectionProbed).toBe(true);
+    expect(probedConnected.connected).toBe(true);
+
+    const probedDisconnected = rows.find((r) => r.hsUserId === '40')!;
+    expect(probedDisconnected.connectionProbed).toBe(true);
+    expect(probedDisconnected.connected).toBe(false);
+
+    // Not probed: connected is null (unknown), never a misleading false.
+    const unprobed = rows.find((r) => r.hsUserId === '20')!;
+    expect(unprobed.connectionProbed).toBe(false);
+    expect(unprobed.connected).toBeNull();
   });
 });

--- a/src/__tests__/worker-admin-auth.test.ts
+++ b/src/__tests__/worker-admin-auth.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit coverage for the admin surface's pure authorization logic (NAS-1503).
+ *
+ * The highest-value pieces are exercised here in CI against injected inputs: the
+ * role gate (which decides whether a demoted admin keeps access), the CSRF check,
+ * the signed admin session round-trip, and the roster merge + write-tier ceiling
+ * logic. The HTTP wiring and the full admin login are exercised by the worker
+ * smoke suite, which drives the real handler and coordinator DO.
+ */
+import {
+  ADMIN_SESSION_COOKIE_NAME,
+  buildAdminSessionSetCookie,
+  buildRoster,
+  ceilingTierCap,
+  csrfTokensMatch,
+  parseHelpScoutRole,
+  policyInputFromTier,
+  roleSatisfiesAdmin,
+  signAdminSession,
+  signAdminState,
+  tierFromPolicy,
+  tierWithinCeiling,
+  verifyAdminSession,
+  verifyAdminState,
+  type AdminSession,
+} from '../../worker/src/admin-auth.js';
+import type { AdminConfig, DirectoryUser, UserPolicy, WriteFlagSet } from '../../worker/src/policy.js';
+
+const SECRET = 'admin-cookie-signing-secret-for-tests';
+
+const config = (over: Partial<AdminConfig> = {}): AdminConfig => ({
+  schemaVersion: 1,
+  allowlistMode: false,
+  adminRole: 'owner',
+  policyCacheTtlSeconds: 45,
+  version: 3,
+  updatedAt: '2026-07-31T00:00:00Z',
+  updatedBy: 'admin',
+  ...over,
+});
+
+const policy = (over: Partial<UserPolicy> = {}): UserPolicy => ({
+  v: 1,
+  allowed: true,
+  writes: false,
+  customerVisibleWrites: false,
+  email: 'user@example.test',
+  updatedAt: '2026-07-31T00:00:00Z',
+  updatedBy: 'admin',
+  version: 1,
+  ...over,
+});
+
+const session = (over: Partial<AdminSession> = {}): AdminSession => ({
+  hsUserId: '987',
+  email: 'owner@example.test',
+  role: 'Owner',
+  csrf: 'csrf-token-abc',
+  ...over,
+});
+
+describe('roleSatisfiesAdmin (the demotion gate)', () => {
+  it('always admits an Owner', () => {
+    expect(roleSatisfiesAdmin('Owner', 'owner')).toBe(true);
+    expect(roleSatisfiesAdmin('Owner', 'administrator')).toBe(true);
+  });
+
+  it('admits an Administrator only when the config opens the role to administrators', () => {
+    expect(roleSatisfiesAdmin('Administrator', 'administrator')).toBe(true);
+    // The demotion case: an Administrator loses access the moment adminRole drops to owner.
+    expect(roleSatisfiesAdmin('Administrator', 'owner')).toBe(false);
+  });
+
+  it('never admits a plain User or a Light user', () => {
+    expect(roleSatisfiesAdmin('User', 'administrator')).toBe(false);
+    expect(roleSatisfiesAdmin('Light', 'administrator')).toBe(false);
+  });
+});
+
+describe('csrfTokensMatch', () => {
+  it('matches only an exact, non-empty pair', () => {
+    expect(csrfTokensMatch('abc123', 'abc123')).toBe(true);
+    expect(csrfTokensMatch('abc123', 'abc124')).toBe(false);
+    expect(csrfTokensMatch('abc123', 'abc12')).toBe(false);
+  });
+
+  it('rejects a missing or empty submitted token', () => {
+    expect(csrfTokensMatch('abc123', null)).toBe(false);
+    expect(csrfTokensMatch('abc123', undefined)).toBe(false);
+    expect(csrfTokensMatch('abc123', '')).toBe(false);
+    expect(csrfTokensMatch('', 'abc123')).toBe(false);
+  });
+});
+
+describe('admin session cookie', () => {
+  it('round-trips a session and its expiry', async () => {
+    const exp = Date.now() + 60_000;
+    const cookie = await signAdminSession(session(), exp, SECRET);
+    const decoded = await verifyAdminSession(cookie, SECRET);
+    expect(decoded?.session).toEqual(session());
+    expect(decoded?.exp).toBe(exp);
+  });
+
+  it('rejects a session signed with a different secret', async () => {
+    const cookie = await signAdminSession(session(), Date.now() + 60_000, 'other-secret');
+    expect(await verifyAdminSession(cookie, SECRET)).toBeNull();
+  });
+
+  it('rejects an expired session', async () => {
+    const cookie = await signAdminSession(session(), Date.now() - 1, SECRET);
+    expect(await verifyAdminSession(cookie, SECRET)).toBeNull();
+  });
+
+  it('rejects a decoded-but-malformed payload (no csrf)', async () => {
+    // Sign a session missing its csrf and confirm the shape guard refuses it.
+    const bad = await signAdminSession({ hsUserId: '1', email: 'x', role: 'Owner', csrf: '' } as AdminSession, Date.now() + 60_000, SECRET);
+    expect(await verifyAdminSession(bad, SECRET)).toBeNull();
+  });
+
+  it('mints an HttpOnly, Secure, Lax, /admin-scoped cookie', () => {
+    const header = buildAdminSessionSetCookie('value');
+    expect(header).toContain(`${ADMIN_SESSION_COOKIE_NAME}=value`);
+    expect(header).toContain('HttpOnly');
+    expect(header).toContain('Secure');
+    expect(header).toContain('SameSite=Lax');
+    expect(header).toContain('Path=/admin');
+  });
+});
+
+describe('admin login state cookie', () => {
+  it('round-trips the bound state nonce', async () => {
+    const cookie = await signAdminState('state-nonce-1', Date.now() + 60_000, SECRET);
+    expect(await verifyAdminState(cookie, SECRET)).toBe('state-nonce-1');
+  });
+
+  it('rejects a tampered or expired state cookie', async () => {
+    expect(await verifyAdminState(await signAdminState('s', Date.now() - 1, SECRET), SECRET)).toBeNull();
+    expect(await verifyAdminState('garbage', SECRET)).toBeNull();
+    expect(await verifyAdminState(undefined, SECRET)).toBeNull();
+  });
+});
+
+describe('parseHelpScoutRole', () => {
+  it('maps role/type strings case-insensitively', () => {
+    expect(parseHelpScoutRole('Owner')).toBe('Owner');
+    expect(parseHelpScoutRole('administrator')).toBe('Administrator');
+    expect(parseHelpScoutRole('admin')).toBe('Administrator');
+    expect(parseHelpScoutRole('user')).toBe('User');
+    expect(parseHelpScoutRole('user', 'light')).toBe('Light');
+    expect(parseHelpScoutRole('light')).toBe('Light');
+    expect(parseHelpScoutRole(undefined)).toBe('User');
+  });
+});
+
+describe('write-tier ceiling logic', () => {
+  it('derives the tier a policy grants', () => {
+    expect(tierFromPolicy(null)).toBe('none');
+    expect(tierFromPolicy(policy())).toBe('none');
+    expect(tierFromPolicy(policy({ writes: true }))).toBe('writes');
+    expect(tierFromPolicy(policy({ writes: true, customerVisibleWrites: true }))).toBe('writes+customerVisible');
+  });
+
+  it('caps the grantable tier at the deployment ceiling', () => {
+    expect(ceilingTierCap({ enabled: false, customerVisibleEnabled: false })).toBe('none');
+    expect(ceilingTierCap({ enabled: true, customerVisibleEnabled: false })).toBe('writes');
+    expect(ceilingTierCap({ enabled: true, customerVisibleEnabled: true })).toBe('writes+customerVisible');
+  });
+
+  it('rejects a tier above the ceiling (fail closed)', () => {
+    const writesOnly: WriteFlagSet = { enabled: true, customerVisibleEnabled: false };
+    expect(tierWithinCeiling('writes', writesOnly)).toBe(true);
+    expect(tierWithinCeiling('writes+customerVisible', writesOnly)).toBe(false);
+    const readOnly: WriteFlagSet = { enabled: false, customerVisibleEnabled: false };
+    expect(tierWithinCeiling('writes', readOnly)).toBe(false);
+  });
+
+  it('maps a tier back into a policy input, raising writes for customer-visible', () => {
+    expect(policyInputFromTier(true, 'none')).toEqual({ allowed: true, writes: false, customerVisibleWrites: false, email: undefined });
+    expect(policyInputFromTier(true, 'writes')).toEqual({ allowed: true, writes: true, customerVisibleWrites: false, email: undefined });
+    expect(policyInputFromTier(false, 'writes+customerVisible')).toEqual({ allowed: false, writes: true, customerVisibleWrites: true, email: undefined });
+  });
+});
+
+describe('buildRoster merge', () => {
+  const directory: DirectoryUser[] = [
+    { hsUserId: '10', email: 'owner@example.test', name: 'Owner One', role: 'Owner' },
+    { hsUserId: '20', email: 'blocked@example.test', name: 'Blocked Two', role: 'User' },
+    { hsUserId: '30', email: 'light@example.test', name: 'Light Three', role: 'Light' },
+    { hsUserId: '40', email: 'writer@example.test', name: 'Writer Four', role: 'User' },
+  ];
+  const ceiling: WriteFlagSet = { enabled: true, customerVisibleEnabled: false };
+
+  it('merges policy + grant state, flags light users, and sorts by email', () => {
+    const policies = new Map<string, UserPolicy>([
+      ['20', policy({ allowed: false, version: 2 })],
+      ['40', policy({ allowed: true, writes: true, customerVisibleWrites: true, version: 5 })],
+    ]);
+    const connected = new Set<string>(['10']);
+    const rows = buildRoster(directory, policies, connected, config(), ceiling);
+
+    // Sorted by email: blocked, light, owner, writer.
+    expect(rows.map((r) => r.hsUserId)).toEqual(['20', '30', '10', '40']);
+
+    const owner = rows.find((r) => r.hsUserId === '10')!;
+    expect(owner.policyState).toBe('open-default');
+    expect(owner.connected).toBe(true);
+    expect(owner.writeTier).toBe('writes'); // open-default inherits the ceiling cap
+    expect(owner.version).toBe(0);
+
+    const blocked = rows.find((r) => r.hsUserId === '20')!;
+    expect(blocked.policyState).toBe('blocked');
+    expect(blocked.effectiveAllowed).toBe(false);
+    expect(blocked.version).toBe(2);
+
+    const light = rows.find((r) => r.hsUserId === '30')!;
+    expect(light.eligible).toBe(false);
+
+    // Writer granted customer-visible, but the ceiling withholds it: configured
+    // tier reflects the grant, effective tier is narrowed to the ceiling.
+    const writer = rows.find((r) => r.hsUserId === '40')!;
+    expect(writer.writeTier).toBe('writes+customerVisible');
+    expect(writer.effectiveWriteTier).toBe('writes');
+    expect(writer.hasPolicy).toBe(true);
+  });
+
+  it('reflects allowlist admission in effectiveAllowed', () => {
+    const rows = buildRoster(directory, new Map(), new Set(), config({ allowlistMode: true }), ceiling);
+    // In allowlist mode, an unconfigured user is not admitted.
+    expect(rows.every((r) => r.effectiveAllowed === false)).toBe(true);
+  });
+});

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -8,9 +8,11 @@
 // localhost (the redirect URL is fixed at app registration), so the mock stands
 // in for it.
 //
-// Usage: node scripts/smoke.mjs            (runs read-only and write modes)
+// Usage: node scripts/smoke.mjs            (runs read-only, write, policy, admin)
 //        SMOKE_MODE=reads node scripts/smoke.mjs
 //        SMOKE_MODE=writes node scripts/smoke.mjs
+//        SMOKE_MODE=policy node scripts/smoke.mjs
+//        SMOKE_MODE=admin node scripts/smoke.mjs
 import crypto from 'node:crypto';
 import http from 'node:http';
 import { spawn } from 'node:child_process';
@@ -54,7 +56,19 @@ const b64url = (buf) =>
 // State is mutated directly from the smoke process (same runtime) to exercise
 // the light-user path and to observe refresh-token rotation.
 function startMockHelpScout() {
-  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0, issuedCodes: new Set(), userId: MOCK_USER.id, noteWrites: 0 };
+  // `role` backs /hs/users/me for the admin login (NAS-1503): the admin role gate
+  // requires Owner (or Administrator when configured). `userId` overrides the me
+  // identity so policy/admin tests can drive distinct users.
+  const state = { lightUser: false, refreshCount: 0, currentRefreshToken: null, accessCounter: 0, issuedCodes: new Set(), userId: MOCK_USER.id, role: 'owner', noteWrites: 0 };
+
+  // The account directory GET /v2/users returns for the admin roster. Includes a
+  // full agent and a Light user (ineligible for the Mailbox API). The signed-in
+  // admin id is injected so it always appears in its own roster.
+  const usersList = () => [
+    { id: state.userId, email: 'admin@example.test', firstName: 'Ada', lastName: 'Admin', role: 'owner' },
+    { id: 5001, email: 'agent@example.test', firstName: 'Grace', lastName: 'Agent', role: 'user' },
+    { id: 5002, email: 'light@example.test', firstName: 'Lee', lastName: 'Light', role: 'user', type: 'light' },
+  ];
 
   const readBody = (req) =>
     new Promise((resolve) => {
@@ -130,7 +144,16 @@ function startMockHelpScout() {
         return;
       }
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ ...MOCK_USER, id: state.userId }));
+      res.end(JSON.stringify({ ...MOCK_USER, id: state.userId, role: state.role }));
+      return;
+    }
+
+    // Account user directory for the admin roster (NAS-1503). Needs an admin's
+    // token; the mock accepts any bearer here, since the worker only reaches it
+    // after its own role gate has passed at /callback.
+    if (url.pathname === '/hs/users' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ _embedded: { users: usersList() }, page: { totalPages: 1 } }));
       return;
     }
 
@@ -830,10 +853,166 @@ async function runPolicyMode({ mock }) {
   check('access list shows the revoked user as not allowed', revokedRow?.allowed === false && revokedRow?.effectiveAllowed === false, JSON.stringify(revokedRow));
 }
 
+// --- Admin surface (NAS-1503) -----------------------------------------------
+// Runs against its own worker (writes enabled at the ceiling, customer-visible
+// off, so the tier control's top option is greyed and the server rejects it).
+// The admin session is minted by driving the full Help Scout dance through the
+// mock: GET /admin -> mock authorize -> /callback with the admin-state cookie ->
+// signed admin-session cookie. No test-only backdoor; the real handler runs.
+const ADMIN_SESSION_COOKIE = 'hs_admin_session';
+const ADMIN_STATE_COOKIE = 'hs_admin_state';
+
+// Drive the admin login. Returns { status, sessionCookie? }, a 302 with a
+// session cookie on success, or the terminal callback status when refused.
+async function adminLogin({ mock, role }) {
+  const prevRole = mock.state.role;
+  mock.state.role = role;
+  try {
+    const start = await fetch(`${BASE}/admin`, { redirect: 'manual' });
+    if (start.status !== 302) return { status: start.status, start };
+    const stateCookie = setCookieValues(start)[ADMIN_STATE_COOKIE];
+    const hsAuthorize = start.headers.get('location');
+    const hsRes = await fetch(hsAuthorize, { redirect: 'manual' });
+    const callbackUrl = hsRes.headers.get('location');
+    const cb = await fetch(callbackUrl, { redirect: 'manual', headers: { Cookie: `${ADMIN_STATE_COOKIE}=${stateCookie}` } });
+    const sessionCookie = setCookieValues(cb)[ADMIN_SESSION_COOKIE];
+    const body = cb.status === 302 ? '' : await cb.text();
+    return { status: cb.status, sessionCookie, start, body };
+  } finally {
+    mock.state.role = prevRole;
+  }
+}
+
+async function runAdminMode({ mock }) {
+  console.log(`\n=== mode: admin surface (${BASE}) ===\n`);
+  mock.state.role = 'owner';
+  mock.state.userId = MOCK_USER.id;
+
+  // The coordinator DO's storage persists across wrangler-dev sessions, so clear
+  // the documents this mode asserts on (via the secret-gated test route the smoke
+  // worker mounts) to keep the roster deterministic across re-runs.
+  await policyRoute({ op: 'del', target: 'config' });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 5001 });
+  await policyRoute({ op: 'del', target: 'user', hsUserId: 5002 });
+
+  // [A1] unauthenticated /admin starts the login dance, it does NOT serve the page.
+  console.log('[A1] unauthenticated /admin redirects to login');
+  const anon = await fetch(`${BASE}/admin`, { redirect: 'manual' });
+  check('GET /admin without a session is a 302 login start (not the console)', anon.status === 302, `status ${anon.status}`);
+  check('the login start sets an admin-state cookie', typeof setCookieValues(anon)[ADMIN_STATE_COOKIE] === 'string');
+  check('the login start redirects to the Help Scout authorize URL', /\/hs\/authorize/.test(anon.headers.get('location') || ''));
+
+  // [A2] /admin/api/* without a session is 401.
+  console.log('[A2] admin API requires a session');
+  const noSessRoster = await fetch(`${BASE}/admin/api/roster`, { redirect: 'manual' });
+  check('GET /admin/api/roster without a session is 401', noSessRoster.status === 401, `status ${noSessRoster.status}`);
+  const noSessPost = await fetch(`${BASE}/admin/api/config`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{"allowlistMode":true,"expectedVersion":0}' });
+  check('POST /admin/api/config without a session is 401', noSessPost.status === 401, `status ${noSessPost.status}`);
+
+  // [A3] a non-Owner role is refused a session.
+  console.log('[A3] a non-administrator role is refused a session');
+  const refused = await adminLogin({ mock, role: 'user' });
+  check('a plain User is refused at the admin callback (403)', refused.status === 403, `status ${refused.status}`);
+  check('the refusal page explains they are not an administrator', /not an administrator/i.test(refused.body || ''));
+  check('no admin session cookie is minted for a refused role', !refused.sessionCookie);
+
+  // [A4] full happy path: Owner logs in, gets a session + roster.
+  console.log('[A4] owner login mints a session and roster');
+  const login = await adminLogin({ mock, role: 'owner' });
+  check('an Owner completes the admin login (302 to /admin)', login.status === 302, `status ${login.status}`);
+  check('the login mints a signed admin-session cookie', typeof login.sessionCookie === 'string' && login.sessionCookie.length > 0);
+  const session = login.sessionCookie;
+  const authed = { Cookie: `${ADMIN_SESSION_COOKIE}=${session}` };
+
+  // GET /admin with the session serves the console and embeds the CSRF token.
+  const page = await fetch(`${BASE}/admin`, { headers: authed });
+  const pageHtml = await page.text();
+  check('GET /admin with a session serves the console page (200)', page.status === 200, `status ${page.status}`);
+  const csrfMatch = pageHtml.match(/var CSRF = "([^"]+)"/);
+  check('the console embeds a per-session CSRF token', Boolean(csrfMatch));
+  const csrf = csrfMatch ? csrfMatch[1] : '';
+  check('the console sets a strict Content-Security-Policy', /content-security-policy/i.test([...page.headers.keys()].join(',')) && /frame-ancestors 'none'/.test(page.headers.get('content-security-policy') || ''));
+
+  const roster1 = await (await fetch(`${BASE}/admin/api/roster`, { headers: authed })).json();
+  check('roster lists the account users merged with policy state', Array.isArray(roster1.rows) && roster1.rows.length >= 2, JSON.stringify(roster1.rows?.length));
+  check('roster reports the deployment write ceiling and cap', roster1.deployment?.ceiling?.enabled === true && roster1.deployment?.ceilingCap === 'writes', JSON.stringify(roster1.deployment));
+  check('roster flags the Light user as ineligible', (roster1.rows || []).some((r) => r.email === 'light@example.test' && r.eligible === false));
+  const agentBefore = (roster1.rows || []).find((r) => r.email === 'agent@example.test');
+  check('the agent starts open-default (no explicit policy)', agentBefore?.policyState === 'open-default', JSON.stringify(agentBefore));
+
+  // [A5] a mutating POST without the CSRF token is rejected.
+  console.log('[A5] CSRF is enforced on mutations');
+  const noCsrf = await fetch(`${BASE}/admin/api/user-policy`, {
+    method: 'POST',
+    headers: { ...authed, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ hsUserId: '5001', allowed: false, writeTier: 'none', expectedVersion: agentBefore?.version ?? 0 }),
+  });
+  check('a mutating POST without the CSRF header is 403', noCsrf.status === 403, `status ${noCsrf.status}`);
+
+  // A tier above the ceiling is rejected server-side even with a valid CSRF token.
+  const overCeiling = await fetch(`${BASE}/admin/api/user-policy`, {
+    method: 'POST',
+    headers: { ...authed, 'Content-Type': 'application/json', 'X-Admin-CSRF': csrf },
+    body: JSON.stringify({ hsUserId: '5001', allowed: true, writeTier: 'writes+customerVisible', expectedVersion: agentBefore?.version ?? 0 }),
+  });
+  check('a write tier above the deployment ceiling is rejected (400)', overCeiling.status === 400, `status ${overCeiling.status}`);
+
+  // [A6] block the agent with a valid CSRF token, then confirm the roster + audit.
+  console.log('[A6] blocking a user is applied and audited');
+  const block = await fetch(`${BASE}/admin/api/user-policy`, {
+    method: 'POST',
+    headers: { ...authed, 'Content-Type': 'application/json', 'X-Admin-CSRF': csrf },
+    body: JSON.stringify({ hsUserId: '5001', allowed: false, writeTier: 'none', expectedVersion: agentBefore?.version ?? 0 }),
+  });
+  check('blocking the agent with a valid CSRF token succeeds (200)', block.status === 200, `status ${block.status}`);
+  const roster2 = await (await fetch(`${BASE}/admin/api/roster`, { headers: authed })).json();
+  const agentAfter = (roster2.rows || []).find((r) => r.email === 'agent@example.test');
+  check('the roster shows the agent as blocked after the mutation', agentAfter?.policyState === 'blocked' && agentAfter?.effectiveAllowed === false, JSON.stringify(agentAfter));
+
+  const audit = await (await fetch(`${BASE}/admin/api/audit?limit=10`, { headers: authed })).json();
+  const adminRow = (audit.page?.entries || []).find((e) => e.action === 'user.policy.updated' && e.targetId === '5001');
+  check('the block is recorded in the audit ledger with the admin actor', adminRow?.actorId === String(MOCK_USER.id), JSON.stringify(adminRow));
+
+  // [A7] the allowlist toggle goes through putConfig with optimistic concurrency.
+  console.log('[A7] the allowlist toggle updates config');
+  const cfgVer = roster2.deployment?.configVersion ?? 0;
+  const toggle = await fetch(`${BASE}/admin/api/config`, {
+    method: 'POST',
+    headers: { ...authed, 'Content-Type': 'application/json', 'X-Admin-CSRF': csrf },
+    body: JSON.stringify({ allowlistMode: true, expectedVersion: cfgVer }),
+  });
+  check('the allowlist toggle succeeds (200)', toggle.status === 200, `status ${toggle.status}`);
+  const stale = await fetch(`${BASE}/admin/api/config`, {
+    method: 'POST',
+    headers: { ...authed, 'Content-Type': 'application/json', 'X-Admin-CSRF': csrf },
+    body: JSON.stringify({ allowlistMode: false, expectedVersion: cfgVer }),
+  });
+  check('a stale allowlist toggle is a 409 conflict', stale.status === 409, `status ${stale.status}`);
+
+  // [A8] evidence exports download with a Content-Disposition attachment.
+  console.log('[A8] evidence exports download');
+  const auditCsv = await fetch(`${BASE}/admin/api/export/audit.csv`, { headers: authed });
+  check('audit CSV export is a 200 attachment', auditCsv.status === 200 && /attachment/.test(auditCsv.headers.get('content-disposition') || ''), `status ${auditCsv.status}`);
+  const auditCsvBody = await auditCsv.text();
+  check('audit CSV export carries the documented header row', auditCsvBody.split('\r\n')[0] === 'seq,ts,actorId,actorEmail,action,targetId,before,after,outcome');
+  const alJson = await fetch(`${BASE}/admin/api/export/access-list.json`, { headers: authed });
+  check('access-list JSON export is a 200 attachment', alJson.status === 200 && /attachment/.test(alJson.headers.get('content-disposition') || ''), `status ${alJson.status}`);
+  const alBody = await alJson.json();
+  check('access-list export is stamped with the config scope note', typeof alBody.config?.scope?.note === 'string' && alBody.config.scope.note.length > 0);
+
+  // Reset the toggled config so a re-run starts clean.
+  await fetch(`${BASE}/admin/api/config`, {
+    method: 'POST',
+    headers: { ...authed, 'Content-Type': 'application/json', 'X-Admin-CSRF': csrf },
+    body: JSON.stringify({ allowlistMode: false, expectedVersion: (await (await fetch(`${BASE}/admin/api/roster`, { headers: authed })).json()).deployment?.configVersion ?? 0 }),
+  });
+}
+
 async function main() {
-  const only = process.env.SMOKE_MODE; // 'reads' | 'writes' | 'policy' | undefined (all)
-  const modes = only === 'reads' ? [false] : only === 'writes' ? [true] : only === 'policy' ? [] : [false, true];
+  const only = process.env.SMOKE_MODE; // 'reads' | 'writes' | 'policy' | 'admin' | undefined (all)
+  const modes = only === 'reads' ? [false] : only === 'writes' ? [true] : only === 'policy' || only === 'admin' ? [] : [false, true];
   const runPolicy = only === undefined || only === 'policy';
+  const runAdmin = only === undefined || only === 'admin';
 
   const mock = await startMockHelpScout();
   console.log(`mock Help Scout on ${mock.url}`);
@@ -858,6 +1037,20 @@ async function main() {
         await runPolicyMode({ mock });
       } finally {
         await policyWorker.close();
+      }
+    }
+
+    if (runAdmin) {
+      // Writes enabled at the ceiling but customer-visible off, so the admin tier
+      // control's top option is greyed and the server rejects it.
+      mock.state.userId = MOCK_USER.id;
+      mock.state.role = 'owner';
+      const adminWorker = startWorker({ mockUrl: mock.url, enableWrites: true, enableCustomerVisible: false });
+      try {
+        await waitForReady(adminWorker.getLog);
+        await runAdminMode({ mock });
+      } finally {
+        await adminWorker.close();
       }
     }
   } finally {

--- a/worker/scripts/smoke.mjs
+++ b/worker/scripts/smoke.mjs
@@ -581,6 +581,44 @@ async function runMode({ mock, enableWrites }) {
     check('replayed callback is rejected via the single-use code', replayed.status === 502, `status ${replayed.status}`);
   }
 
+  // [7c] an abandoned admin sign-in must not break the next MCP connector sign-in.
+  // A leftover admin-state cookie (admin opened /admin, wandered off) carried into
+  // an MCP /callback whose state is the MCP flow's state must fall through to the
+  // MCP consent callback, not 400 as an admin error.
+  console.log('[7c] a stale admin-state cookie does not hijack the MCP callback');
+  const adminStart = await fetch(`${BASE}/admin`, { redirect: 'manual' });
+  const staleAdminState = setCookieValues(adminStart)[ADMIN_STATE_COOKIE];
+  check('captured a leftover admin-state cookie from an abandoned admin sign-in', typeof staleAdminState === 'string' && staleAdminState.length > 0);
+  {
+    const verifier = b64url(crypto.randomBytes(32));
+    const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+    const st = b64url(crypto.randomBytes(8));
+    const a = new URL(`${BASE}/authorize`);
+    a.searchParams.set('response_type', 'code');
+    a.searchParams.set('client_id', reg.clientId);
+    a.searchParams.set('redirect_uri', REDIRECT_URI);
+    a.searchParams.set('code_challenge', challenge);
+    a.searchParams.set('code_challenge_method', 'S256');
+    a.searchParams.set('state', st);
+    if (resource) a.searchParams.set('resource', resource);
+    const consentR = await fetch(a, { headers: { Accept: 'text/html' }, redirect: 'manual' });
+    const c1 = setCookieValues(consentR)[CONSENT_COOKIE];
+    const appr = await fetch(`${BASE}/approve`, { method: 'POST', redirect: 'manual', headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: `${CONSENT_COOKIE}=${c1}` }, body: 'approve=true' });
+    const c2 = setCookieValues(appr)[CONSENT_COOKIE] || c1;
+    const hs = await fetch(appr.headers.get('location'), { redirect: 'manual' });
+    const callbackUrl = new URL(hs.headers.get('location'));
+    // Land on /callback carrying BOTH the MCP consent cookie AND the leftover admin
+    // state cookie. The query state is the MCP state (not the admin one), so the
+    // admin handler must decline and the MCP consent callback must complete.
+    const cb = await fetch(callbackUrl, {
+      redirect: 'manual',
+      headers: { Cookie: `${CONSENT_COOKIE}=${c2}; ${ADMIN_STATE_COOKIE}=${staleAdminState}` },
+    });
+    check('MCP /callback with a stale admin-state cookie still completes (302, not an admin 400)', cb.status === 302, `status ${cb.status}`);
+    const cbCode = cb.status === 302 ? new URL(cb.headers.get('location')).searchParams.get('code') : null;
+    check('the MCP callback minted an OUR code despite the stale admin cookie', typeof cbCode === 'string' && cbCode.length > 0);
+  }
+
   // [8] light-user 403 -> seat-required page, no grant
   console.log('[8] light-user seat-required path');
   const lightFlow = await runFullFlow({ clientId: reg.clientId, resource, mock, lightUser: true });
@@ -973,6 +1011,13 @@ async function runAdminMode({ mock }) {
   const adminRow = (audit.page?.entries || []).find((e) => e.action === 'user.policy.updated' && e.targetId === '5001');
   check('the block is recorded in the audit ledger with the admin actor', adminRow?.actorId === String(MOCK_USER.id), JSON.stringify(adminRow));
 
+  // The console resolves the user's email from the cached directory when it writes
+  // the policy, so the evidence export carries a real email, not a blank column.
+  const alAfterBlock = await (await fetch(`${BASE}/admin/api/export/access-list.json`, { headers: authed })).json();
+  const agentAlRow = (alAfterBlock.rows || []).find((r) => r.hsUserId === '5001');
+  check('the access-list export row for the configured user carries a non-empty email', typeof agentAlRow?.email === 'string' && agentAlRow.email.length > 0, JSON.stringify(agentAlRow));
+  check('the configured user email matches the directory (not blanked)', agentAlRow?.email === 'agent@example.test', JSON.stringify(agentAlRow?.email));
+
   // [A7] the allowlist toggle goes through putConfig with optimistic concurrency.
   console.log('[A7] the allowlist toggle updates config');
   const cfgVer = roster2.deployment?.configVersion ?? 0;
@@ -1006,6 +1051,20 @@ async function runAdminMode({ mock }) {
     headers: { ...authed, 'Content-Type': 'application/json', 'X-Admin-CSRF': csrf },
     body: JSON.stringify({ allowlistMode: false, expectedVersion: (await (await fetch(`${BASE}/admin/api/roster`, { headers: authed })).json()).deployment?.configVersion ?? 0 }),
   });
+
+  // [A9] logout is a CSRF-protected POST: a cross-site GET must not sign the admin
+  // out, and a POST without the CSRF token is rejected. Run last, since the final
+  // successful POST clears the session.
+  console.log('[A9] logout requires POST + CSRF');
+  const getLogout = await fetch(`${BASE}/admin/logout`, { headers: authed, redirect: 'manual' });
+  check('GET /admin/logout does not clear the session cookie', !/hs_admin_session=;/.test(getLogout.headers.get('set-cookie') || ''), `set-cookie ${getLogout.headers.get('set-cookie')}`);
+  const stillValid = await fetch(`${BASE}/admin/api/roster`, { headers: authed });
+  check('the session still works after a GET /admin/logout (no logout happened)', stillValid.status === 200, `status ${stillValid.status}`);
+  const logoutNoCsrf = await fetch(`${BASE}/admin/logout`, { method: 'POST', headers: authed });
+  check('POST /admin/logout without a CSRF token is rejected (403)', logoutNoCsrf.status === 403, `status ${logoutNoCsrf.status}`);
+  const logoutOk = await fetch(`${BASE}/admin/logout`, { method: 'POST', headers: { ...authed, 'X-Admin-CSRF': csrf } });
+  check('POST /admin/logout with a valid CSRF token succeeds (200)', logoutOk.status === 200, `status ${logoutOk.status}`);
+  check('a valid logout clears the admin session cookie', /hs_admin_session=;/.test(logoutOk.headers.get('set-cookie') || ''), `set-cookie ${logoutOk.headers.get('set-cookie')}`);
 }
 
 async function main() {

--- a/worker/src/admin-auth.ts
+++ b/worker/src/admin-auth.ts
@@ -1,0 +1,284 @@
+/**
+ * Pure authorization logic for the self-hosted admin surface (NAS-1503).
+ *
+ * This module owns everything the admin surface can decide WITHOUT the Workers
+ * runtime, so the root unit suite can drive it directly against injected inputs:
+ *   - the admin session + login-state signed cookies (reusing the tested HMAC
+ *     envelope from oauth-cookie.ts, so there is ONE signing primitive);
+ *   - the CSRF token check;
+ *   - the role gate (which Help Scout role may administer, given config.adminRole);
+ *   - the write-tier ceiling cap and the tier<->policy mapping;
+ *   - the roster merge (Help Scout directory + policy docs + grant state).
+ *
+ * The admin session is deliberately NOT the MCP OAuth token. An admin logs in
+ * through the same Help Scout Authorization Code dance the consent flow uses, but
+ * the resulting credential is a short-lived signed cookie this surface owns. The
+ * cookie carries only identity + role + a CSRF token; it holds no Help Scout
+ * token (the login fetches the roster directory once and caches it).
+ */
+import {
+  signConsentCookie,
+  verifyConsentCookie,
+} from './oauth-cookie.js';
+import {
+  evaluateAccess,
+  effectiveWriteFlags,
+  type AdminConfig,
+  type DirectoryUser,
+  type HelpScoutRole,
+  type UserPolicy,
+  type WriteFlagSet,
+} from './policy.js';
+
+// --- Cookies ---------------------------------------------------------------
+
+/** The admin session cookie. Scoped to /admin so it never rides other routes. */
+export const ADMIN_SESSION_COOKIE_NAME = 'hs_admin_session';
+
+/** The transient admin-login state cookie (the OAuth CSRF nonce for the dance). */
+export const ADMIN_STATE_COOKIE_NAME = 'hs_admin_state';
+
+/** Admin sessions live 8 hours: long enough for real work, short enough to bound a stolen cookie. */
+export const ADMIN_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+
+/** The admin-login state cookie lives 10 minutes, like the consent transaction. */
+export const ADMIN_STATE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * The identity + CSRF token carried in the signed admin session cookie. `role`
+ * is the Help Scout role captured at login and is display/short-circuit only:
+ * the config admin-role gate is re-evaluated on every request, so a role cached
+ * here can never widen access beyond what the live config allows.
+ */
+export interface AdminSession {
+  hsUserId: string;
+  email: string;
+  role: HelpScoutRole;
+  /** Per-session CSRF token, embedded in the page and required on every mutation. */
+  csrf: string;
+}
+
+/** Sign an admin session into a cookie value with the given absolute expiry (epoch ms). */
+export async function signAdminSession(session: AdminSession, exp: number, secret: string): Promise<string> {
+  return signConsentCookie({ oauthReq: session, exp }, secret);
+}
+
+/** Verify + decode an admin session cookie. Returns null on any failure (missing, tampered, expired). */
+export async function verifyAdminSession(
+  value: string | undefined,
+  secret: string,
+): Promise<{ session: AdminSession; exp: number } | null> {
+  const txn = await verifyConsentCookie<AdminSession>(value, secret);
+  if (!txn) return null;
+  const s = txn.oauthReq;
+  // Defensive shape check: a decoded-but-malformed payload must not be trusted.
+  if (!s || typeof s.hsUserId !== 'string' || typeof s.csrf !== 'string' || s.csrf.length === 0) return null;
+  return { session: s, exp: txn.exp };
+}
+
+/** Sign the admin-login state nonce into the transient state cookie. */
+export async function signAdminState(state: string, exp: number, secret: string): Promise<string> {
+  return signConsentCookie({ oauthReq: {}, state, exp }, secret);
+}
+
+/** Verify the admin-login state cookie and return the bound state nonce, or null. */
+export async function verifyAdminState(value: string | undefined, secret: string): Promise<string | null> {
+  const txn = await verifyConsentCookie(value, secret);
+  if (!txn || typeof txn.state !== 'string' || txn.state.length === 0) return null;
+  return txn.state;
+}
+
+/** Build the Set-Cookie header for the admin session (HttpOnly, Secure, Lax, /admin-scoped). */
+export function buildAdminSessionSetCookie(value: string): string {
+  const maxAge = Math.floor(ADMIN_SESSION_TTL_MS / 1000);
+  return `${ADMIN_SESSION_COOKIE_NAME}=${value}; HttpOnly; Secure; SameSite=Lax; Path=/admin; Max-Age=${maxAge}`;
+}
+
+/** Clear the admin session cookie. */
+export function buildAdminSessionClearCookie(): string {
+  return `${ADMIN_SESSION_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Lax; Path=/admin; Max-Age=0`;
+}
+
+/**
+ * Build the Set-Cookie for the transient login-state cookie. Path=/ so it is
+ * sent on the Help Scout redirect back to /callback (which is outside /admin).
+ */
+export function buildAdminStateSetCookie(value: string): string {
+  const maxAge = Math.floor(ADMIN_STATE_TTL_MS / 1000);
+  return `${ADMIN_STATE_COOKIE_NAME}=${value}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`;
+}
+
+/** Clear the transient login-state cookie. */
+export function buildAdminStateClearCookie(): string {
+  return `${ADMIN_STATE_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`;
+}
+
+// --- CSRF ------------------------------------------------------------------
+
+/** A random, URL-safe token (used for CSRF and the login state nonce). */
+export function randomToken(byteLength = 24): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Constant-time-ish string equality for the CSRF check: length-independent
+ * short-circuit avoided by folding every character. Both values must be present
+ * and equal; an empty submitted token never matches.
+ */
+export function csrfTokensMatch(sessionToken: string, submitted: string | null | undefined): boolean {
+  if (typeof sessionToken !== 'string' || sessionToken.length === 0) return false;
+  if (typeof submitted !== 'string' || submitted.length === 0) return false;
+  if (sessionToken.length !== submitted.length) return false;
+  let diff = 0;
+  for (let i = 0; i < sessionToken.length; i++) {
+    diff |= sessionToken.charCodeAt(i) ^ submitted.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+// --- Role gate -------------------------------------------------------------
+
+/**
+ * Whether a Help Scout role may administer this deployment under the current
+ * config. An Owner always may. An Administrator may only when the deployment's
+ * adminRole is set to 'administrator'. Everyone else (User, Light) never may.
+ *
+ * This is re-evaluated on EVERY admin request against the LIVE config, so an
+ * admin demoted by lowering config.adminRole from 'administrator' to 'owner'
+ * loses access on their next request even though their session cookie still
+ * says 'Administrator'.
+ */
+export function roleSatisfiesAdmin(role: HelpScoutRole, adminRole: AdminConfig['adminRole']): boolean {
+  if (role === 'Owner') return true;
+  if (role === 'Administrator') return adminRole === 'administrator';
+  return false;
+}
+
+/** Parse an untrusted Help Scout role/type into the roles the admin surface knows. */
+export function parseHelpScoutRole(role: unknown, type?: unknown): HelpScoutRole {
+  const r = typeof role === 'string' ? role.toLowerCase() : '';
+  const t = typeof type === 'string' ? type.toLowerCase() : '';
+  if (r === 'light' || t === 'light') return 'Light';
+  if (r.includes('owner')) return 'Owner';
+  if (r.includes('admin')) return 'Administrator';
+  return 'User';
+}
+
+// --- Write tiers -----------------------------------------------------------
+
+/** The three write tiers the per-user control exposes. */
+export type WriteTier = 'none' | 'writes' | 'writes+customerVisible';
+
+/** The tier a stored policy grants (before intersecting with the deployment ceiling). */
+export function tierFromPolicy(policy: UserPolicy | null): WriteTier {
+  if (!policy || !policy.writes) return 'none';
+  return policy.customerVisibleWrites ? 'writes+customerVisible' : 'writes';
+}
+
+/** The highest tier the deployment ceiling permits granting. Above it the control is greyed. */
+export function ceilingTierCap(ceiling: WriteFlagSet): WriteTier {
+  if (!ceiling.enabled) return 'none';
+  return ceiling.customerVisibleEnabled ? 'writes+customerVisible' : 'writes';
+}
+
+const TIER_RANK: Record<WriteTier, number> = { none: 0, writes: 1, 'writes+customerVisible': 2 };
+
+/** Whether `tier` is within the deployment ceiling cap (fail-closed server-side check). */
+export function tierWithinCeiling(tier: WriteTier, ceiling: WriteFlagSet): boolean {
+  return TIER_RANK[tier] <= TIER_RANK[ceilingTierCap(ceiling)];
+}
+
+/** Map a desired allowed + tier into the UserPolicyInput the policy store accepts. */
+export function policyInputFromTier(
+  allowed: boolean,
+  tier: WriteTier,
+  email?: string,
+): { allowed: boolean; writes: boolean; customerVisibleWrites: boolean; email?: string } {
+  return {
+    allowed,
+    writes: tier !== 'none',
+    customerVisibleWrites: tier === 'writes+customerVisible',
+    email,
+  };
+}
+
+// --- Roster merge ----------------------------------------------------------
+
+/** Where a user sits in the access policy, for display. */
+export type PolicyState = 'open-default' | 'explicitly-allowed' | 'blocked';
+
+/** One roster row: a Help Scout user merged with policy + grant state. */
+export interface RosterRow {
+  hsUserId: string;
+  email: string;
+  name: string;
+  role: HelpScoutRole;
+  /** Light users 403 the Mailbox API, so they can never use the connector. */
+  eligible: boolean;
+  policyState: PolicyState;
+  /** The configured write tier (from the policy doc, or the ceiling for open-default users). */
+  writeTier: WriteTier;
+  /** The tier actually in force after intersecting the grant with the ceiling. */
+  effectiveWriteTier: WriteTier;
+  /** Admission decision under the current config (allowlist mode + explicit block). */
+  effectiveAllowed: boolean;
+  connected: boolean;
+  hasPolicy: boolean;
+  /** Policy doc version, for the optimistic-concurrency guard on a write (0 = no doc). */
+  version: number;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+function effectiveTier(ceiling: WriteFlagSet, policy: UserPolicy | null): WriteTier {
+  const flags = effectiveWriteFlags(ceiling, policy);
+  if (!flags.enabled) return 'none';
+  return flags.customerVisibleEnabled ? 'writes+customerVisible' : 'writes';
+}
+
+function policyState(policy: UserPolicy | null): PolicyState {
+  if (!policy) return 'open-default';
+  if (!policy.allowed) return 'blocked';
+  return 'explicitly-allowed';
+}
+
+/**
+ * Merge the cached Help Scout directory with the live policy documents and grant
+ * state into roster rows. A user with no policy document is open-default (and
+ * inherits the ceiling as their write tier); a policy document narrows both
+ * admission and the write tier. Light users are flagged ineligible. Sorted by
+ * email for a stable, human-scannable roster.
+ */
+export function buildRoster(
+  directory: DirectoryUser[],
+  policies: Map<string, UserPolicy>,
+  connectedIds: Set<string>,
+  config: AdminConfig,
+  ceiling: WriteFlagSet,
+): RosterRow[] {
+  const rows = directory.map((user): RosterRow => {
+    const policy = policies.get(user.hsUserId) ?? null;
+    const configuredTier = policy ? tierFromPolicy(policy) : ceilingTierCap(ceiling);
+    return {
+      hsUserId: user.hsUserId,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      eligible: user.role !== 'Light',
+      policyState: policyState(policy),
+      writeTier: configuredTier,
+      effectiveWriteTier: effectiveTier(ceiling, policy),
+      effectiveAllowed: evaluateAccess(config, policy).allowed,
+      connected: connectedIds.has(user.hsUserId),
+      hasPolicy: policy !== null,
+      version: policy?.version ?? 0,
+      updatedAt: policy?.updatedAt ?? '',
+      updatedBy: policy?.updatedBy ?? '',
+    };
+  });
+  return rows.sort((a, b) => (a.email < b.email ? -1 : a.email > b.email ? 1 : 0));
+}

--- a/worker/src/admin-auth.ts
+++ b/worker/src/admin-auth.ts
@@ -38,8 +38,15 @@ export const ADMIN_SESSION_COOKIE_NAME = 'hs_admin_session';
 /** The transient admin-login state cookie (the OAuth CSRF nonce for the dance). */
 export const ADMIN_STATE_COOKIE_NAME = 'hs_admin_state';
 
-/** Admin sessions live 8 hours: long enough for real work, short enough to bound a stolen cookie. */
-export const ADMIN_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+/**
+ * Admin sessions live 1 hour. The session captures the Help Scout role at login
+ * and the per-request gate only re-reads config.adminRole, so a Help-Scout-side
+ * demotion (Owner to User) is not caught until the cookie expires and re-login
+ * re-reads the live role. A 1 hour ceiling bounds that role window without
+ * storing the admin's Help Scout token. This is separate from a user's MCP
+ * access, which the policy engine revokes immediately.
+ */
+export const ADMIN_SESSION_TTL_MS = 1 * 60 * 60 * 1000;
 
 /** The admin-login state cookie lives 10 minutes, like the consent transaction. */
 export const ADMIN_STATE_TTL_MS = 10 * 60 * 1000;
@@ -226,7 +233,15 @@ export interface RosterRow {
   effectiveWriteTier: WriteTier;
   /** Admission decision under the current config (allowlist mode + explicit block). */
   effectiveAllowed: boolean;
-  connected: boolean;
+  /**
+   * Whether the user holds a live OAuth grant. `null` means the user was NOT
+   * probed (the connection probe is capped for large accounts), so the console
+   * must not present them as disconnected. `connectionProbed` says the same thing
+   * as a plain boolean for callers that would rather branch on it.
+   */
+  connected: boolean | null;
+  /** False when the grant probe was skipped for this user (over the probe cap). */
+  connectionProbed: boolean;
   hasPolicy: boolean;
   /** Policy doc version, for the optimistic-concurrency guard on a write (0 = no doc). */
   version: number;
@@ -252,17 +267,24 @@ function policyState(policy: UserPolicy | null): PolicyState {
  * inherits the ceiling as their write tier); a policy document narrows both
  * admission and the write tier. Light users are flagged ineligible. Sorted by
  * email for a stable, human-scannable roster.
+ *
+ * `connectedIds` holds the users found to have a live grant; `probedIds` holds
+ * the users the grant probe actually ran for. A user outside `probedIds` was not
+ * probed (the probe is capped for large accounts), so its `connected` is `null`
+ * rather than a misleading `false`.
  */
 export function buildRoster(
   directory: DirectoryUser[],
   policies: Map<string, UserPolicy>,
   connectedIds: Set<string>,
+  probedIds: Set<string>,
   config: AdminConfig,
   ceiling: WriteFlagSet,
 ): RosterRow[] {
   const rows = directory.map((user): RosterRow => {
     const policy = policies.get(user.hsUserId) ?? null;
     const configuredTier = policy ? tierFromPolicy(policy) : ceilingTierCap(ceiling);
+    const probed = probedIds.has(user.hsUserId);
     return {
       hsUserId: user.hsUserId,
       email: user.email,
@@ -273,7 +295,8 @@ export function buildRoster(
       writeTier: configuredTier,
       effectiveWriteTier: effectiveTier(ceiling, policy),
       effectiveAllowed: evaluateAccess(config, policy).allowed,
-      connected: connectedIds.has(user.hsUserId),
+      connected: probed ? connectedIds.has(user.hsUserId) : null,
+      connectionProbed: probed,
       hasPolicy: policy !== null,
       version: policy?.version ?? 0,
       updatedAt: policy?.updatedAt ?? '',

--- a/worker/src/admin-handler.ts
+++ b/worker/src/admin-handler.ts
@@ -1,0 +1,639 @@
+/**
+ * The self-hosted admin surface (NAS-1503): /admin + /admin/api/*.
+ *
+ * This is a thin auth + CSRF + HTTP layer over the policy engine, the audit
+ * ledger, and the evidence exports that already exist. It adds NO policy logic:
+ * the pure decisions live in admin-auth.ts and the storage in the coordinator.
+ *
+ * Security model:
+ *   - The admin session is SEPARATE from the MCP OAuth token. An admin logs in
+ *     through the same Help Scout Authorization Code dance the consent flow uses,
+ *     but the credential is a short-lived (8h) signed HTTP-only cookie THIS
+ *     surface owns (admin-auth.ts). No Help Scout token is retained past login.
+ *   - The Help Scout app has ONE registered Redirection URL (the worker's
+ *     /callback), so the admin login's authorize leg lands on /callback too. It
+ *     is disambiguated from the MCP consent callback by its own signed state
+ *     cookie (tryAdminCallback), mirroring the consent flow's state discipline:
+ *     signed state, exact-match, single-use via the Help Scout code.
+ *   - The role gate requires Owner (or Administrator only when
+ *     config.adminRole === 'administrator'). It is re-evaluated against the LIVE
+ *     config on EVERY /admin/api/* request, so a demoted admin loses access on
+ *     their next request even with a still-valid session cookie.
+ *   - Every mutating request must carry a CSRF token matching the one bound in
+ *     the session cookie (a synchronizer token embedded in the page).
+ *   - Strict security headers on every response: a self-contained CSP (no
+ *     third-party origins, nonce'd inline CSS/JS), frame-ancestors none,
+ *     nosniff, no-referrer.
+ */
+import type { Env } from './mcp-agent.js';
+import { SERVER_VERSION } from './mcp-agent.js';
+import { readCookie } from './oauth-cookie.js';
+import { isSecureUpstreamUrl, joinUrl } from './upstream-url.js';
+import {
+  PolicyConflictError,
+  type AdminConfig,
+  type DirectoryUser,
+  type UserDirectory,
+  type WriteFlagSet,
+} from './policy.js';
+import { getConfig, putConfig, putUserPolicy, revokeUser } from './policy-store.js';
+import { deploymentId, exportAccessList, exportAuditLog, listAuditEntries } from './audit-store.js';
+import { getDirectory, listUserPolicies, putDirectory } from './admin-store.js';
+import {
+  ADMIN_STATE_COOKIE_NAME,
+  ADMIN_SESSION_COOKIE_NAME,
+  ADMIN_SESSION_TTL_MS,
+  ADMIN_STATE_TTL_MS,
+  buildAdminSessionClearCookie,
+  buildAdminSessionSetCookie,
+  buildAdminStateClearCookie,
+  buildAdminStateSetCookie,
+  buildRoster,
+  ceilingTierCap,
+  csrfTokensMatch,
+  parseHelpScoutRole,
+  policyInputFromTier,
+  randomToken,
+  roleSatisfiesAdmin,
+  signAdminSession,
+  signAdminState,
+  tierWithinCeiling,
+  verifyAdminSession,
+  verifyAdminState,
+  type AdminSession,
+  type WriteTier,
+} from './admin-auth.js';
+import { renderAdminPage, renderAdminNotice } from './admin-page.js';
+
+const HELP_SCOUT_FETCH_TIMEOUT_MS = 30_000;
+/** Cap the /v2/users pagination so a hostile or broken upstream cannot loop unbounded. */
+const MAX_USER_PAGES = 200;
+
+// --- Response helpers ------------------------------------------------------
+
+/** Security headers applied to every admin response. */
+function securityHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+    'Cache-Control': 'no-store',
+    ...extra,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: securityHeaders({
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+      ...extra,
+    }),
+  });
+}
+
+/** A self-contained HTML page with a per-response nonce'd CSP (no third-party origins). */
+function htmlResponse(html: string, nonce: string, status = 200, extra: Record<string, string> = {}): Response {
+  const csp =
+    "default-src 'none'; " +
+    `script-src 'nonce-${nonce}'; ` +
+    `style-src 'nonce-${nonce}'; ` +
+    "connect-src 'self'; " +
+    "img-src data:; " +
+    "form-action 'self'; " +
+    "base-uri 'none'; " +
+    "frame-ancestors 'none'";
+  return new Response(html, {
+    status,
+    headers: securityHeaders({
+      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Security-Policy': csp,
+      ...extra,
+    }),
+  });
+}
+
+/** A minimal notice page (login prompt, not-an-administrator, errors). */
+function noticePage(title: string, heading: string, message: string, status: number, extra: Record<string, string> = {}): Response {
+  const nonce = randomToken(16);
+  return htmlResponse(renderAdminNotice(nonce, title, heading, message), nonce, status, extra);
+}
+
+// --- The deployment write ceiling (env-only, never raised from the GUI) ----
+
+function ceilingFromEnv(env: Env): WriteFlagSet {
+  return {
+    enabled: env.HELPSCOUT_ENABLE_WRITES === 'true',
+    customerVisibleEnabled: env.HELPSCOUT_ENABLE_CUSTOMER_VISIBLE_WRITES === 'true',
+  };
+}
+
+// --- Help Scout calls (admin token, only during login) ---------------------
+
+interface HelpScoutMe {
+  id?: unknown;
+  email?: unknown;
+  firstName?: unknown;
+  lastName?: unknown;
+  role?: unknown;
+  type?: unknown;
+}
+
+function displayName(u: { firstName?: unknown; lastName?: unknown; email?: unknown }, fallbackId: string): string {
+  const name = [u.firstName, u.lastName]
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .join(' ');
+  if (name) return name;
+  if (typeof u.email === 'string' && u.email.length > 0) return u.email;
+  return `Help Scout user ${fallbackId}`;
+}
+
+/** Page through GET /v2/users with the admin's token, mapping to the cached directory shape. */
+async function fetchDirectory(env: Env, token: string, allowLoopback: boolean): Promise<DirectoryUser[]> {
+  const users: DirectoryUser[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const url = new URL(joinUrl(env.HELPSCOUT_BASE_URL, 'users'));
+    url.searchParams.set('page', String(page));
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(HELP_SCOUT_FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`Help Scout GET /users failed with status ${res.status}`);
+    }
+    const body = (await res.json()) as {
+      _embedded?: { users?: HelpScoutMe[] };
+      page?: { totalPages?: number };
+    };
+    const batch = body._embedded?.users ?? [];
+    for (const u of batch) {
+      const id = typeof u.id === 'number' ? u.id : Number(u.id);
+      if (!Number.isInteger(id) || id <= 0) continue;
+      const hsUserId = String(id);
+      users.push({
+        hsUserId,
+        email: typeof u.email === 'string' ? u.email : '',
+        name: displayName(u, hsUserId),
+        role: parseHelpScoutRole(u.role, u.type),
+      });
+    }
+    totalPages = typeof body.page?.totalPages === 'number' ? body.page.totalPages : 1;
+    page += 1;
+  } while (page <= totalPages && page <= MAX_USER_PAGES);
+  return users;
+}
+
+// --- Admin login (authorize leg) -------------------------------------------
+
+/** GET /admin with no valid session: start the Help Scout authorization dance. */
+async function startAdminLogin(env: Env): Promise<Response> {
+  const key = env.COOKIE_ENCRYPTION_KEY ?? '';
+  const allowLoopback = Boolean(env.HELPSCOUT_TEST_POLICY_ROUTES);
+  if (!isSecureUpstreamUrl(env.HELPSCOUT_AUTHORIZE_URL, allowLoopback)) {
+    return noticePage(
+      'Admin sign-in',
+      'Deployment misconfigured',
+      'This server is configured with a non-https Help Scout URL. Ask whoever operates it to fix HELPSCOUT_AUTHORIZE_URL.',
+      500,
+    );
+  }
+
+  const state = randomToken(24);
+  const stateCookie = await signAdminState(state, Date.now() + ADMIN_STATE_TTL_MS, key);
+
+  const authorizeUrl = new URL(env.HELPSCOUT_AUTHORIZE_URL);
+  authorizeUrl.searchParams.set('client_id', env.HELPSCOUT_CLIENT_ID);
+  authorizeUrl.searchParams.set('state', state);
+
+  const headers = new Headers(securityHeaders({ Location: authorizeUrl.toString() }));
+  headers.append('Set-Cookie', buildAdminStateSetCookie(stateCookie));
+  return new Response(null, { status: 302, headers });
+}
+
+/**
+ * Handle the admin-login callback at /callback. Returns a Response when this
+ * callback carries an admin-login state cookie (admin intent), otherwise null so
+ * the MCP consent callback runs unchanged. Once an admin-state cookie is present
+ * we own the callback and never fall through, so a dangling admin cookie cannot
+ * hijack an MCP sign-in (which never carries this cookie).
+ */
+export async function tryAdminCallback(request: Request, env: Env): Promise<Response | null> {
+  const stateCookie = readCookie(request, ADMIN_STATE_COOKIE_NAME);
+  if (!stateCookie) return null;
+  return handleAdminCallback(request, env, stateCookie);
+}
+
+async function handleAdminCallback(request: Request, env: Env, stateCookie: string): Promise<Response> {
+  const key = env.COOKIE_ENCRYPTION_KEY ?? '';
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  const boundState = await verifyAdminState(stateCookie, key);
+  if (!boundState || !state || !code || boundState !== state) {
+    return noticePage(
+      'Admin sign-in',
+      'Could not verify this sign-in',
+      'The admin sign-in could not be verified. Start again from /admin.',
+      400,
+      { 'Set-Cookie': buildAdminStateClearCookie() },
+    );
+  }
+
+  const allowLoopback = Boolean(env.HELPSCOUT_TEST_POLICY_ROUTES);
+  if (
+    !isSecureUpstreamUrl(env.HELPSCOUT_TOKEN_URL, allowLoopback) ||
+    !isSecureUpstreamUrl(env.HELPSCOUT_BASE_URL, allowLoopback)
+  ) {
+    return noticePage(
+      'Admin sign-in',
+      'Deployment misconfigured',
+      'This server is configured with a non-https Help Scout URL. Ask whoever operates it to fix HELPSCOUT_TOKEN_URL / HELPSCOUT_BASE_URL.',
+      500,
+      { 'Set-Cookie': buildAdminStateClearCookie() },
+    );
+  }
+
+  // Exchange the single-use code for the admin's Help Scout token (used only to
+  // read identity + the user directory during this login, then discarded).
+  let accessToken: string;
+  try {
+    const tokenRes = await fetch(env.HELPSCOUT_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        client_id: env.HELPSCOUT_CLIENT_ID,
+        client_secret: env.HELPSCOUT_CLIENT_SECRET,
+      }),
+      signal: AbortSignal.timeout(HELP_SCOUT_FETCH_TIMEOUT_MS),
+    });
+    if (!tokenRes.ok) {
+      return noticePage(
+        'Admin sign-in',
+        'Help Scout sign-in failed',
+        'Help Scout could not complete the sign-in. Start again from /admin.',
+        502,
+        { 'Set-Cookie': buildAdminStateClearCookie() },
+      );
+    }
+    const tokenData = (await tokenRes.json()) as { access_token?: unknown };
+    if (typeof tokenData.access_token !== 'string' || tokenData.access_token === '') {
+      return noticePage('Admin sign-in', 'Help Scout sign-in failed', 'Help Scout returned an unexpected response. Start again from /admin.', 502, {
+        'Set-Cookie': buildAdminStateClearCookie(),
+      });
+    }
+    accessToken = tokenData.access_token;
+  } catch {
+    return noticePage('Admin sign-in', 'Help Scout is unreachable', 'Could not reach Help Scout to complete the sign-in. Try again in a moment.', 502, {
+      'Set-Cookie': buildAdminStateClearCookie(),
+    });
+  }
+
+  // Identity. A 403 here is a Light User (no Mailbox API), who cannot administer.
+  let me: HelpScoutMe;
+  try {
+    const meRes = await fetch(joinUrl(env.HELPSCOUT_BASE_URL, 'users/me'), {
+      method: 'GET',
+      headers: { Accept: 'application/json', Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(HELP_SCOUT_FETCH_TIMEOUT_MS),
+    });
+    if (!meRes.ok) {
+      return noticePage(
+        'Admin sign-in',
+        'You are not an administrator of this deployment',
+        'Your Help Scout account could not be verified as an administrator of this deployment. If you believe this is a mistake, contact whoever operates it.',
+        403,
+        { 'Set-Cookie': buildAdminStateClearCookie() },
+      );
+    }
+    me = (await meRes.json()) as HelpScoutMe;
+  } catch {
+    return noticePage('Admin sign-in', 'Help Scout is unreachable', 'Could not reach Help Scout to read your profile. Try again in a moment.', 502, {
+      'Set-Cookie': buildAdminStateClearCookie(),
+    });
+  }
+
+  const userId = typeof me.id === 'number' ? me.id : Number(me.id);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return noticePage('Admin sign-in', 'Could not read your Help Scout profile', 'Help Scout returned a profile without a usable identity. Try again in a moment.', 502, {
+      'Set-Cookie': buildAdminStateClearCookie(),
+    });
+  }
+  const hsUserId = String(userId);
+  const email = typeof me.email === 'string' ? me.email : '';
+  const role = parseHelpScoutRole(me.role, me.type);
+
+  // Role gate against the LIVE config. An insufficient role gets a clear page and
+  // NO session cookie.
+  let config: AdminConfig;
+  try {
+    config = await getConfig(env);
+  } catch {
+    return noticePage('Admin sign-in', 'Access could not be verified', 'This deployment could not verify administrator access right now. Try again in a moment.', 503, {
+      'Set-Cookie': buildAdminStateClearCookie(),
+    });
+  }
+  if (!roleSatisfiesAdmin(role, config.adminRole)) {
+    return noticePage(
+      'Admin sign-in',
+      'You are not an administrator of this deployment',
+      `Your Help Scout role (${role}) is not permitted to administer this deployment. Access is limited to ${config.adminRole === 'administrator' ? 'Owners and Administrators' : 'Owners'}. Contact whoever operates it if you believe this is a mistake.`,
+      403,
+      { 'Set-Cookie': buildAdminStateClearCookie() },
+    );
+  }
+
+  // Fetch + cache the account directory once, so the roster endpoint needs no
+  // Help Scout token for the life of the session.
+  try {
+    const users = await fetchDirectory(env, accessToken, allowLoopback);
+    const directory: UserDirectory = { users, fetchedAt: new Date().toISOString(), fetchedBy: hsUserId };
+    await putDirectory(env, directory);
+  } catch {
+    return noticePage('Admin sign-in', 'Could not load the account roster', 'Help Scout accepted the sign-in but the account user list could not be read. Try again in a moment.', 502, {
+      'Set-Cookie': buildAdminStateClearCookie(),
+    });
+  }
+
+  const session: AdminSession = { hsUserId, email, role, csrf: randomToken(24) };
+  const sessionCookie = await signAdminSession(session, Date.now() + ADMIN_SESSION_TTL_MS, key);
+
+  const headers = new Headers(securityHeaders({ Location: '/admin' }));
+  headers.append('Set-Cookie', buildAdminSessionSetCookie(sessionCookie));
+  headers.append('Set-Cookie', buildAdminStateClearCookie());
+  return new Response(null, { status: 302, headers });
+}
+
+// --- Authenticated admin surface -------------------------------------------
+
+/** Resolve and re-validate the admin session for an /admin/api/* request. */
+async function requireSession(
+  request: Request,
+  env: Env,
+): Promise<{ session: AdminSession; config: AdminConfig } | { error: Response }> {
+  const key = env.COOKIE_ENCRYPTION_KEY ?? '';
+  const cookie = readCookie(request, ADMIN_SESSION_COOKIE_NAME);
+  const verified = await verifyAdminSession(cookie, key);
+  if (!verified) {
+    return { error: jsonResponse({ error: 'Not authenticated.', code: 'UNAUTHENTICATED' }, 401) };
+  }
+  let config: AdminConfig;
+  try {
+    config = await getConfig(env);
+  } catch {
+    return { error: jsonResponse({ error: 'Access could not be verified right now.', code: 'TEMPORARY_ERROR' }, 503) };
+  }
+  // Re-check the role against the LIVE config: a demoted admin loses access here.
+  if (!roleSatisfiesAdmin(verified.session.role, config.adminRole)) {
+    return { error: jsonResponse({ error: 'Your administrator access is no longer permitted by this deployment.', code: 'FORBIDDEN' }, 403) };
+  }
+  return { session: verified.session, config };
+}
+
+/** GET /admin/api/roster: the merged roster plus deployment state. */
+async function handleRoster(env: Env, config: AdminConfig): Promise<Response> {
+  const ceiling = ceilingFromEnv(env);
+  const directory = await getDirectory(env);
+  const policies = await listUserPolicies(env);
+
+  const users = directory?.users ?? [];
+  const connectedIds = new Set<string>();
+  await Promise.all(
+    users.map(async (u) => {
+      try {
+        const page = await env.OAUTH_PROVIDER.listUserGrants(u.hsUserId);
+        if (page.items.length > 0) connectedIds.add(u.hsUserId);
+      } catch {
+        // Grant lookup is informational; a failure just leaves "connected" false.
+      }
+    }),
+  );
+
+  const rows = buildRoster(users, policies, connectedIds, config, ceiling);
+  return jsonResponse({
+    deployment: {
+      allowlistMode: config.allowlistMode,
+      adminRole: config.adminRole,
+      configVersion: config.version,
+      ceiling,
+      ceilingCap: ceilingTierCap(ceiling),
+      workerVersion: SERVER_VERSION,
+      deploymentId: deploymentId(env),
+      directoryFetchedAt: directory?.fetchedAt ?? null,
+    },
+    rows,
+  });
+}
+
+async function readJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const body = await request.json();
+    return body && typeof body === 'object' ? (body as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function conflictResponse(error: PolicyConflictError): Response {
+  return jsonResponse(
+    {
+      error: 'This record changed since you loaded it. Reload the page and try again.',
+      code: 'POLICY_CONFLICT',
+      expectedVersion: error.expectedVersion,
+      currentVersion: error.currentVersion,
+    },
+    409,
+  );
+}
+
+/** POST /admin/api/user-policy: set a user's allowed state and write tier together. */
+async function handleUserPolicy(request: Request, env: Env, session: AdminSession): Promise<Response> {
+  const body = await readJsonBody(request);
+  if (!body) return jsonResponse({ error: 'Body must be JSON.' }, 400);
+
+  const hsUserId = typeof body.hsUserId === 'string' ? body.hsUserId : String(body.hsUserId ?? '');
+  const allowed = body.allowed === true;
+  const writeTier = body.writeTier as WriteTier;
+  const expectedVersion = typeof body.expectedVersion === 'number' ? body.expectedVersion : Number(body.expectedVersion);
+
+  if (!/^\d+$/.test(hsUserId)) return jsonResponse({ error: 'hsUserId must be a Help Scout user id.' }, 400);
+  if (writeTier !== 'none' && writeTier !== 'writes' && writeTier !== 'writes+customerVisible') {
+    return jsonResponse({ error: 'writeTier must be none, writes, or writes+customerVisible.' }, 400);
+  }
+  if (!Number.isInteger(expectedVersion) || expectedVersion < 0) {
+    return jsonResponse({ error: 'expectedVersion must be a non-negative integer.' }, 400);
+  }
+
+  // Fail closed: never let the GUI grant a tier above the deployment env ceiling,
+  // regardless of what the client sent (the control greys these out client-side).
+  const ceiling = ceilingFromEnv(env);
+  if (!tierWithinCeiling(writeTier, ceiling)) {
+    return jsonResponse(
+      { error: 'That write tier exceeds this deployment write ceiling, which is set at deploy time and cannot be raised from here.', code: 'CEILING_EXCEEDED' },
+      400,
+    );
+  }
+
+  try {
+    const policy = await putUserPolicy(env, hsUserId, policyInputFromTier(allowed, writeTier), {
+      expectedVersion,
+      updatedBy: session.hsUserId,
+      actorEmail: session.email,
+    });
+    return jsonResponse({ policy });
+  } catch (error) {
+    if (error instanceof PolicyConflictError) return conflictResponse(error);
+    throw error;
+  }
+}
+
+/** POST /admin/api/revoke: hard-revoke a user's grants and pin allowed:false. */
+async function handleRevoke(request: Request, env: Env, session: AdminSession): Promise<Response> {
+  const body = await readJsonBody(request);
+  if (!body) return jsonResponse({ error: 'Body must be JSON.' }, 400);
+  const hsUserId = typeof body.hsUserId === 'string' ? body.hsUserId : String(body.hsUserId ?? '');
+  if (!/^\d+$/.test(hsUserId)) return jsonResponse({ error: 'hsUserId must be a Help Scout user id.' }, 400);
+
+  const result = await revokeUser(env, hsUserId, { updatedBy: session.hsUserId, actorEmail: session.email });
+  return jsonResponse({ result });
+}
+
+/** POST /admin/api/config: set the allowlist-mode switch (the only GUI-mutable config). */
+async function handleConfig(request: Request, env: Env, session: AdminSession): Promise<Response> {
+  const body = await readJsonBody(request);
+  if (!body) return jsonResponse({ error: 'Body must be JSON.' }, 400);
+  if (typeof body.allowlistMode !== 'boolean') return jsonResponse({ error: 'allowlistMode must be a boolean.' }, 400);
+  const expectedVersion = typeof body.expectedVersion === 'number' ? body.expectedVersion : Number(body.expectedVersion);
+  if (!Number.isInteger(expectedVersion) || expectedVersion < 0) {
+    return jsonResponse({ error: 'expectedVersion must be a non-negative integer.' }, 400);
+  }
+
+  try {
+    const config = await putConfig(env, { allowlistMode: body.allowlistMode }, {
+      expectedVersion,
+      updatedBy: session.hsUserId,
+      actorEmail: session.email,
+    });
+    return jsonResponse({ config });
+  } catch (error) {
+    if (error instanceof PolicyConflictError) return conflictResponse(error);
+    throw error;
+  }
+}
+
+/** GET /admin/api/audit: a newest-first page of audit rows. */
+async function handleAudit(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? undefined;
+  const limitParam = url.searchParams.get('limit');
+  const limit = limitParam ? Number(limitParam) : undefined;
+  const page = await listAuditEntries(env, { cursor, limit: Number.isFinite(limit) ? limit : undefined });
+  return jsonResponse({ page });
+}
+
+/** GET /admin/api/export/*: evidence downloads with a Content-Disposition attachment. */
+async function handleExport(env: Env, kind: string): Promise<Response> {
+  const stamp = new Date().toISOString().slice(0, 10);
+  if (kind === 'audit.json') {
+    const data = await exportAuditLog(env, { format: 'json' });
+    return download(JSON.stringify(data, null, 2), 'application/json; charset=utf-8', `helpscout-audit-${stamp}.json`);
+  }
+  if (kind === 'audit.csv') {
+    const data = await exportAuditLog(env, { format: 'csv' });
+    const csv = data.format === 'csv' ? data.csv : '';
+    return download(csv, 'text/csv; charset=utf-8', `helpscout-audit-${stamp}.csv`);
+  }
+  if (kind === 'access-list.json') {
+    const data = await exportAccessList(env, { format: 'json' });
+    return download(JSON.stringify(data, null, 2), 'application/json; charset=utf-8', `helpscout-access-list-${stamp}.json`);
+  }
+  if (kind === 'access-list.csv') {
+    const data = await exportAccessList(env, { format: 'csv' });
+    const csv = data.format === 'csv' ? data.csv : '';
+    return download(csv, 'text/csv; charset=utf-8', `helpscout-access-list-${stamp}.csv`);
+  }
+  return jsonResponse({ error: 'Unknown export.' }, 404);
+}
+
+function download(body: string, contentType: string, filename: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: securityHeaders({
+      'Content-Type': contentType,
+      'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    }),
+  });
+}
+
+/** Dispatch every /admin/api/* request behind session + role + (for POST) CSRF gates. */
+async function handleAdminApi(request: Request, env: Env, pathname: string): Promise<Response> {
+  const gate = await requireSession(request, env);
+  if ('error' in gate) return gate.error;
+  const { session, config } = gate;
+
+  // Every mutating request must carry the session's CSRF token.
+  if (request.method === 'POST') {
+    if (!csrfTokensMatch(session.csrf, request.headers.get('X-Admin-CSRF'))) {
+      return jsonResponse({ error: 'Missing or invalid CSRF token.', code: 'CSRF_FAILED' }, 403);
+    }
+  }
+
+  if (pathname === '/admin/api/roster' && request.method === 'GET') return handleRoster(env, config);
+  if (pathname === '/admin/api/user-policy' && request.method === 'POST') return handleUserPolicy(request, env, session);
+  if (pathname === '/admin/api/revoke' && request.method === 'POST') return handleRevoke(request, env, session);
+  if (pathname === '/admin/api/config' && request.method === 'POST') return handleConfig(request, env, session);
+  if (pathname === '/admin/api/audit' && request.method === 'GET') return handleAudit(request, env);
+  if (pathname.startsWith('/admin/api/export/') && request.method === 'GET') {
+    return handleExport(env, pathname.slice('/admin/api/export/'.length));
+  }
+  return jsonResponse({ error: 'Not found.' }, 404);
+}
+
+/** GET /admin: render the console for a valid session, or start the login dance. */
+async function handleAdminRoot(request: Request, env: Env): Promise<Response> {
+  const key = env.COOKIE_ENCRYPTION_KEY ?? '';
+  const cookie = readCookie(request, ADMIN_SESSION_COOKIE_NAME);
+  const verified = await verifyAdminSession(cookie, key);
+  if (!verified) return startAdminLogin(env);
+  const nonce = randomToken(16);
+  return htmlResponse(renderAdminPage(nonce, verified.session.csrf), nonce);
+}
+
+/** GET /admin/logout: clear the admin session and return to /admin. */
+function handleLogout(): Response {
+  const headers = new Headers(securityHeaders({ Location: '/admin' }));
+  headers.append('Set-Cookie', buildAdminSessionClearCookie());
+  return new Response(null, { status: 302, headers });
+}
+
+/** The entry point help-scout-handler delegates every /admin and /admin/api/* path to. */
+export async function handleAdmin(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const { pathname } = url;
+
+  if (pathname === '/admin') {
+    if (request.method !== 'GET') return jsonResponse({ error: 'Method not allowed.' }, 405);
+    return handleAdminRoot(request, env);
+  }
+  if (pathname === '/admin/logout') {
+    return handleLogout();
+  }
+  if (pathname.startsWith('/admin/api/')) {
+    try {
+      return await handleAdminApi(request, env, pathname);
+    } catch (error) {
+      return jsonResponse(
+        { error: error instanceof Error ? error.message : 'Internal error.', code: 'INTERNAL' },
+        500,
+      );
+    }
+  }
+  return noticePage('Admin', 'Not found', 'This admin page does not exist.', 404);
+}

--- a/worker/src/admin-handler.ts
+++ b/worker/src/admin-handler.ts
@@ -8,8 +8,10 @@
  * Security model:
  *   - The admin session is SEPARATE from the MCP OAuth token. An admin logs in
  *     through the same Help Scout Authorization Code dance the consent flow uses,
- *     but the credential is a short-lived (8h) signed HTTP-only cookie THIS
+ *     but the credential is a short-lived (1h) signed HTTP-only cookie THIS
  *     surface owns (admin-auth.ts). No Help Scout token is retained past login.
+ *     The 1h ceiling bounds the window in which a Help-Scout-side demotion is
+ *     still reflected by the cached session role (see ADMIN_SESSION_TTL_MS).
  *   - The Help Scout app has ONE registered Redirection URL (the worker's
  *     /callback), so the admin login's authorize leg lands on /callback too. It
  *     is disambiguated from the MCP consent callback by its own signed state
@@ -64,10 +66,39 @@ import {
   type WriteTier,
 } from './admin-auth.js';
 import { renderAdminPage, renderAdminNotice } from './admin-page.js';
+import { logger } from '../../src/utils/logger.js';
 
 const HELP_SCOUT_FETCH_TIMEOUT_MS = 30_000;
 /** Cap the /v2/users pagination so a hostile or broken upstream cannot loop unbounded. */
 const MAX_USER_PAGES = 200;
+/**
+ * Cap the connection probe: a large account (fetchDirectory pages up to
+ * MAX_USER_PAGES) could otherwise fan out thousands of concurrent KV-backed
+ * grant lookups and exceed the per-invocation operation budget, silently making
+ * the Connected column wrong. Above this cap the unprobed users are reported
+ * honestly (connected: null) rather than as disconnected.
+ */
+const CONNECTION_PROBE_CAP = 250;
+/** How many grant lookups to run at once (a small pool keeps the op budget bounded). */
+const CONNECTION_PROBE_CONCURRENCY = 8;
+
+/** Run `worker` over `items` with at most `limit` in flight at any moment. */
+async function runPool<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let index = 0;
+  const size = Math.min(limit, items.length);
+  const runners: Promise<void>[] = [];
+  for (let i = 0; i < size; i++) {
+    runners.push(
+      (async () => {
+        while (index < items.length) {
+          const current = index++;
+          await worker(items[current]);
+        }
+      })(),
+    );
+  }
+  await Promise.all(runners);
+}
 
 // --- Response helpers ------------------------------------------------------
 
@@ -118,6 +149,21 @@ function htmlResponse(html: string, nonce: string, status = 200, extra: Record<s
 function noticePage(title: string, heading: string, message: string, status: number, extra: Record<string, string> = {}): Response {
   const nonce = randomToken(16);
   return htmlResponse(renderAdminNotice(nonce, title, heading, message), nonce, status, extra);
+}
+
+/**
+ * Fail-closed page when the cookie signing key is absent (NAS-1503 hardening).
+ * The admin surface self-guards this rather than trusting the caller's ordering,
+ * so it never signs or verifies a cookie with an empty key. Mirrors the
+ * consent-flow guard copy.
+ */
+function misconfiguredKeyPage(): Response {
+  return noticePage(
+    'Admin',
+    'Deployment misconfigured',
+    'This server is missing its COOKIE_ENCRYPTION_KEY secret. Ask whoever operates it to set one with wrangler secret put COOKIE_ENCRYPTION_KEY.',
+    500,
+  );
 }
 
 // --- The deployment write ceiling (env-only, never raised from the GUI) ----
@@ -215,15 +261,34 @@ async function startAdminLogin(env: Env): Promise<Response> {
 }
 
 /**
- * Handle the admin-login callback at /callback. Returns a Response when this
- * callback carries an admin-login state cookie (admin intent), otherwise null so
- * the MCP consent callback runs unchanged. Once an admin-state cookie is present
- * we own the callback and never fall through, so a dangling admin cookie cannot
- * hijack an MCP sign-in (which never carries this cookie).
+ * Handle the admin-login callback at /callback. Returns a Response ONLY when this
+ * callback is genuinely an admin callback: an admin-state cookie is present AND
+ * its bound state equals the query `state`. Otherwise it returns null so the MCP
+ * consent callback runs unchanged.
+ *
+ * The one fixed /callback is shared by both flows, so an abandoned admin sign-in
+ * can leave a still-valid admin-state cookie in the browser. If we claimed the
+ * callback on the mere presence of that cookie, a later connector sign-in
+ * returning to /callback with the MCP flow's state would be answered with an
+ * admin error page and break. Gating on state equality lets the leftover cookie
+ * fall through to the MCP flow; only a matching admin state proceeds, and there a
+ * missing code etc. is a real admin error.
  */
 export async function tryAdminCallback(request: Request, env: Env): Promise<Response | null> {
   const stateCookie = readCookie(request, ADMIN_STATE_COOKIE_NAME);
   if (!stateCookie) return null;
+
+  // A present admin-state cookie signals admin intent, so fail closed on an
+  // empty signing key rather than verify it with one (defense in depth: the
+  // fetch entrypoint already guards this before delegating).
+  if (!env.COOKIE_ENCRYPTION_KEY) return misconfiguredKeyPage();
+
+  const state = new URL(request.url).searchParams.get('state');
+  const boundState = await verifyAdminState(stateCookie, env.COOKIE_ENCRYPTION_KEY);
+  // Claim the callback only on an exact admin-state match; anything else (no
+  // binding, or the MCP flow's state) falls through to the MCP consent callback.
+  if (!boundState || !state || boundState !== state) return null;
+
   return handleAdminCallback(request, env, stateCookie);
 }
 
@@ -403,19 +468,26 @@ async function handleRoster(env: Env, config: AdminConfig): Promise<Response> {
   const policies = await listUserPolicies(env);
 
   const users = directory?.users ?? [];
-  const connectedIds = new Set<string>();
-  await Promise.all(
-    users.map(async (u) => {
-      try {
-        const page = await env.OAUTH_PROVIDER.listUserGrants(u.hsUserId);
-        if (page.items.length > 0) connectedIds.add(u.hsUserId);
-      } catch {
-        // Grant lookup is informational; a failure just leaves "connected" false.
-      }
-    }),
-  );
 
-  const rows = buildRoster(users, policies, connectedIds, config, ceiling);
+  // Bound the grant probe: cap the users probed and run with a small concurrency
+  // pool so a large account cannot blow the per-invocation op budget. Users past
+  // the cap are left unprobed and reported honestly (connected: null), never as
+  // a misleading connected:false.
+  const probed = users.slice(0, CONNECTION_PROBE_CAP);
+  const probedIds = new Set(probed.map((u) => u.hsUserId));
+  const connectedIds = new Set<string>();
+  await runPool(probed, CONNECTION_PROBE_CONCURRENCY, async (u) => {
+    try {
+      const page = await env.OAUTH_PROVIDER.listUserGrants(u.hsUserId);
+      if (page.items.length > 0) connectedIds.add(u.hsUserId);
+    } catch {
+      // Grant lookup is informational; a single failure just leaves this user
+      // not-connected/unknown and never fails the roster request.
+    }
+  });
+  const connectionStatus: 'complete' | 'partial' = users.length > probed.length ? 'partial' : 'complete';
+
+  const rows = buildRoster(users, policies, connectedIds, probedIds, config, ceiling);
   return jsonResponse({
     deployment: {
       allowlistMode: config.allowlistMode,
@@ -426,6 +498,9 @@ async function handleRoster(env: Env, config: AdminConfig): Promise<Response> {
       workerVersion: SERVER_VERSION,
       deploymentId: deploymentId(env),
       directoryFetchedAt: directory?.fetchedAt ?? null,
+      connectionStatus,
+      connectionProbeCap: CONNECTION_PROBE_CAP,
+      connectionProbedCount: probed.length,
     },
     rows,
   });
@@ -480,8 +555,16 @@ async function handleUserPolicy(request: Request, env: Env, session: AdminSessio
     );
   }
 
+  // Resolve the user's email from the cached directory so the stored policy (and
+  // therefore the evidence export) carries it instead of a blank. When the
+  // directory has no entry for this id, omit the email so putUserPolicy preserves
+  // whatever the current document holds rather than blanking it.
+  const directory = await getDirectory(env);
+  const directoryEmail = directory?.users.find((u) => u.hsUserId === hsUserId)?.email;
+  const email = directoryEmail && directoryEmail.length > 0 ? directoryEmail : undefined;
+
   try {
-    const policy = await putUserPolicy(env, hsUserId, policyInputFromTier(allowed, writeTier), {
+    const policy = await putUserPolicy(env, hsUserId, policyInputFromTier(allowed, writeTier, email), {
       expectedVersion,
       updatedBy: session.hsUserId,
       actorEmail: session.email,
@@ -606,11 +689,20 @@ async function handleAdminRoot(request: Request, env: Env): Promise<Response> {
   return htmlResponse(renderAdminPage(nonce, verified.session.csrf), nonce);
 }
 
-/** GET /admin/logout: clear the admin session and return to /admin. */
-function handleLogout(): Response {
-  const headers = new Headers(securityHeaders({ Location: '/admin' }));
-  headers.append('Set-Cookie', buildAdminSessionClearCookie());
-  return new Response(null, { status: 302, headers });
+/**
+ * POST /admin/logout: clear the admin session. Requires a valid session AND the
+ * session CSRF token, exactly like the mutating API, so a cross-site page (which
+ * cannot read the signed cookie or the in-page token) cannot force a logout. The
+ * clear is returned as JSON with the clear-cookie header; the page's small fetch
+ * then navigates back to /admin.
+ */
+async function handleLogout(request: Request, env: Env): Promise<Response> {
+  const gate = await requireSession(request, env);
+  if ('error' in gate) return gate.error;
+  if (!csrfTokensMatch(gate.session.csrf, request.headers.get('X-Admin-CSRF'))) {
+    return jsonResponse({ error: 'Missing or invalid CSRF token.', code: 'CSRF_FAILED' }, 403);
+  }
+  return jsonResponse({ ok: true }, 200, { 'Set-Cookie': buildAdminSessionClearCookie() });
 }
 
 /** The entry point help-scout-handler delegates every /admin and /admin/api/* path to. */
@@ -618,21 +710,35 @@ export async function handleAdmin(request: Request, env: Env): Promise<Response>
   const url = new URL(request.url);
   const { pathname } = url;
 
+  // Self-guard the signing key rather than trust the caller's ordering: never
+  // sign or verify an admin cookie with an empty key (NAS-1503 hardening).
+  if (!env.COOKIE_ENCRYPTION_KEY) return misconfiguredKeyPage();
+
   if (pathname === '/admin') {
     if (request.method !== 'GET') return jsonResponse({ error: 'Method not allowed.' }, 405);
     return handleAdminRoot(request, env);
   }
   if (pathname === '/admin/logout') {
-    return handleLogout();
+    // Logout is a mutation: only POST with a valid session + CSRF may clear the
+    // cookie. A cross-site GET must not log the admin out, so it just returns to
+    // /admin without clearing anything.
+    if (request.method !== 'POST') {
+      return new Response(null, { status: 302, headers: securityHeaders({ Location: '/admin' }) });
+    }
+    return handleLogout(request, env);
   }
   if (pathname.startsWith('/admin/api/')) {
     try {
       return await handleAdminApi(request, env, pathname);
     } catch (error) {
-      return jsonResponse(
-        { error: error instanceof Error ? error.message : 'Internal error.', code: 'INTERNAL' },
-        500,
-      );
+      // Never leak an internal message to the client: log the detail server-side
+      // and return a generic error.
+      logger.error('Admin API request failed', {
+        pathname,
+        method: request.method,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return jsonResponse({ error: 'Something went wrong handling that request.', code: 'INTERNAL' }, 500);
     }
   }
   return noticePage('Admin', 'Not found', 'This admin page does not exist.', 404);

--- a/worker/src/admin-page.ts
+++ b/worker/src/admin-page.ts
@@ -49,6 +49,7 @@ td.user{white-space:normal;min-width:180px}
 .badge.muted{color:var(--muted)}
 select,button{font:inherit;font-size:13px;border:1px solid var(--line);border-radius:7px;background:var(--bg);color:var(--ink);padding:5px 8px}
 button{cursor:pointer}
+button.link{background:none;border:0;color:var(--accent);padding:0;font:inherit;cursor:pointer;text-decoration:underline}
 button.primary{background:var(--accent);color:#fff;border-color:transparent}
 button.danger{color:var(--danger)}
 button:disabled,select:disabled{opacity:.5;cursor:not-allowed}
@@ -76,7 +77,7 @@ export function renderAdminNotice(nonce: string, title: string, heading: string,
 export function renderAdminPage(nonce: string, csrf: string): string {
   const body = `<header class="top">
   <h1>Help Scout MCP Admin</h1>
-  <a href="/admin/logout">Sign out</a>
+  <button type="button" id="signout" class="link">Sign out</button>
 </header>
 <p class="flash" id="flash"></p>
 
@@ -98,6 +99,7 @@ export function renderAdminPage(nonce: string, csrf: string): string {
 <section class="card">
   <h2>Users</h2>
   <input type="search" id="roster-search" placeholder="Filter by name, email, or role" autocomplete="off">
+  <p class="note" id="conn-note"></p>
   <div class="scroll"><table>
     <thead><tr><th>User</th><th>Role</th><th>Status</th><th>Admission</th><th>Write tier</th><th>Actions</th></tr></thead>
     <tbody id="roster-body"><tr><td colspan="6" class="muted">Loading roster…</td></tr></tbody>
@@ -158,6 +160,12 @@ function renderDeployment(dep){
   var cb = document.getElementById('allowlist-toggle');
   cb.checked = !!dep.allowlistMode;
   cb.disabled = false;
+  var connNote = document.getElementById('conn-note');
+  if(dep.connectionStatus === 'partial'){
+    connNote.textContent = 'Connection status shown for the first ' + dep.connectionProbedCount + ' users.';
+  } else {
+    connNote.textContent = '';
+  }
 }
 
 function onAllowlist(){
@@ -232,6 +240,7 @@ function renderRoster(){
 
     var status = document.createElement('td');
     if(!row.eligible){ status.appendChild(badge('Light (ineligible)', 'muted')); }
+    else if(row.connected === null){ status.appendChild(badge('Not probed', 'muted')); }
     else { status.appendChild(badge(row.connected ? 'Connected' : 'Not connected', row.connected ? 'ok' : 'muted')); }
     tr.appendChild(status);
 
@@ -314,6 +323,11 @@ function loadScope(){
   });
 }
 
+// Logout is a CSRF-protected POST (a cross-site GET must not sign the admin out).
+// req() attaches the X-Admin-CSRF header on POST; navigate to /admin either way.
+document.getElementById('signout').addEventListener('click', function(){
+  req('POST', '/admin/logout').then(toLogin, toLogin);
+});
 document.getElementById('allowlist-toggle').addEventListener('change', onAllowlist);
 document.getElementById('roster-search').addEventListener('input', renderRoster);
 document.getElementById('audit-more').addEventListener('click', function(){ loadAudit(false); });

--- a/worker/src/admin-page.ts
+++ b/worker/src/admin-page.ts
@@ -1,0 +1,328 @@
+/**
+ * The self-contained admin console page (NAS-1503).
+ *
+ * One server-rendered HTML document with nonce'd inline CSS and a single nonce'd
+ * inline vanilla-JS app. No SPA framework, no third-party frontend dependency,
+ * nothing loaded from another origin, so the page satisfies the strict CSP the
+ * handler sets (default-src 'none'; script/style limited to the per-response
+ * nonce; connect-src 'self'). All Help Scout-supplied text (emails, names,
+ * updatedBy) is rendered with textContent, never innerHTML, so profile fields an
+ * account admin can edit cannot inject markup.
+ *
+ * The CSRF token is a per-session synchronizer token: embedded here in the app
+ * and sent back in the X-Admin-CSRF header on every mutating request, where the
+ * handler compares it to the token bound in the signed session cookie. It is not
+ * a secret to hide from the page; it is meant to live in the page.
+ */
+
+/** Shared page chrome: doctype, head with nonce'd style, and the shell markup. */
+function shell(nonce: string, title: string, bodyHtml: string, scriptHtml = ''): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style nonce="${nonce}">
+:root{color-scheme:light dark;--bg:#f6f3ee;--card:#fffdfa;--ink:#1f2528;--muted:#667174;--line:#d8d1c7;--accent:#3f6fd6;--danger:#c1442e;--ok:#2f7d48;--warn:#9a6a12}
+@media (prefers-color-scheme:dark){:root{--bg:#181a1c;--card:#212528;--ink:#e9eaeb;--muted:#9aa3a7;--line:#333a3e;--accent:#6d9bff;--danger:#e77a68;--ok:#5fbf82;--warn:#d0a24a}}
+*{box-sizing:border-box}
+body{font-family:-apple-system,system-ui,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--ink);margin:0;line-height:1.5}
+main{max-width:1080px;margin:0 auto;padding:24px 20px 64px}
+header.top{display:flex;justify-content:space-between;align-items:baseline;gap:16px;flex-wrap:wrap;margin-bottom:20px}
+h1{font-size:20px;margin:0}
+h2{font-size:15px;margin:0 0 12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+a{color:var(--accent)}
+.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:20px;margin-bottom:20px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px 20px}
+.kv .k{font-size:12px;color:var(--muted)}
+.kv .v{font-size:14px;word-break:break-all}
+label.toggle{display:inline-flex;align-items:center;gap:8px;font-size:14px;cursor:pointer}
+input[type=search]{width:100%;padding:9px 12px;border:1px solid var(--line);border-radius:8px;background:var(--bg);color:var(--ink);font-size:14px;margin-bottom:12px}
+.scroll{overflow-x:auto}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top;white-space:nowrap}
+th{color:var(--muted);font-weight:600;font-size:12px}
+td.user{white-space:normal;min-width:180px}
+.email{font-size:12px;color:var(--muted)}
+.badge{display:inline-block;padding:1px 8px;border-radius:999px;font-size:11px;border:1px solid var(--line)}
+.badge.ok{color:var(--ok);border-color:var(--ok)}
+.badge.warn{color:var(--warn);border-color:var(--warn)}
+.badge.danger{color:var(--danger);border-color:var(--danger)}
+.badge.muted{color:var(--muted)}
+select,button{font:inherit;font-size:13px;border:1px solid var(--line);border-radius:7px;background:var(--bg);color:var(--ink);padding:5px 8px}
+button{cursor:pointer}
+button.primary{background:var(--accent);color:#fff;border-color:transparent}
+button.danger{color:var(--danger)}
+button:disabled,select:disabled{opacity:.5;cursor:not-allowed}
+.actions{display:flex;gap:6px}
+.exports{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:12px}
+.exports a{display:inline-block;padding:6px 10px;border:1px solid var(--line);border-radius:7px;text-decoration:none;font-size:13px}
+.flash{min-height:20px;font-size:13px;margin:0 0 12px;padding:0}
+.flash.ok{color:var(--ok)}
+.flash.err{color:var(--danger)}
+.muted{color:var(--muted)}
+.note{font-size:12px;color:var(--muted);margin-top:8px}
+</style></head><body><main>${bodyHtml}</main>${scriptHtml}</body></html>`;
+}
+
+/** A minimal notice page for login prompts, refusals, and errors. */
+export function renderAdminNotice(nonce: string, title: string, heading: string, message: string): string {
+  // heading/message are all server-controlled constants (never user input), so a
+  // static template is safe here.
+  const body = `<header class="top"><h1>Help Scout MCP Admin</h1></header>
+<div class="card"><h2>${heading}</h2><p>${message}</p><p><a href="/admin">Return to the admin console</a></p></div>`;
+  return shell(nonce, title, body);
+}
+
+/** The full admin console. `csrf` is the per-session synchronizer token. */
+export function renderAdminPage(nonce: string, csrf: string): string {
+  const body = `<header class="top">
+  <h1>Help Scout MCP Admin</h1>
+  <a href="/admin/logout">Sign out</a>
+</header>
+<p class="flash" id="flash"></p>
+
+<section class="card">
+  <h2>Deployment</h2>
+  <div class="grid">
+    <div class="kv"><div class="k">Access mode</div><div class="v">
+      <label class="toggle"><input type="checkbox" id="allowlist-toggle" disabled> Allowlist mode</label>
+      <div class="note">On: only explicitly-allowed users may connect. Off: any full Help Scout User seat may connect unless explicitly blocked.</div>
+    </div></div>
+    <div class="kv"><div class="k">Write ceiling (deploy-time, read-only)</div><div class="v" id="dep-ceiling">-</div></div>
+    <div class="kv"><div class="k">Admin role</div><div class="v" id="dep-admin-role">-</div></div>
+    <div class="kv"><div class="k">Worker version</div><div class="v" id="dep-worker">-</div></div>
+    <div class="kv"><div class="k">Deployment id</div><div class="v" id="dep-id">-</div></div>
+    <div class="kv"><div class="k">Roster snapshot</div><div class="v" id="dep-fetched">-</div></div>
+  </div>
+</section>
+
+<section class="card">
+  <h2>Users</h2>
+  <input type="search" id="roster-search" placeholder="Filter by name, email, or role" autocomplete="off">
+  <div class="scroll"><table>
+    <thead><tr><th>User</th><th>Role</th><th>Status</th><th>Admission</th><th>Write tier</th><th>Actions</th></tr></thead>
+    <tbody id="roster-body"><tr><td colspan="6" class="muted">Loading roster…</td></tr></tbody>
+  </table></div>
+</section>
+
+<section class="card">
+  <h2>Audit &amp; evidence</h2>
+  <div class="exports">
+    <a href="/admin/api/export/audit.json">Audit log (JSON)</a>
+    <a href="/admin/api/export/audit.csv">Audit log (CSV)</a>
+    <a href="/admin/api/export/access-list.json">Access list (JSON)</a>
+    <a href="/admin/api/export/access-list.csv">Access list (CSV)</a>
+  </div>
+  <p class="note" id="access-scope"></p>
+  <div class="scroll"><table>
+    <thead><tr><th>Seq</th><th>Time</th><th>Actor</th><th>Action</th><th>Target</th><th>Outcome</th></tr></thead>
+    <tbody id="audit-body"><tr><td colspan="6" class="muted">Loading audit…</td></tr></tbody>
+  </table></div>
+  <p><button id="audit-more" disabled>Load older</button></p>
+</section>`;
+
+  const script = `<script nonce="${nonce}">
+(function(){
+"use strict";
+var CSRF = ${JSON.stringify(csrf)};
+var deployment = null;
+var flashEl = document.getElementById('flash');
+
+function flash(text, kind){
+  flashEl.textContent = text || '';
+  flashEl.className = 'flash ' + (kind || '');
+}
+function toLogin(){ window.location = '/admin'; }
+
+function req(method, url, body){
+  var opts = { method: method, headers: { 'Accept': 'application/json' } };
+  if(method === 'POST'){ opts.headers['Content-Type'] = 'application/json'; opts.headers['X-Admin-CSRF'] = CSRF; opts.body = JSON.stringify(body || {}); }
+  return fetch(url, opts).then(function(r){
+    if(r.status === 401){ toLogin(); throw new Error('unauthenticated'); }
+    return r.json().then(function(b){ return { status: r.status, body: b }; }, function(){ return { status: r.status, body: {} }; });
+  });
+}
+function setText(id, val){ var e = document.getElementById(id); if(e) e.textContent = String(val); }
+function cell(text, cls){ var td = document.createElement('td'); if(cls) td.className = cls; td.textContent = text; return td; }
+function badge(text, cls){ var s = document.createElement('span'); s.className = 'badge ' + (cls || 'muted'); s.textContent = text; return s; }
+function tierRank(t){ return t === 'writes+customerVisible' ? 2 : (t === 'writes' ? 1 : 0); }
+function tierText(t){ return t === 'writes+customerVisible' ? 'Writes + customer-visible' : (t === 'writes' ? 'Writes' : 'None'); }
+function ceilingText(c){ return c.enabled ? (c.customerVisibleEnabled ? 'Writes + customer-visible' : 'Writes') : 'Read-only'; }
+
+function renderDeployment(dep){
+  deployment = dep;
+  setText('dep-worker', dep.workerVersion);
+  setText('dep-id', dep.deploymentId);
+  setText('dep-admin-role', dep.adminRole === 'administrator' ? 'Owners and Administrators' : 'Owners only');
+  setText('dep-ceiling', ceilingText(dep.ceiling));
+  setText('dep-fetched', dep.directoryFetchedAt || 'unknown');
+  var cb = document.getElementById('allowlist-toggle');
+  cb.checked = !!dep.allowlistMode;
+  cb.disabled = false;
+}
+
+function onAllowlist(){
+  var cb = document.getElementById('allowlist-toggle');
+  cb.disabled = true;
+  req('POST', '/admin/api/config', { allowlistMode: cb.checked, expectedVersion: deployment.configVersion }).then(function(res){
+    if(res.status === 200){ flash('Access mode updated.', 'ok'); loadRoster(); }
+    else if(res.status === 409){ flash('Configuration changed since load, reloading.', 'err'); loadRoster(); }
+    else { flash((res.body && res.body.error) || 'Update failed.', 'err'); cb.checked = !!deployment.allowlistMode; cb.disabled = false; }
+  });
+}
+
+var rosterRows = [];
+function loadRoster(){
+  return req('GET', '/admin/api/roster').then(function(res){
+    if(res.status !== 200){ flash((res.body && res.body.error) || 'Could not load roster.', 'err'); return; }
+    renderDeployment(res.body.deployment);
+    rosterRows = res.body.rows || [];
+    renderRoster();
+  });
+}
+
+function makeTierSelect(row, allowedNow){
+  var sel = document.createElement('select');
+  var cap = tierRank(deployment.ceilingCap);
+  ['none','writes','writes+customerVisible'].forEach(function(t){
+    var o = document.createElement('option');
+    o.value = t; o.textContent = tierText(t);
+    if(tierRank(t) > cap) o.disabled = true;
+    if(t === row.writeTier) o.selected = true;
+    sel.appendChild(o);
+  });
+  if(!row.eligible) sel.disabled = true;
+  sel.addEventListener('change', function(){
+    var tier = sel.value;
+    sel.disabled = true;
+    req('POST', '/admin/api/user-policy', { hsUserId: row.hsUserId, allowed: allowedNow, writeTier: tier, expectedVersion: row.version }).then(function(res){
+      if(res.status === 200){ flash('Write tier updated for ' + row.email + '.', 'ok'); loadRoster(); }
+      else if(res.status === 409){ flash('This user changed since load, reloading.', 'err'); loadRoster(); }
+      else { flash((res.body && res.body.error) || 'Update failed.', 'err'); loadRoster(); }
+    });
+  });
+  return sel;
+}
+
+function admissionBadge(row){
+  if(row.policyState === 'blocked') return badge('Blocked', 'danger');
+  if(!row.effectiveAllowed) return badge('Not admitted (allowlist)', 'warn');
+  if(row.policyState === 'explicitly-allowed') return badge('Allowed', 'ok');
+  return badge('Open default', 'muted');
+}
+
+function renderRoster(){
+  var q = (document.getElementById('roster-search').value || '').toLowerCase();
+  var body = document.getElementById('roster-body');
+  body.textContent = '';
+  var shown = 0;
+  rosterRows.forEach(function(row){
+    var hay = (row.email + ' ' + row.name + ' ' + row.role).toLowerCase();
+    if(q && hay.indexOf(q) === -1) return;
+    shown++;
+    var allowedNow = row.policyState !== 'blocked';
+    var tr = document.createElement('tr');
+
+    var user = document.createElement('td');
+    user.className = 'user';
+    var nm = document.createElement('div'); nm.textContent = row.name; user.appendChild(nm);
+    var em = document.createElement('div'); em.className = 'email'; em.textContent = row.email; user.appendChild(em);
+    tr.appendChild(user);
+
+    tr.appendChild(cell(row.role));
+
+    var status = document.createElement('td');
+    if(!row.eligible){ status.appendChild(badge('Light (ineligible)', 'muted')); }
+    else { status.appendChild(badge(row.connected ? 'Connected' : 'Not connected', row.connected ? 'ok' : 'muted')); }
+    tr.appendChild(status);
+
+    var adm = document.createElement('td'); adm.appendChild(admissionBadge(row)); tr.appendChild(adm);
+
+    var tier = document.createElement('td'); tier.appendChild(makeTierSelect(row, allowedNow)); tr.appendChild(tier);
+
+    var act = document.createElement('td');
+    var actions = document.createElement('div'); actions.className = 'actions';
+    var block = document.createElement('button');
+    block.textContent = allowedNow ? 'Block' : 'Unblock';
+    block.disabled = !row.eligible;
+    block.addEventListener('click', function(){
+      block.disabled = true;
+      req('POST', '/admin/api/user-policy', { hsUserId: row.hsUserId, allowed: !allowedNow, writeTier: row.writeTier, expectedVersion: row.version }).then(function(res){
+        if(res.status === 200){ flash((allowedNow ? 'Blocked ' : 'Unblocked ') + row.email + '.', 'ok'); loadRoster(); }
+        else if(res.status === 409){ flash('This user changed since load, reloading.', 'err'); loadRoster(); }
+        else { flash((res.body && res.body.error) || 'Update failed.', 'err'); loadRoster(); }
+      });
+    });
+    actions.appendChild(block);
+
+    var revoke = document.createElement('button');
+    revoke.className = 'danger'; revoke.textContent = 'Revoke';
+    revoke.addEventListener('click', function(){
+      if(!window.confirm('Revoke all access for ' + row.email + '? This tears down their live sessions and blocks reconnection.')) return;
+      revoke.disabled = true;
+      req('POST', '/admin/api/revoke', { hsUserId: row.hsUserId }).then(function(res){
+        if(res.status === 200){ flash('Revoked ' + row.email + ' (' + ((res.body.result && res.body.result.grantsRevoked) || 0) + ' grant(s)).', 'ok'); loadRoster(); }
+        else { flash((res.body && res.body.error) || 'Revoke failed.', 'err'); loadRoster(); }
+      });
+    });
+    actions.appendChild(revoke);
+    act.appendChild(actions);
+    tr.appendChild(act);
+
+    body.appendChild(tr);
+  });
+  if(shown === 0){
+    var tr = document.createElement('tr');
+    var td = document.createElement('td'); td.colSpan = 6; td.className = 'muted'; td.textContent = 'No users match.';
+    tr.appendChild(td); body.appendChild(tr);
+  }
+}
+
+var auditCursor = null;
+function loadAudit(reset){
+  var url = '/admin/api/audit?limit=25' + (auditCursor ? ('&cursor=' + encodeURIComponent(auditCursor)) : '');
+  return req('GET', url).then(function(res){
+    var body = document.getElementById('audit-body');
+    if(reset) body.textContent = '';
+    if(res.status !== 200){ flash((res.body && res.body.error) || 'Could not load audit.', 'err'); return; }
+    var page = res.body.page || {};
+    (page.entries || []).forEach(function(e){
+      var tr = document.createElement('tr');
+      tr.appendChild(cell(String(e.seq)));
+      tr.appendChild(cell(e.ts));
+      tr.appendChild(cell(e.actorEmail || e.actorId));
+      tr.appendChild(cell(e.action));
+      tr.appendChild(cell(e.targetId));
+      var out = document.createElement('td'); out.appendChild(badge(e.outcome, e.outcome === 'denied' ? 'warn' : 'ok')); tr.appendChild(out);
+      body.appendChild(tr);
+    });
+    if(reset && (page.entries || []).length === 0){
+      var tr = document.createElement('tr'); var td = document.createElement('td'); td.colSpan = 6; td.className = 'muted'; td.textContent = 'No audit entries yet.'; tr.appendChild(td); body.appendChild(tr);
+    }
+    auditCursor = page.nextCursor || null;
+    var more = document.getElementById('audit-more');
+    more.disabled = !auditCursor;
+  });
+}
+
+// Surface the authoritative access-list scope note from the export payload, so a
+// reader does not mistake the roster for the full set of people with access.
+function loadScope(){
+  return req('GET', '/admin/api/export/access-list.json').then(function(res){
+    if(res.status === 200 && res.body && res.body.config && res.body.config.scope){
+      document.getElementById('access-scope').textContent = res.body.config.scope.note;
+    }
+  });
+}
+
+document.getElementById('allowlist-toggle').addEventListener('change', onAllowlist);
+document.getElementById('roster-search').addEventListener('input', renderRoster);
+document.getElementById('audit-more').addEventListener('click', function(){ loadAudit(false); });
+
+loadRoster();
+loadAudit(true);
+loadScope();
+})();
+</script>`;
+
+  return shell(nonce, 'Help Scout MCP Admin', body, script);
+}

--- a/worker/src/admin-page.ts
+++ b/worker/src/admin-page.ts
@@ -172,8 +172,8 @@ function onAllowlist(){
   var cb = document.getElementById('allowlist-toggle');
   cb.disabled = true;
   req('POST', '/admin/api/config', { allowlistMode: cb.checked, expectedVersion: deployment.configVersion }).then(function(res){
-    if(res.status === 200){ flash('Access mode updated.', 'ok'); loadRoster(); }
-    else if(res.status === 409){ flash('Configuration changed since load, reloading.', 'err'); loadRoster(); }
+    if(res.status === 200){ flash('Access mode updated.', 'ok'); reload(); }
+    else if(res.status === 409){ flash('Configuration changed since load, reloading.', 'err'); reload(); }
     else { flash((res.body && res.body.error) || 'Update failed.', 'err'); cb.checked = !!deployment.allowlistMode; cb.disabled = false; }
   });
 }
@@ -187,6 +187,10 @@ function loadRoster(){
     renderRoster();
   });
 }
+// After any mutation (including a rejected one, which records a denied audit
+// row) refresh both the roster and the audit table so the ledger the admin sees
+// stays live without a page reload.
+function reload(){ loadRoster(); loadAudit(true); }
 
 function makeTierSelect(row, allowedNow){
   var sel = document.createElement('select');
@@ -203,9 +207,9 @@ function makeTierSelect(row, allowedNow){
     var tier = sel.value;
     sel.disabled = true;
     req('POST', '/admin/api/user-policy', { hsUserId: row.hsUserId, allowed: allowedNow, writeTier: tier, expectedVersion: row.version }).then(function(res){
-      if(res.status === 200){ flash('Write tier updated for ' + row.email + '.', 'ok'); loadRoster(); }
-      else if(res.status === 409){ flash('This user changed since load, reloading.', 'err'); loadRoster(); }
-      else { flash((res.body && res.body.error) || 'Update failed.', 'err'); loadRoster(); }
+      if(res.status === 200){ flash('Write tier updated for ' + row.email + '.', 'ok'); reload(); }
+      else if(res.status === 409){ flash('This user changed since load, reloading.', 'err'); reload(); }
+      else { flash((res.body && res.body.error) || 'Update failed.', 'err'); reload(); }
     });
   });
   return sel;
@@ -256,9 +260,9 @@ function renderRoster(){
     block.addEventListener('click', function(){
       block.disabled = true;
       req('POST', '/admin/api/user-policy', { hsUserId: row.hsUserId, allowed: !allowedNow, writeTier: row.writeTier, expectedVersion: row.version }).then(function(res){
-        if(res.status === 200){ flash((allowedNow ? 'Blocked ' : 'Unblocked ') + row.email + '.', 'ok'); loadRoster(); }
-        else if(res.status === 409){ flash('This user changed since load, reloading.', 'err'); loadRoster(); }
-        else { flash((res.body && res.body.error) || 'Update failed.', 'err'); loadRoster(); }
+        if(res.status === 200){ flash((allowedNow ? 'Blocked ' : 'Unblocked ') + row.email + '.', 'ok'); reload(); }
+        else if(res.status === 409){ flash('This user changed since load, reloading.', 'err'); reload(); }
+        else { flash((res.body && res.body.error) || 'Update failed.', 'err'); reload(); }
       });
     });
     actions.appendChild(block);
@@ -269,8 +273,8 @@ function renderRoster(){
       if(!window.confirm('Revoke all access for ' + row.email + '? This tears down their live sessions and blocks reconnection.')) return;
       revoke.disabled = true;
       req('POST', '/admin/api/revoke', { hsUserId: row.hsUserId }).then(function(res){
-        if(res.status === 200){ flash('Revoked ' + row.email + ' (' + ((res.body.result && res.body.result.grantsRevoked) || 0) + ' grant(s)).', 'ok'); loadRoster(); }
-        else { flash((res.body && res.body.error) || 'Revoke failed.', 'err'); loadRoster(); }
+        if(res.status === 200){ flash('Revoked ' + row.email + ' (' + ((res.body.result && res.body.result.grantsRevoked) || 0) + ' grant(s)).', 'ok'); reload(); }
+        else { flash((res.body && res.body.error) || 'Revoke failed.', 'err'); reload(); }
       });
     });
     actions.appendChild(revoke);

--- a/worker/src/admin-store.ts
+++ b/worker/src/admin-store.ts
@@ -1,0 +1,59 @@
+/**
+ * Env-facing reads/writes the admin surface needs beyond policy-store/audit-store
+ * (NAS-1503): the cached Help Scout user directory and the full list of user
+ * policy documents that the roster merges.
+ *
+ * Like policy-store and audit-store, this is a thin wrapper that resolves the ONE
+ * coordinator Durable Object by its fixed name and RPCs it. The admin HTTP layer
+ * (admin-handler.ts) wraps these in session + CSRF authorization; these functions
+ * own no auth of their own.
+ */
+import {
+  POLICY_COORDINATOR_NAME,
+  type UserDirectory,
+  type UserPolicy,
+} from './policy.js';
+
+/** The coordinator's admin RPC surface, as seen through its Durable Object stub. */
+interface AdminCoordinatorStub {
+  getDirectory(): Promise<UserDirectory | null>;
+  putDirectory(directory: UserDirectory): Promise<void>;
+  listUserPolicies(): Promise<Array<{ hsUserId: string; policy: UserPolicy }>>;
+}
+
+/** The subset of the worker env the admin store needs. */
+export interface AdminStoreEnv {
+  POLICY_OBJECT: DurableObjectNamespace;
+}
+
+/** Resolve the single coordinator instance by its fixed name (same as policy-store/audit-store). */
+function coordinator(env: AdminStoreEnv): AdminCoordinatorStub {
+  const namespace = env.POLICY_OBJECT;
+  if (!namespace) {
+    throw new Error(
+      "POLICY_OBJECT Durable Object binding is missing from this deployment's wrangler config. " +
+        'The admin surface requires it. Add the POLICY_OBJECT binding and the v2 migration to your ' +
+        'wrangler.deploy.jsonc, then re-deploy. See the upgrade section of guides/remote-self-host.md.',
+    );
+  }
+  const id = namespace.idFromName(POLICY_COORDINATOR_NAME);
+  return namespace.get(id) as unknown as AdminCoordinatorStub;
+}
+
+/** Read the cached Help Scout user directory, or null when login has not populated it. */
+export async function getDirectory(env: AdminStoreEnv): Promise<UserDirectory | null> {
+  return coordinator(env).getDirectory();
+}
+
+/** Overwrite the cached Help Scout user directory (populated at admin login). */
+export async function putDirectory(env: AdminStoreEnv, directory: UserDirectory): Promise<void> {
+  await coordinator(env).putDirectory(directory);
+}
+
+/** List every stored user policy document, keyed by hsUserId, for the roster merge. */
+export async function listUserPolicies(env: AdminStoreEnv): Promise<Map<string, UserPolicy>> {
+  const rows = await coordinator(env).listUserPolicies();
+  const map = new Map<string, UserPolicy>();
+  for (const { hsUserId, policy } of rows) map.set(hsUserId, policy);
+  return map;
+}

--- a/worker/src/help-scout-handler.ts
+++ b/worker/src/help-scout-handler.ts
@@ -31,6 +31,8 @@ import { evaluateAccess, type AccessDecision } from './policy.js';
 import { getConfig, getUserPolicy } from './policy-store.js';
 import { recordAdmissionDenied, recordGrantCreated } from './audit-store.js';
 import { handleTestPolicyRoute } from './test-policy-route.js';
+import { isSecureUpstreamUrl, joinUrl } from './upstream-url.js';
+import { handleAdmin, tryAdminCallback } from './admin-handler.js';
 
 /** HTML-escape untrusted values before echoing them into a page. */
 function esc(value: unknown): string {
@@ -52,38 +54,6 @@ function newState(): string {
   let binary = '';
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-/** Join base URL + path the way the fetch client does, tolerating a trailing slash on the base. */
-function joinUrl(base: string, path: string): string {
-  return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
-}
-
-/**
- * Codes, client secrets, and fresh bearer tokens flow to these URLs, so they
- * must be https, the same invariant the fetch client enforces.
- *
- * `allowLoopback` opens a narrow exception for the smoke harness's http mock
- * upstream, and ONLY the smoke turns it on: it is the deployment's test-mode
- * signal (Boolean(HELPSCOUT_TEST_POLICY_ROUTES)), which production never sets.
- * With it false, only https passes: a loopback http URL is rejected like any
- * other non-https URL, so a production deployment cannot be pointed at http.
- * The loopback allow-list is exact-match so `http://127.0.0.1.evil.com` (which
- * merely starts with 127.0.0.1) is rejected.
- */
-function isSecureUpstreamUrl(value: string, allowLoopback: boolean): boolean {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return false;
-  }
-  if (url.protocol === 'https:') return true;
-  if (!allowLoopback) return false;
-  return (
-    url.protocol === 'http:' &&
-    (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')
-  );
 }
 
 /**
@@ -504,6 +474,13 @@ export const helpScoutHandler: ExportedHandler<Env> = {
       );
     }
 
+    // The self-hosted admin surface (NAS-1503). Its own signed HTTP-only session
+    // cookie gates /admin and /admin/api/*; this is SEPARATE from the MCP OAuth
+    // token. Mounted before the consent routes and the 404 so it owns its paths.
+    if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {
+      return handleAdmin(request, env);
+    }
+
     if (url.pathname === '/authorize' && request.method === 'GET') {
       return renderConsent(request, env);
     }
@@ -511,6 +488,14 @@ export const helpScoutHandler: ExportedHandler<Env> = {
       return handleApprove(request, env);
     }
     if (url.pathname === '/callback' && request.method === 'GET') {
+      // The Help Scout app has ONE registered Redirection URL (this /callback),
+      // so the admin login's authorize leg lands here too, not on a separate
+      // /admin/callback. An admin-login callback is disambiguated by its own
+      // signed state cookie: tryAdminCallback returns a Response when this
+      // callback carries a valid admin-login state, otherwise null and the MCP
+      // consent callback runs exactly as before.
+      const adminResponse = await tryAdminCallback(request, env);
+      if (adminResponse) return adminResponse;
       return handleCallback(request, env);
     }
 

--- a/worker/src/mcp-agent.ts
+++ b/worker/src/mcp-agent.ts
@@ -45,7 +45,8 @@ import { getConfig, getUserPolicy } from './policy-store.js';
 
 /** Kept in step with the stdio server identity in `src/index.ts`. */
 const SERVER_NAME = 'helpscout-search';
-const SERVER_VERSION = '2.1.0';
+/** Exported so the admin surface (NAS-1503) can display the deployment's worker version. */
+export const SERVER_VERSION = '2.1.0';
 
 /**
  * The per-user grant, decrypted by workers-oauth-provider and re-injected as

--- a/worker/src/policy-coordinator.ts
+++ b/worker/src/policy-coordinator.ts
@@ -42,9 +42,11 @@ import {
   readAuditPage,
   readAuditRange,
   readConfigDoc,
+  readDirectory,
   readUserPolicyDoc,
   toPolicyErrorEnvelope,
   writeConfigDoc,
+  writeDirectory,
   writeUserPolicyDoc,
   type AccessListRow,
   type AdminConfig,
@@ -58,6 +60,7 @@ import {
   type PolicyErrorEnvelope,
   type PolicyListOptions,
   type PolicyStorage,
+  type UserDirectory,
   type UserPolicy,
   type UserPolicyDocResult,
   type UserPolicyInput,
@@ -136,6 +139,16 @@ export class PolicyCoordinator extends DurableObject {
   /** Every stored user policy document, for the access-list evidence export. */
   async listUserPolicies(): Promise<Array<{ hsUserId: string; policy: UserPolicy }>> {
     return listUserPolicyDocs(this.store);
+  }
+
+  /** The cached Help Scout user directory the admin roster merges (NAS-1503), or null. */
+  async getDirectory(): Promise<UserDirectory | null> {
+    return readDirectory(this.store);
+  }
+
+  /** Overwrite the cached Help Scout user directory (populated at admin login). */
+  async putDirectory(directory: UserDirectory): Promise<void> {
+    await writeDirectory(this.store, directory);
   }
 
   /**

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -868,6 +868,50 @@ export async function readAuditRange(
   return out;
 }
 
+// --- Help Scout user directory cache (NAS-1503) ----------------------------
+//
+// The admin GUI's roster is the full set of Help Scout account users merged with
+// the policy documents. Listing account users needs an admin's Help Scout token
+// (GET /v2/users), which the admin surface holds only during login. Rather than
+// keep that token for the life of the 8-hour admin session, the login fetches the
+// directory ONCE and caches this non-secret snapshot (ids, emails, names, roles)
+// in the coordinator's storage; the roster endpoint then merges the cached
+// directory with LIVE policy/grant state on every request. A re-login refreshes
+// the snapshot. No Help Scout token is retained past login.
+
+/** The single storage key holding the cached Help Scout user directory. */
+export const ADMIN_DIRECTORY_KEY = 'admin:directory:v1';
+
+/** The Help Scout account roles the admin surface distinguishes. */
+export type HelpScoutRole = 'Owner' | 'Administrator' | 'User' | 'Light';
+
+/** One cached Help Scout account user (display directory data, never a secret). */
+export interface DirectoryUser {
+  hsUserId: string;
+  email: string;
+  name: string;
+  role: HelpScoutRole;
+}
+
+/** The cached directory snapshot plus the provenance of when/who fetched it. */
+export interface UserDirectory {
+  users: DirectoryUser[];
+  fetchedAt: string;
+  fetchedBy: string;
+}
+
+/** Read the cached directory snapshot, or null when login has not populated it. */
+export async function readDirectory(storage: PolicyStorage): Promise<UserDirectory | null> {
+  const raw = await storage.get<UserDirectory>(ADMIN_DIRECTORY_KEY);
+  if (!raw || !Array.isArray(raw.users)) return null;
+  return raw;
+}
+
+/** Overwrite the cached directory snapshot (a cache; not versioned, not audited). */
+export async function writeDirectory(storage: PolicyStorage, directory: UserDirectory): Promise<void> {
+  await storage.put(ADMIN_DIRECTORY_KEY, directory);
+}
+
 /** List every stored user policy document (normalized), keyed by hsUserId. */
 export async function listUserPolicyDocs(
   storage: PolicyStorage,

--- a/worker/src/upstream-url.ts
+++ b/worker/src/upstream-url.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared upstream-URL helpers for the Help Scout legs.
+ *
+ * These were originally private to help-scout-handler.ts. The admin surface
+ * (NAS-1503) runs the SAME Help Scout Authorization Code dance (authorize +
+ * token exchange + a users lookup) as the consent flow, so it needs the exact
+ * same https guard and URL join. Keeping ONE copy here means the two callers can
+ * never drift on the security-critical https rule: a real deployment is always
+ * https, and only 127.0.0.1 / localhost / [::1] over http is tolerated, and only
+ * in test mode (the smoke's http loopback mock).
+ */
+
+/**
+ * Codes, client secrets, and fresh bearer tokens flow to these URLs, so they
+ * must be https.
+ *
+ * `allowLoopback` opens a narrow exception for the smoke harness's http mock
+ * upstream, and ONLY the smoke turns it on: it is the deployment's test-mode
+ * signal (Boolean(HELPSCOUT_TEST_POLICY_ROUTES)), which production never sets.
+ * With it false, only https passes: a loopback http URL is rejected like any
+ * other non-https URL, so a production deployment cannot be pointed at http.
+ * The loopback allow-list is exact-match so `http://127.0.0.1.evil.com` (which
+ * merely starts with 127.0.0.1) is rejected.
+ */
+export function isSecureUpstreamUrl(value: string, allowLoopback: boolean): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol === 'https:') return true;
+  if (!allowLoopback) return false;
+  return (
+    url.protocol === 'http:' &&
+    (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')
+  );
+}
+
+/** Join base URL + path the way the fetch client does, tolerating a trailing slash on the base. */
+export function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -45,7 +45,12 @@
   // Non-secret configuration. Secrets (HELPSCOUT_CLIENT_ID, HELPSCOUT_CLIENT_SECRET,
   // COOKIE_ENCRYPTION_KEY) are set with `wrangler secret put` and never live here.
   // COOKIE_ENCRYPTION_KEY signs the consent-transaction cookie (the confused-deputy
-  // defense); set it to a long random string. Optional: `wrangler secret put
+  // defense); set it to a long random string. It ALSO signs the admin surface's
+  // session and login-state cookies (NAS-1503, at /admin + /admin/api/*), so no
+  // additional secret is needed for the admin console: it logs in through the same
+  // Help Scout OAuth app (HELPSCOUT_CLIENT_ID/SECRET) as the consent flow, and its
+  // Owner/Administrator role gate is driven by config.adminRole in the policy store.
+  // Optional: `wrangler secret put
   // HELPSCOUT_DOCS_API_KEY` enables the Docs API operations; without it they are
   // still advertised but fail at call time with a credentials-missing error.
   //


### PR DESCRIPTION
## What

The admin GUI that ties the access-management backend together (parent NAS-1500), served by the worker at /admin and /admin/api/* as a thin auth + CSRF + HTTP layer over the existing policy engine, audit ledger, and evidence exports. No policy logic reimplemented.

**Admin session, separate from the MCP token.** An admin signs in through the same Help Scout Authorization Code dance the consent flow uses; the credential is a short-lived signed HTTP-only cookie the surface owns (identity + role + CSRF token, no Help Scout token). Because the Help Scout app has one fixed redirect URL, the admin login leg lands on the existing /callback, disambiguated by its own signed single-use state cookie, so the MCP consent callback is untouched (tryAdminCallback returns null when no admin-login is in flight). The missing-COOKIE_ENCRYPTION_KEY guard runs before the admin routes, so an empty signing key can never mint a forgeable session.

**Authorization.** Owner may administer; an Administrator only when the deployment sets adminRole to administrator. The role gate is re-evaluated against live config on every /admin/api/* request, so lowering the setting locks out an Administrator on their next call even with a valid cookie. The session gate runs before the CSRF gate (no session is 401, session-without-CSRF is 403); every mutating POST requires the session's CSRF token (constant-time compare). Strict per-response nonce CSP with no third-party origins, anti-framing, no-store; the page is one self-contained server-rendered document with inline vanilla JS, no framework, no third-party frontend deps.

**Console.** The full Help Scout roster (paged from GET /v2/users with the admin's own token, cached once in the coordinator DO, merged live with policy docs and grant state), per-user block and write-tier controls that are greyed and server-side fail-closed past the deployment env ceiling, one-click revoke, the allowlist-mode switch, a paginated audit view, and the audit and access-list evidence downloads. Every mutation records through the coordinator's atomic audit seam with the admin as actor. The env write ceiling is display-only and can never be raised from the GUI.

No new secret or binding: reuses COOKIE_ENCRYPTION_KEY, the existing OAuth app, and the POLICY_OBJECT coordinator DO (directory cached under admin:directory:v1).

## Verification

- 19 admin-auth unit tests (root suite 682 passing, known local-.env case aside): the role gate including the demotion case, CSRF match, admin session and login-state cookie round-trip/tamper/expiry, role parsing, write-tier cap and tier-policy mapping, and the roster merge (Light ineligibility, ceiling narrowing, allowlist admission).
- Type-check, lint, worker tsc clean.
- Smoke grows 117 to 145: an admin block driving a full Owner login through the mock (extended with a user directory and a role on users/me), roster read, a block toggle recorded in the audit with the admin actor, a stale-version 409, evidence exports as attachments, and the no-session (401), no-CSRF (403), and non-Owner (refused a session) rejections, plus a tier above the ceiling rejected server-side.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/help-scout-mcp-server/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->